### PR TITLE
Use unique id during test runs

### DIFF
--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - template-only-infra/**
       - infra/modules/**
+      - template-only-test/**
       - .github/workflows/template-only-ci-infra.yml
 
 # For now, only allow one workflow run at a time, since this actually provisions infra.

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -2,22 +2,21 @@ package test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
-func ProjectName() string {
-	return "platform-test-account"
-}
+// Note: projectName can't be too long since S3 bucket names have a 63 character max length
+var uniqueId = strings.ToLower(random.UniqueId())
+var projectName = fmt.Sprintf("plt-tst-act-%s", uniqueId)
 
 func TestSetUpAccount(t *testing.T) {
-	// Note: projectName can't be too long since S3 bucket names have a 63 character max length
-	projectName := ProjectName()
-
 	defer TeardownAccount(t)
 	SetUpProject(t, projectName)
 	SetUpAccount(t)
@@ -27,7 +26,7 @@ func TestSetUpAccount(t *testing.T) {
 }
 
 func ValidateAccount(t *testing.T) {
-	projectName := ProjectName()
+	projectName := projectName
 	accountId := "368823044688"
 	region := "us-east-1"
 	ValidateAccountBackend(t, region, projectName)
@@ -35,7 +34,7 @@ func ValidateAccount(t *testing.T) {
 }
 
 func SubtestSetUpAppBackends(t *testing.T) {
-	projectName := ProjectName()
+	projectName := projectName
 	SetUpAppBackends(t, projectName)
 	ValidateAppBackends(t)
 
@@ -43,7 +42,7 @@ func SubtestSetUpAppBackends(t *testing.T) {
 }
 
 func SubtestBuildRepository(t *testing.T) {
-	projectName := ProjectName()
+	projectName := projectName
 	defer TeardownBuildRepository(t)
 	SetUpBuildRepository(t, projectName)
 	ValidateBuildRepository(t, projectName)

--- a/template-only.mak
+++ b/template-only.mak
@@ -33,6 +33,7 @@ set-up-app-build-repository:
 
 clean:
 	rm -fr infra/accounts/account/.terraform infra/app/envs/dev/.terraform infra/app/envs/staging/.terraform infra/app/envs/prod/.terraform infra/app/build-repository/.terraform
+	rm -f infra/accounts/account/terraform.tfstate* infra/app/envs/dev/terraform.tfstate* infra/app/envs/staging/terraform.tfstate* infra/app/envs/prod/terraform.tfstate* infra/app/build-repository/terraform.tfstate*
 	git reset --hard HEAD
 	git clean -f
 

--- a/template-only.mak
+++ b/template-only.mak
@@ -32,7 +32,7 @@ set-up-app-build-repository:
 	./template-only-bin/set-up-app-build-repository.sh $(PROJECT_NAME)
 
 clean:
-	rm -fr infra/app/envs/dev/.terraform infra/app/envs/staging/.terraform infra/app/envs/prod/.terraform infra/app/build-repository/.terraform
+	rm -fr infra/accounts/account/.terraform infra/app/envs/dev/.terraform infra/app/envs/staging/.terraform infra/app/envs/prod/.terraform infra/app/build-repository/.terraform
 	git reset --hard HEAD
 	git clean -f
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

* Use unique id for infra resource names during test runs
* Remove leftover tfstate files during template-only make clean

## Context for reviewers

Small improvement to make tests more isolated from each other. I'm asking Mike Moran to see if we can have separate accounts. One of the accounts I'll use for template testing, while in the other account I'll leave the backends and OIDC stuff running (rather than tearing it down after the tests) and use that to test the app infra.

## Testing

Testing locally, should also pass in CI