### PR TITLE
Automate account creation and destruction

### DIFF
--- a/bin/bootstrap-account.sh
+++ b/bin/bootstrap-account.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euxo pipefail
+
+# PROJECT_NAME defaults to name of the current directory.
+PROJECT_NAME=$(basename $(PWD))
+
+cd infra/bootstrap/account
+
+cat main.tf \
+  | sed "s/<PROJECT_NAME>/$PROJECT_NAME/" \
+  > tmp.tf
+mv tmp.tf main.tf
+
+terraform init
+
+terraform apply -auto-approve
+
+TF_STATE_BUCKET_NAME=$(terraform output -raw tf_state_bucket_name)
+TF_LOCKS_TABLE_NAME=$(terraform output -raw tf_locks_table_name)
+
+cat main.tf \
+  | sed "s/<TF_STATE_BUCKET_NAME>/$TF_STATE_BUCKET_NAME/" \
+  | sed "s/<TF_LOCKS_TABLE_NAME>/$TF_LOCKS_TABLE_NAME/" \
+  | sed 's/#uncomment# //g' \
+  > tmp.tf
+mv tmp.tf main.tf
+
+terraform init -force-copy

--- a/bin/bootstrap-account.sh
+++ b/bin/bootstrap-account.sh
@@ -6,23 +6,31 @@ PROJECT_NAME=$(basename $(PWD))
 
 cd infra/bootstrap/account
 
-cat main.tf \
-  | sed "s/<PROJECT_NAME>/$PROJECT_NAME/" \
-  > tmp.tf
-mv tmp.tf main.tf
-
+# Initialize terraform
 terraform init
 
+# First replace the placeholder value for <PROJECT_NAME> in main.tf
+# The project name is used to define unique names for the infrastructure
+# resources that are created in the subsequent steps.
+sed -i .bak "s/<PROJECT_NAME>/$PROJECT_NAME/" main.tf
+
+# Create the infrastructure for the terraform backend such as the S3 bucket
+# for storing tfstate files and the DynamoDB table for tfstate locks.
 terraform apply -auto-approve
 
+# Get the name of the S3 bucket that was created to store the tf state
+# and the name of the DynamoDB table that was created for tf state locks.
+# This will be used to configure the S3 backend in main.tf
 TF_STATE_BUCKET_NAME=$(terraform output -raw tf_state_bucket_name)
 TF_LOCKS_TABLE_NAME=$(terraform output -raw tf_locks_table_name)
 
-cat main.tf \
-  | sed "s/<TF_STATE_BUCKET_NAME>/$TF_STATE_BUCKET_NAME/" \
-  | sed "s/<TF_LOCKS_TABLE_NAME>/$TF_LOCKS_TABLE_NAME/" \
-  | sed 's/#uncomment# //g' \
-  > tmp.tf
-mv tmp.tf main.tf
+# Configure the S3 backend in main.tf by replacing the placeholder
+# values with the actual values from the previous step, then
+# uncomment the S3 backend block
+sed -i .bak "s/<TF_STATE_BUCKET_NAME>/$TF_STATE_BUCKET_NAME/" main.tf
+sed -i .bak "s/<TF_LOCKS_TABLE_NAME>/$TF_LOCKS_TABLE_NAME/" main.tf
+sed -i .bak 's/#uncomment# //g' main.tf
 
+# Re-initialize terraform with the new backend and copy the tfstate
+# to the new backend in S3
 terraform init -force-copy

--- a/bin/template-only-destroy-account.sh
+++ b/bin/template-only-destroy-account.sh
@@ -5,22 +5,26 @@ set -euxo pipefail
 
 cd infra/bootstrap/account
 
-cat ../../modules/bootstrap/main.tf \
-  | sed 's/resource "aws_s3_bucket" "tf_state" {/&\n  force_destroy = true/' \
-  | sed 's/resource "aws_s3_bucket" "tf_log" {/&\n  force_destroy = true/' \
-  | sed 's/prevent_destroy = true/prevent_destroy = false/g' \
-  > tmp.tf
-mv tmp.tf ../../modules/bootstrap/main.tf
+# The following lines update S3 buckets in the terraform bootstrap module
+# add force_destroy = true to S3 resource blocks and update any lifecycle
+# prevent_destroy = true rules to false. The reason we need to do this is
+# because S3 buckets by default are protected from destruction to avoid
+# loss of data. See [Terraform: Destroy/Replace Buckets](https://medium.com/interleap/terraform-destroy-replace-buckets-cf9d63d0029d)
+# for a more in depth explanation.
+sed -i .bak 's/resource "aws_s3_bucket" "tf_state" {/&\n  force_destroy = true/' ../../modules/bootstrap/main.tf
+sed -i .bak 's/resource "aws_s3_bucket" "tf_log" {/&\n  force_destroy = true/' ../../modules/bootstrap/main.tf
+sed -i .bak 's/prevent_destroy = true/prevent_destroy = false/g' ../../modules/bootstrap/main.tf
 
