### PR TITLE
Fix miscellaneous issues and add validation check

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -26,6 +26,17 @@ jobs:
         run: |
           echo "If this fails, run 'make infra-format'"
           make infra-lint
+  validate-terraform:
+    name: Validate Terraform 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.2.1
+          terraform_wrapper: false
+      - name: Run infra-validate
+        run: make infra-validate
   check-compliance-with-checkov:
     name: Check compliance with checkov
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -27,7 +27,7 @@ jobs:
           echo "If this fails, run 'make infra-format'"
           make infra-lint
   validate-terraform:
-    name: Validate Terraform 
+    name: Validate Terraform modules
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -35,8 +35,8 @@ jobs:
         with:
           terraform_version: 1.2.1
           terraform_wrapper: false
-      - name: Run infra-validate
-        run: make infra-validate
+      - name: Run infra-validate-modules
+        run: make infra-validate-modules
   check-compliance-with-checkov:
     name: Check compliance with checkov
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ PROJECT_NAME := $(notdir $(PWD))
 APP_NAME := app
 
 .PHONY : \
+	infra-check-compliance \
+	infra-check-compliance-checkov \
+	infra-check-compliance-tfsec \
 	infra-lint \
 	infra-format \
 	release-build \

--- a/infra/modules/bootstrap/main.tf
+++ b/infra/modules/bootstrap/main.tf
@@ -13,7 +13,7 @@ locals {
 # Options for encryption are an AWS owned key, which is not unique to your account; AWS managed; or customer managed. The latter two options are more secure, and customer managed gives
 # control over the key. This allows for ability to restrict access by key as well as policies attached to roles or users. 
 # https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
-resource "aws_kms_key" "tfstate" {
+resource "aws_kms_key" "tf_backend" {
   description = "KMS key for DynamoDB table ${local.tf_locks_table_name}"
   # The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key.
   deletion_window_in_days = "10"
@@ -33,7 +33,7 @@ resource "aws_dynamodb_table" "terraform_lock" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.tfstate.arn
+    kms_key_arn = aws_kms_key.tf_backend.arn
   }
 
   point_in_time_recovery {
@@ -65,7 +65,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
   bucket = aws_s3_bucket.tf_state.id
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.tfstate.arn
+      kms_master_key_id = aws_kms_key.tf_backend.arn
       sse_algorithm = "aws:kms"
     }
     bucket_key_enabled = true
@@ -141,7 +141,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tf_log" {
   bucket = aws_s3_bucket.tf_log.id
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.tfstate.arn
+      kms_master_key_id = aws_kms_key.tf_backend.arn
       sse_algorithm = "aws:kms"
     }
     bucket_key_enabled = true

--- a/infra/modules/bootstrap/main.tf
+++ b/infra/modules/bootstrap/main.tf
@@ -13,7 +13,7 @@ locals {
 # Options for encryption are an AWS owned key, which is not unique to your account; AWS managed; or customer managed. The latter two options are more secure, and customer managed gives
 # control over the key. This allows for ability to restrict access by key as well as policies attached to roles or users. 
 # https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
-resource "aws_kms_key" "terraform_lock" {
+resource "aws_kms_key" "tfstate" {
   description = "KMS key for DynamoDB table ${local.tf_locks_table_name}"
   # The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key.
   deletion_window_in_days = "10"
@@ -33,7 +33,7 @@ resource "aws_dynamodb_table" "terraform_lock" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.terraform_lock.arn
+    kms_key_arn = aws_kms_key.tfstate.arn
   }
 
   point_in_time_recovery {
@@ -61,7 +61,7 @@ resource "aws_s3_bucket" "tf_state" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.mykey.arn
+        kms_master_key_id = aws_kms_key.tfstate.arn
         sse_algorithm     = "aws:kms"
       }
     }
@@ -145,7 +145,7 @@ resource "aws_s3_bucket" "tf_log" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.mykey.arn
+        kms_master_key_id = aws_kms_key.tfstate.arn
         sse_algorithm     = "aws:kms"
       }
     }

--- a/infra/modules/bootstrap/main.tf
+++ b/infra/modules/bootstrap/main.tf
@@ -52,15 +52,6 @@ resource "aws_s3_bucket" "tf_state" {
   lifecycle {
     prevent_destroy = true
   }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.tfstate.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
 }
 
 resource "aws_s3_bucket_versioning" "tf_state" {
@@ -74,7 +65,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
   bucket = aws_s3_bucket.tf_state.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = aws_kms_key.tfstate.arn
+      sse_algorithm = "aws:kms"
     }
     bucket_key_enabled = true
   }
@@ -136,15 +128,6 @@ resource "aws_s3_bucket" "tf_log" {
   bucket = local.tf_logs_bucket_name
 
   # checkov:skip=CKV_AWS_144:Cross region replication not required by default
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.tfstate.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
 }
 
 resource "aws_s3_bucket_versioning" "tf_log" {
@@ -158,7 +141,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tf_log" {
   bucket = aws_s3_bucket.tf_log.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = aws_kms_key.tfstate.arn
+      sse_algorithm = "aws:kms"
     }
     bucket_key_enabled = true
   }

--- a/infra/modules/bootstrap/main.tf
+++ b/infra/modules/bootstrap/main.tf
@@ -66,7 +66,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
   rule {
     apply_server_side_encryption_by_default {
       kms_master_key_id = aws_kms_key.tf_backend.arn
-      sse_algorithm = "aws:kms"
+      sse_algorithm     = "aws:kms"
     }
     bucket_key_enabled = true
   }
@@ -142,7 +142,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tf_log" {
   rule {
     apply_server_side_encryption_by_default {
       kms_master_key_id = aws_kms_key.tf_backend.arn
-      sse_algorithm = "aws:kms"
+      sse_algorithm     = "aws:kms"
     }
     bucket_key_enabled = true
   }

--- a/infra/modules/bootstrap/main.tf
+++ b/infra/modules/bootstrap/main.tf
@@ -53,11 +53,6 @@ resource "aws_s3_bucket" "tf_state" {
     prevent_destroy = true
   }
 
-  logging {
-    target_bucket = aws_s3_bucket.tf_log.bucket
-    target_prefix = "log/${local.tf_state_bucket_name}"
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -281,9 +276,16 @@ resource "aws_s3_bucket_policy" "tf_log" {
   policy = data.aws_iam_policy_document.tf_log.json
 }
 
+resource "aws_s3_bucket_logging" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  target_bucket = aws_s3_bucket.tf_log.id
+  target_prefix = "logs/${aws_s3_bucket.tf_state.bucket}/"
+}
+
 resource "aws_s3_bucket_logging" "tf_log" {
   bucket = aws_s3_bucket.tf_log.id
 
   target_bucket = aws_s3_bucket.tf_log.id
-  target_prefix = "log/"
+  target_prefix = "logs/${aws_s3_bucket.tf_log.bucket}/"
 }


### PR DESCRIPTION
## Ticket

n/a

## Changes

* Fix Makefile .PHONY targets
* Fix broken KMS key references
* Use aws_s3_bucket_logging instead of logging attribute in aws_s3_bucket
* Remove duplicate deprecated s3_server_side_encryption settings
* Add make infra-validate-modules
* Add infra validation to ci-infra workflow

## Context for reviewers

When working on ECR I realized I at some point must have broken the bootstrap module, so I fixed it in this PR along with some other misc fixes and added a CI check to prevent the breakage in the future

## Testing

* Ran `make -f template-only.mak bootstrap-account` and `make -f template-only.mak destroy-account`
* Added make infra-validate-modules, ran it locally and added it to ci-infra