### PR TITLE
Group logs in template CI for readability

### DIFF
--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -49,46 +50,57 @@ func SubtestBuildRepository(t *testing.T) {
 }
 
 func SetUpProject(t *testing.T, projectName string) {
+	logger.Log(t, "::group::Configuring project")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-project", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
 		WorkingDir: "../",
 	})
+	logger.Log(t, "::endgroup::")
 }
 
 func SetUpAccount(t *testing.T) {
+	logger.Log(t, "::group::Setting up account")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-account"},
 		WorkingDir: "../",
 	})
+	logger.Log(t, "::endgroup::")
 }
 
 func SetUpAppBackends(t *testing.T, projectName string) {
+	logger.Log(t, "::group::Configuring terraform backends for application modules")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-app-backends", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
 		WorkingDir: "../",
 	})
+	logger.Log(t, "::endgroup::")
 }
 
 func SetUpBuildRepository(t *testing.T, projectName string) {
+	logger.Log(t, "::group::Creating build repository resources")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-app-build-repository", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
 		WorkingDir: "../",
 	})
+	logger.Log(t, "::endgroup::")
 }
 
 func ValidateAccountBackend(t *testing.T, region string, projectName string) {
+	logger.Log(t, "::group::Validating terraform backend for account")
 	expectedTfStateBucket := fmt.Sprintf("%s-368823044688-%s-tf-state", projectName, region)
 	expectedTfStateKey := "infra/account.tfstate"
 	aws.AssertS3BucketExists(t, region, expectedTfStateBucket)
 	_, err := aws.GetS3ObjectContentsE(t, region, expectedTfStateBucket, expectedTfStateKey)
 	assert.NoError(t, err, fmt.Sprintf("Failed to get tfstate object from tfstate bucket %s", expectedTfStateBucket))
+	logger.Log(t, "::endgroup::")
 }
 
 func ValidateGithubActionsAuth(t *testing.T, accountId string, projectName string) {
+	logger.Log(t, "::group::Validating that GitHub actions can authenticate with AWS account")
 	githubActionsRole := fmt.Sprintf("arn:aws:iam::%s:role/%s-github-actions", accountId, projectName)
 	// Check that GitHub Actions can authenticate with AWS
 	err := shell.RunCommandE(t, shell.Command{
@@ -97,6 +109,7 @@ func ValidateGithubActionsAuth(t *testing.T, accountId string, projectName strin
 		WorkingDir: "../",
 	})
 	assert.NoError(t, err, "GitHub actions failed to authenticate")
+	logger.Log(t, "::endgroup::")
 }
 
 func ValidateAppBackends(t *testing.T) {
@@ -104,6 +117,8 @@ func ValidateAppBackends(t *testing.T) {
 }
 
 func ValidateBuildRepository(t *testing.T, projectName string) {
+	logger.Log(t, "::group::Validating ability to publish build artifacts to build repository")
+
 	err := shell.RunCommandE(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"release-build", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
@@ -117,14 +132,18 @@ func ValidateBuildRepository(t *testing.T, projectName string) {
 		WorkingDir: "../",
 	})
 	assert.NoError(t, err, "GitHub actions failed to authenticate")
+
+	logger.Log(t, "::endgroup::")
 }
 
 func TeardownAccount(t *testing.T) {
+	logger.Log(t, "::group::Destroying account")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "destroy-account"},
 		WorkingDir: "../",
 	})