+# Apply the S3 bucket changes from the previous step
 terraform apply -auto-approve
 
-# Delete the backend s3 block
-cat main.tf \
-  | sed '{N;N;N;N;N;N;N;N;N;N;N;N;s/backend "s3" {.*}//;}' \
-  > tmp.tf
-mv tmp.tf main.tf
+# Delete the backend S3 block to re-configure terraform to use local state
+# since we're about to delete the backend S3 bucket
+sed -i .bak '{N;N;N;N;N;N;N;N;N;N;N;N;s/backend "s3" {.*}//;}' main.tf
 
-# Unconfigure S3 backend and move tfstate file to local tfstate
+# Now re-initialize terraform to unconfigure the S3 backend and
+# move the tfstate file to a local tfstate file
 terraform init -force-copy
 
+# Finally destroy the infrastructure
 terraform destroy -auto-approve

--- a/bin/template-only-destroy-account.sh
+++ b/bin/template-only-destroy-account.sh
@@ -19,8 +19,9 @@ sed -i .bak 's/prevent_destroy = true/prevent_destroy = false/g' ../../modules/b
 terraform apply -auto-approve
 
 # Delete the backend S3 block to re-configure terraform to use local state
-# since we're about to delete the backend S3 bucket
-sed -i .bak '{N;N;N;N;N;N;N;N;N;N;N;N;s/backend "s3" {.*}//;}' main.tf
+# since we're about to delete the backend S3 bucket. The following sed command
+# deletes every line between 'backend "s3" {' and '}'
+sed -i .bak '{/backend "s3" {/,/}/d;}' main.tf
 
 # Now re-initialize terraform to unconfigure the S3 backend and
 # move the tfstate file to a local tfstate file

--- a/bin/template-only-destroy-account.sh
+++ b/bin/template-only-destroy-account.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Do not use this script on your project. This script is only used for testing
+# the platform bootstrap process.
+set -euxo pipefail
+
+cd infra/bootstrap/account
+
+cat ../../modules/bootstrap/main.tf \
+  | sed 's/resource "aws_s3_bucket" "tf_state" {/&\n  force_destroy = true/' \
+  | sed 's/resource "aws_s3_bucket" "tf_log" {/&\n  force_destroy = true/' \
+  | sed 's/prevent_destroy = true/prevent_destroy = false/g' \
+  > tmp.tf
+mv tmp.tf ../../modules/bootstrap/main.tf
+
+terraform apply -auto-approve
+
+# Delete the backend s3 block
+cat main.tf \
+  | sed '{N;N;N;N;N;N;N;N;N;N;N;N;s/backend "s3" {.*}//;}' \
+  > tmp.tf
+mv tmp.tf main.tf
+
+# Unconfigure S3 backend and move tfstate file to local tfstate
+terraform init -force-copy
+
+terraform destroy -auto-approve

--- a/infra/bootstrap/account/main.tf
+++ b/infra/bootstrap/account/main.tf
@@ -29,13 +29,13 @@ terraform {
 
   # Terraform does not allow interpolation here, values must be hardcoded.
  
-  # backend "s3" {
-  #   bucket         = "<TF_STATE_BUCKET_NAME>"
-  #   dynamodb_table = "<TF_LOCKS_TABLE_NAME>"
-  #   key            = "terraform/backend/terraform.tfstate"
-  #   region         = "REGION"
-  #   encrypt        = "true"
-  # }
+  #uncomment# backend "s3" {
+  #uncomment#   bucket         = "<TF_STATE_BUCKET_NAME>"
+  #uncomment#   dynamodb_table = "<TF_LOCKS_TABLE_NAME>"
+  #uncomment#   key            = "terraform/backend/terraform.tfstate"
+  #uncomment#   region         = "us-east-1"
+  #uncomment#   encrypt        = "true"
+  #uncomment# }
 
 }
 

--- a/template-only.mak
+++ b/template-only.mak
@@ -1,0 +1,8 @@
+.PHONY = \
+	bootstrap-account
+
+bootstrap-account:
+	./bin/bootstrap-account.sh
+
+destroy-account:
+	./bin/template-only-destroy-account.sh


### PR DESCRIPTION
## Ticket

Makes progress on #122 

## Changes

- Add ./bin/bootstrap-account.sh
- Add ./bin/template-only-destroy-account.sh

## Context for reviewers

Eventually we want to have some template only CI that only runs on template-infra for the purposes of testing the template. This CI workflow would not be copied over to the project repo.

This PR adds the beginning pieces of that, adding scripts that are used to spin up and tear down the terraform account backend infrastructure.

## Testing

Ran both scripts
