### PR TITLE
Init build-repository before publishing in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,9 @@
 name: Deploy
 
 on:
-  push:
-    branches: ["main"]
+  # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
+  # push:
+  #   branches: ["main"]
   workflow_dispatch:
     inputs:
       env_name:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,18 +3,18 @@ name: Deploy
 on:
   push:
     branches: ["main"]
-  workflow_dispatch: 
+  workflow_dispatch:
     inputs:
       env_name:
-        description: 'env_name input'
+        description: "env_name input"
         required: true
-        default: 'dev' 
+        default: "dev"
         type: choice
         options:
-        - dev
-        - staging
-        - prod 
-  
+          - dev
+          - staging
+          - prod
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ release-build:
 		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG)"
 
 release-publish:
+	# Need to init module when running in CD since GitHub actions does a fresh checkout of repo
+	terraform -chdir=infra/$(APP_NAME)/build-repository init
 	./bin/publish-release.sh $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG)
 
 release-deploy:

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,6 @@ release-build:
 		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG)"
 
 release-publish:
-	# Need to init module when running in CD since GitHub actions does a fresh checkout of repo
-	terraform -chdir=infra/$(APP_NAME)/build-repository init
 	./bin/publish-release.sh $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG)
 
 release-deploy:

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Now you're ready to set up the various pieces of your infrastructure.
 3. [Set up continuous integration](./template-only-docs/set-up-ci.md)
 4. [Set up application](./docs/infra/set-up-app.md)
 5. [Set up application environments](./docs/infra/set-up-app-env.md)
+6. [Set up continous deployment](./template-only-docs/set-up-cd.md)

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -5,17 +5,14 @@ APP_NAME=$1
 IMAGE_TAG=$2
 ENV_NAME=$3
 
-ACCOUNT_ID=$(terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME output -raw account_id)
-
 echo "--------------------------"
 echo "Deploy release parameters"
 echo "--------------------------"
 echo "APP_NAME=$APP_NAME"
 echo "IMAGE_TAG=$IMAGE_TAG"
 echo "IMAGE_NAME=$ENV_NAME"
-echo "ACCOUNT_ID=$ACCOUNT_ID"
 echo
 echo "Deploy image to AWS"
-terraform init
+terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME init
 terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME apply -auto-approve -var="image_tag=$IMAGE_TAG"
-echo "Deployed $ENV_NAME to aws account $ACCOUNT_ID"
+echo "Deploy success"

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -5,14 +5,18 @@ APP_NAME=$1
 IMAGE_TAG=$2
 ENV_NAME=$3
 
+# Need to init module when running in CD since GitHub actions does a fresh checkout of repo
+terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME init
+ACCOUNT_ID=$(terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME output -raw account_id)
+
 echo "--------------------------"
 echo "Deploy release parameters"
 echo "--------------------------"
 echo "APP_NAME=$APP_NAME"
 echo "IMAGE_TAG=$IMAGE_TAG"
-echo "IMAGE_NAME=$ENV_NAME"
+echo "ENV_NAME=$ENV_NAME"
+echo "ACCOUNT_ID=$ACCOUNT_ID"
 echo
-echo "Deploy image to AWS"
-terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME init
+echo "Starting $APP_NAME deploy of $IMAGE_TAG to $ENV_NAME"
 terraform -chdir=infra/$APP_NAME/envs/$ENV_NAME apply -auto-approve -var="image_tag=$IMAGE_TAG"
-echo "Deploy success"
+echo "Completed $APP_NAME deploy of $IMAGE_TAG to $ENV_NAME"

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -5,6 +5,8 @@ APP_NAME=$1
 IMAGE_NAME=$2
 IMAGE_TAG=$3
 
+# Need to init module when running in CD since GitHub actions does a fresh checkout of repo
+terraform -chdir=infra/$APP_NAME/build-repository init
 REGION=$(terraform -chdir=infra/$APP_NAME/build-repository output -raw region)
 IMAGE_REGISTRY=$(terraform -chdir=infra/$APP_NAME/build-repository output -raw image_registry)
 IMAGE_REPOSITORY_URL=$(terraform -chdir=infra/$APP_NAME/build-repository output -raw image_repository_url)

--- a/template-only-docs/set-up-cd.md
+++ b/template-only-docs/set-up-cd.md
@@ -1,0 +1,3 @@
+# Set up CD
+
+Once you have set up your application environments, you can enable continuous deployment in [cd.yml](../.github/workflows/cd.yml) by searching for `!!` and uncommenting the `on: push: ["main]` workflow trigger. This will trigger the deployment workflow on every merge to `main`.


### PR DESCRIPTION
## Ticket

Resolves #180 

## Changes
* Init build-repository module before publishing
* Fix log message in deploy script
* Fix directory that terraform init runs in as part of deploy script
* Disable cd in template and add instructions for enabling

## Context for reviewers
CD was failing to publish the built docker image since the build-repository module wasn't initialized. See [this run](https://github.com/navapbc/platform-test/actions/runs/3480941215/jobs/5821384944) as an example. This PR runs terraform init first as part of release-publish.

## Testing
CI