### PR TITLE
Label PRs that change anything in the repo EXCEPT dependabot only PRs.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
 engineering:
-- any: ['**/*', '!app/package.json', '!app/yarn.lock']
+- any: ['**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+engineering:
+- any: ['**/*', '!app/package.json', '!app/yarn.lock']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
 engineering:
-- any: ['**/*']
+- any: ['**/*', '.github/*']

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -5,7 +5,7 @@ name: Auto label Pull Requests
 # **Who does it impact**: Automation that relies on the engineering label.
 
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   triage:

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -5,17 +5,15 @@ name: Auto label Pull Requests
 # **Who does it impact**: Automation that relies on the engineering label.
 
 on:
-  pull_request:
-
-permissions:
-  contents: read
-  pull-requests: write
+- pull_request_target
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # See labeling configuration in the `.github/labeler.yml` file
-      - uses: actions/labeler@v4
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,0 +1,21 @@
+name: Auto label Pull Requests
+
+# **What it does**: Automatically adds the engineering label when specific files change.
+# **Why we have it**: Other automation applies specifically to engineering label issues and pull requests.
+# **Who does it impact**: Automation that relies on the engineering label.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      # See labeling configuration in the `.github/labeler.yml` file
+      - uses: actions/labeler@v4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Ticket

N/A

## Changes
> What was added, updated, or removed in this PR.

- Add support for https://github.com/actions/labeler
- Copy a [Github CI job](https://github.com/github/docs/blob/main/.github/workflows/auto-label-prs.yml) to auto-label PRs

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This PR adds a CI job to auto-label PRs that make changes to any file in the repo using the `engineering` label. Ideally, we _don't_ label dependabot PRs, which will let us do some smart filtering on PRs based on whether the PR is human-created or dependabot-created.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
