### PR TITLE
Add compliance check

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -16,15 +16,26 @@ jobs:
   check-terraform-format:
     name: Check Terraform format
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.1
           terraform_wrapper: false
-
       - name: Run infra-lint
         run: |
           echo "If this fails, run 'make infra-format'"
           make infra-lint
+  check-compliance:
+    name: Check compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Run Checkov check
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: infra
+          framework: terraform 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ APP_NAME := app
 	db-migrate-down \
 	db-migrate-create
 
+infra-check-compliance:
+	checkov --directory infra
+
 infra-lint:
 	terraform fmt -recursive -check infra
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -15,3 +15,7 @@ brew install checkov
 ```bash
 make infra-check-compliance
 ```
+
+## Pre-Commit
+
+If you use [pre-commit](https://www.checkov.io/4.Integrations/pre-commit.html), you can optionally add checkov to your own pre-commit hook by following the instructions [here](https://www.checkov.io/4.Integrations/pre-commit.html).

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,17 @@
+# Compliance
+
+We use the [Checkov](https://www.checkov.io/) static analysis tool to check for compliance with infrastructure policies.
+
+## Setup
+
+To run this tool locally, first install Checkov by running the following command.
+
+```bash
+brew install checkov
+```
+
+## Check compliance
+
+```bash
+make infra-check-compliance
+```

--- a/infra/modules/example/main.tf
+++ b/infra/modules/example/main.tf
@@ -1,8 +1,0 @@
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
-# Create the S3 bucket with a unique prefix from terraform.workspace.
-resource "aws_s3_bucket" "example" {
-  bucket = "${var.prefix}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-bucket"
-
-}

--- a/infra/modules/example/outputs.tf
+++ b/infra/modules/example/outputs.tf
@@ -1,3 +1,0 @@
-output "bucket_name" {
-  value = aws_s3_bucket.example.id
-}

--- a/infra/modules/example/variable.tf
+++ b/infra/modules/example/variable.tf
@@ -1,5 +1,0 @@
-variable "prefix" {
-  type        = string
-  description = "prefix used to uniquely identify resources, allows parallel development"
-
-}


### PR DESCRIPTION
## Ticket

Resolves #129 

## Changes

- Add infra-check-compliance target to Makefile
- Add instructions for setting up and running checkov locally
- Add compliance check to ci-infra

## Context for reviewers

I thought it would be a good idea to add compliance checks to CI by default. A lot of agencies deal with security audits so having a tool like this could help with accelerating path to production.

## Testing

- CI
- Also ran `make infra-check-compliance` locally:
<img width="1607" alt="image" src="https://user-images.githubusercontent.com/447859/194433952-0d650a3b-2069-4e33-b001-ed726064621d.png">
