### PR TITLE
Clean up CI/CD interface

### DIFF
--- a/.github/workflows/template-only-ci-app.yml
+++ b/.github/workflows/template-only-ci-app.yml
@@ -1,4 +1,4 @@
-name: CI Application Checks
+name: Template Only - CI Application Checks
 
 on:
   push:

--- a/.github/workflows/template-only-ci-app.yml
+++ b/.github/workflows/template-only-ci-app.yml
@@ -1,4 +1,4 @@
-name: Template Only - CI Application Checks
+name: Template CI App Checks
 
 on:
   push:

--- a/.github/workflows/template-only-ci-app.yml
+++ b/.github/workflows/template-only-ci-app.yml
@@ -5,16 +5,15 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - app/**
+      - .github/workflows/template-only-ci-app.yml
+
+defaults:
+  run:
+    working-directory: ./app
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run check
-      run: make check
-
   # Run the build to make sure it doesn't fail
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-only-ci-app.yml
+++ b/.github/workflows/template-only-ci-app.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Application Checks
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ PROJECT_NAME := $(notdir $(PWD))
 APP_NAME := app
 
 .PHONY : \
-	check \
-	lint \
-	type-check \
-	test \
 	release-build \
 	release-publish \
 	release-deploy \
@@ -18,18 +14,6 @@ APP_NAME := app
 	db-migrate \
 	db-migrate-down \
 	db-migrate-create
-
-######################
-## Automated Checks ##
-######################
-
-check: lint type-check test
-
-lint:
-
-type-check:
-
-test:
 
 ########################
 ## Release Management ##
@@ -58,13 +42,3 @@ release-build:
 release-publish:
 
 release-deploy:
-
-#########################
-## Database Management ##
-#########################
-
-db-migrate:
-
-db-migrate-down:
-
-db-migrate-create:


### PR DESCRIPTION
## Ticket
Follow up from #106 

## Changes
- Rename ci.yml to ci-app.yml 
- Remove stub make commands that weren't defined in the ADR

## Context for reviewers
Cleaning up template-infra based on [this ADR](https://github.com/navapbc/template-infra/blob/main/docs/decisions/0001-ci-cd-interface.md), and renaming ci to ci-app based on [this ADR](https://github.com/navapbc/template-infra/blob/main/docs/decisions/0001-ci-cd-interface.md) and [this discussion thread](https://github.com/navapbc/template-infra/pull/106#discussion_r983854402)

## Testing
