### PR TITLE
Set PORT env var for application

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,14 +11,10 @@
 # then visit localhost in a browser (or can use curl from a terminal)
 
 FROM busybox:latest AS release
-ENV PORT=8000
 
 ADD index.html /www/index.html
 ADD health /www/health
-
-EXPOSE $PORT
-
-HEALTHCHECK CMD nc -z localhost $PORT
+ADD start-server.sh /bin/start-server.sh
 
 # Create a basic webserver and run it until the container is stopped
-CMD echo "httpd started" && trap "exit 0;" TERM INT; httpd -v -p $PORT -h /www -f & wait
+CMD start-server.sh

--- a/app/start-server.sh
+++ b/app/start-server.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "httpd started on port $PORT" && trap "exit 0;" TERM INT; httpd -v -p $PORT -h /www -f & wait

--- a/infra/modules/service/container-definitions.json.tftpl
+++ b/infra/modules/service/container-definitions.json.tftpl
@@ -14,6 +14,12 @@
         "curl -f http://localhost:${container_port}/health || exit 1"
       ]
     },
+    "environment": [
+      {
+        "name": "PORT",
+        "value": "${container_port}"
+      }
+    ],
     "portMappings": [
       {
         "containerPort": ${container_port}

--- a/template-only-docs/application-requirements.md
+++ b/template-only-docs/application-requirements.md
@@ -1,6 +1,10 @@
 # Application Requirements
 
-In order to use the template infrastructure, you need an application in a folder that lives in the project root folder e.g. `/app`. The application folder needs to have a `Makefile` that has a build target `release-build` that takes in a Makefile variable `OPTS`, and passes those `OPTS` as options to the `docker build` command. The top level [Makefile](./Makefile) in this repo will call the application's `release-build` make target passing in release tags to tag the docker image with.
+In order to use the template infrastructure, you need an application that meets the following requirements.
+
+* The application's source code lives in a folder that lives in the project root folder e.g. `/app`.
+* The application folder needs to have a `Makefile` that has a build target `release-build` that takes in a Makefile variable `OPTS`, and passes those `OPTS` as options to the `docker build` command. The top level [Makefile](./Makefile) in this repo will call the application's `release-build` make target passing in release tags to tag the docker image with.
+* The web application needs to listen on the port defined by the environment variable `PORT`, rather than hardcode the `PORT`. This allows the infrastructure to configure the application to listen on a container port specified by the infrastructure. See [The Twelve-Factor App](https://12factor.net/) to learn more about designing applications to be portable to different infrastructure environments using environment variables.
 
 ## Example Application
 


### PR DESCRIPTION
## Ticket

n/a

## Changes
* Set PORT env var in task definition for application service
* Describe PORT env var application requirement
* Update example app to use PORT from env var

## Context for reviewers
While integrating https://github.com/navapbc/template-application-nextjs with template-infra I noticed that template-application-next uses a different port (3000), and realize that as part of [12-factor app](https://12factor.net/) the applications should use the port defined by environment variables rather than hardcoding it. I fixed the nextjs template to use port from env var in [this nextjs template PR](https://github.com/navapbc/template-application-nextjs/pull/85). The current PR updates the template-infra to set the `PORT` env var in the task definition, updates the example app to also use the PORT env var, and documents the PORT requirement.

## Testing
Made the changes in https://github.com/navapbc/platform-test-nextjs repo and deployed and it works. See http://platform-nextjs-app-dev-570903412.us-east-1.elb.amazonaws.com/

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/447859/202596260-34662acb-1514-4ab3-8c6a-a7e70f371cc1.png">
