### PR TITLE
Add Makefile with stub targets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,9 @@
-name: CD
+name: Deploy
 
 on:
   push:
     branches: ["main"]
+  workflow_dispatch: {}
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,21 @@
+name: CD
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build release
+        run: make release-build
+
+      - name: Publish release
+        run: make release-publish
+
+      - name: Deploy release
+        run: make release-deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: NextJS CI
+name: CI
 
 on:
   push:
@@ -7,23 +7,19 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: pass/fail checks
+  check:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: ./app
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run check
+      run: make check
+
+  # Run the build to make sure it doesn't fail
+  build:
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 16
-    - run: npm install --location=global yarn
-    - run: yarn install --frozen-lockfile
-    - run: yarn build
-    - run: yarn lint
-    - run: yarn format-check
-    - run: yarn test
-    
+      - name: Run build
+        run: release-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
     - name: Run check
       run: make check
 
@@ -21,5 +20,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Run build
-        run: release-build
+    - uses: actions/checkout@v3
+    - name: Run build
+      run: release-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run build
-      run: release-build
+      run: make release-build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY : \
+	check \
+	lint \
+	type-check \
+	test
+
+######################
+## Automated Checks ##
+######################
+
+check: lint type-check test
+
+lint:
+
+type-check:
+
+test:
+
+########################
+## Release Management ##
+########################
+
+release-build:
+
+release-publish:
+
+release-deploy:
+
+#########################
+## Database Management ##
+#########################
+
+db-migrate:
+
+db-migrate-down:
+
+db-migrate-create:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,14 @@
 	check \
 	lint \
 	type-check \
-	test
+	test \
+	release-build \
+	release-publish \
+	release-deploy \
+	image-registry-login \
+	db-migrate \
+	db-migrate-down \
+	db-migrate-create
 
 ######################
 ## Automated Checks ##


### PR DESCRIPTION
## Ticket

Resolves #109 

## Changes
- Add Makefile with stub commands
- Update CI to use Makefile stub commands
- Add CD workflow that calls Makefile stub commands

## Context for reviewers
See [this proposal on establishing a CI/CD interface](https://github.com/navapbc/template-infra/pull/106), the idea is that the template infra would have CI/CD, then when people want to "install" a particular template application, they'll hook in the application's Makefile into the existing CI/CD.

CI and CD are not meant to be complete or necessarily even correct. They will be completed later as we implement each piece and refine the interface.

## Testing
Don't know how to test CD without merging first