+	logger.Log(t, "::endgroup::")
 }
 
 func TeardownBuildRepository(t *testing.T) {

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -50,57 +49,57 @@ func SubtestBuildRepository(t *testing.T) {
 }
 
 func SetUpProject(t *testing.T, projectName string) {
-	logger.Log(t, "::group::Configuring project")
+	fmt.Println("::group::Configuring project")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-project", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
 		WorkingDir: "../",
 	})
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func SetUpAccount(t *testing.T) {
-	logger.Log(t, "::group::Setting up account")
+	fmt.Println("::group::Setting up account")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-account"},
 		WorkingDir: "../",
 	})
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func SetUpAppBackends(t *testing.T, projectName string) {
-	logger.Log(t, "::group::Configuring terraform backends for application modules")
+	fmt.Println("::group::Configuring terraform backends for application modules")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-app-backends", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
 		WorkingDir: "../",
 	})
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func SetUpBuildRepository(t *testing.T, projectName string) {
-	logger.Log(t, "::group::Creating build repository resources")
+	fmt.Println("::group::Creating build repository resources")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "set-up-app-build-repository", fmt.Sprintf("PROJECT_NAME=%s", projectName)},
 		WorkingDir: "../",
 	})
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func ValidateAccountBackend(t *testing.T, region string, projectName string) {
-	logger.Log(t, "::group::Validating terraform backend for account")
+	fmt.Println("::group::Validating terraform backend for account")
 	expectedTfStateBucket := fmt.Sprintf("%s-368823044688-%s-tf-state", projectName, region)
 	expectedTfStateKey := "infra/account.tfstate"
 	aws.AssertS3BucketExists(t, region, expectedTfStateBucket)
 	_, err := aws.GetS3ObjectContentsE(t, region, expectedTfStateBucket, expectedTfStateKey)
 	assert.NoError(t, err, fmt.Sprintf("Failed to get tfstate object from tfstate bucket %s", expectedTfStateBucket))
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func ValidateGithubActionsAuth(t *testing.T, accountId string, projectName string) {
-	logger.Log(t, "::group::Validating that GitHub actions can authenticate with AWS account")
+	fmt.Println("::group::Validating that GitHub actions can authenticate with AWS account")
 	githubActionsRole := fmt.Sprintf("arn:aws:iam::%s:role/%s-github-actions", accountId, projectName)
 	// Check that GitHub Actions can authenticate with AWS
 	err := shell.RunCommandE(t, shell.Command{
@@ -109,7 +108,7 @@ func ValidateGithubActionsAuth(t *testing.T, accountId string, projectName strin
 		WorkingDir: "../",
 	})
 	assert.NoError(t, err, "GitHub actions failed to authenticate")
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func ValidateAppBackends(t *testing.T) {
@@ -117,7 +116,7 @@ func ValidateAppBackends(t *testing.T) {
 }
 
 func ValidateBuildRepository(t *testing.T, projectName string) {
-	logger.Log(t, "::group::Validating ability to publish build artifacts to build repository")
+	fmt.Println("::group::Validating ability to publish build artifacts to build repository")
 
 	err := shell.RunCommandE(t, shell.Command{
 		Command:    "make",
@@ -133,17 +132,17 @@ func ValidateBuildRepository(t *testing.T, projectName string) {
 	})
 	assert.NoError(t, err, "GitHub actions failed to authenticate")
 
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func TeardownAccount(t *testing.T) {
-	logger.Log(t, "::group::Destroying account")
+	fmt.Println("::group::Destroying account")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "destroy-account"},
 		WorkingDir: "../",
 	})
-	logger.Log(t, "::endgroup::")
+	fmt.Println("::endgroup::")
 }
 
 func TeardownBuildRepository(t *testing.T) {

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -136,7 +136,7 @@ func ValidateBuildRepository(t *testing.T, projectName string) {
 }
 
 func TeardownAccount(t *testing.T) {
-	fmt.Println("::group::Destroying account")
+	fmt.Println("::group::Destroying account resources")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "destroy-account"},
@@ -146,15 +146,19 @@ func TeardownAccount(t *testing.T) {
 }
 
 func TeardownBuildRepository(t *testing.T) {
+	fmt.Println("::group::Destroying build repository resources")
 	terraform.Destroy(t, &terraform.Options{
 		TerraformDir: "../infra/app/build-repository/",
 	})
+	fmt.Println("::endgroup::")
 }
 
 func TeardownDevEnvironment(t *testing.T) {
+	fmt.Println("::group::Destroying dev environment resources")
 	terraform.Destroy(t, &terraform.Options{
 		TerraformDir: "../infra/app/envs/dev/",
 	})
+	fmt.Println("::endgroup::")
 }
 
 func GetCurrentCommitHash(t *testing.T) string {


### PR DESCRIPTION
## Ticket

Resolves #183 

## Changes
* Grop logs in template CI for readability

## Context for reviewers
I noticed that it's really hard to read the template CI logs (especially for folks who isn't familiar with them), so this PR groups the template-infra-test logs to make them more readable.

## Testing
Looked at the CI run and saw that the output is much more readable
<img width="640" alt="image" src="https://user-images.githubusercontent.com/447859/202315944-d522de8a-be73-4ada-8f08-36015cb75692.png">

