### PR TITLE
Remove docker-compose from README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cp -r \
   template-infra/bin \
   template-infra/docs \
   template-infra/infra \
-  Makefile \
+  template-infra/Makefile \
   .
 
 rm .github/workflows/template-only-*

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ cp -r \
   template-infra/bin \
   template-infra/docs \
   template-infra/infra \
-  template-infra/docker-compose.yml \
   Makefile \
   .
 


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
docker-compose is part of application templates now based on [slack discussion](https://nava.slack.com/archives/C03G1SWD9H7/p1666652902898639?thread_ts=1666648081.886369&cid=C03G1SWD9H7), so removing this form the instructions for now since we forgot to remove it from instructions in #151 

## Testing
none