### PR TITLE
Clean up template infra folder at end of install

### DIFF
--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "Fetch latest version of template-infra"
 git clone --single-branch --branch main --depth 1 git@github.com:navapbc/template-infra.git
 
-echo "Copy files form template-infra"
+echo "Copy files from template-infra"
 cp -r \
   template-infra/.github \
   template-infra/bin \

--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "Fetch latest version of template-infra"
 git clone --single-branch --branch main --depth 1 git@github.com:navapbc/template-infra.git
 
+echo "Copy files form template-infra"
 cp -r \
   template-infra/.github \
   template-infra/bin \
@@ -11,4 +13,8 @@ cp -r \
   template-infra/Makefile \
   .
 
+echo "Remove files relevant only to template development"
 rm .github/workflows/template-only-*
+
+echo "Clean up template-infra folder"
+rm -fr template-infra


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
I realize I forgot to `rm` the template-infra folder at the end of installing. Fixes bug in #177 

## Testing
Ran the script and saw that it properly deleted the template-infra folder