### PR TITLE
Ignore .env, .envrc, and VS code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ override.tf.json
 
 # MacOS files
 .DS_Store
+
+# Ignore local environment variables which can contain environment secrets
+.env
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # MacOS files
 .DS_Store
 
+# Ignore develop-specific VS code settings files
+.vscode
+
 # Ignore local environment variables which can contain environment secrets
 .env
 .envrc


### PR DESCRIPTION
## Ticket

No ticket, tiny one line change

## Changes
- Ignore .env and .envrc in default .gitignore which can contain environment secrets
- Ignore visual studio code settings which can be developer specific

## Context for reviewers
Small thing I noticed as I was going through the application setup

## Testing
I don't see .env and .envrc in my untracked files anymore when running `git status`
