### PR TITLE
Authenticate with AWS in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,12 @@ on:
           - staging
           - prod
 
+env:
+  ENV_NAME: ${{ inputs.env_name || "dev" }}
+
+concurrency:
+  group: cd-${{ env.ENV_NAME }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -30,17 +36,14 @@ jobs:
       - name: Build release
         run: make release-build
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
-      #     aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::430004246987:role/platform-test-github-actions
+          aws-region: us-east-1
 
       - name: Publish release
         run: make release-publish
 
       - name: Deploy release
-        run: |
-          ENV_NAME_INPUT="${{inputs.env_name}}"
-          ENV_NAME="${ENV_NAME_INPUT:-dev}"
-          make release-deploy ENV_NAME="$ENV_NAME"
+        run: make release-deploy ENV_NAME="$ENV_NAME"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,5 +41,5 @@ jobs:
 
       - name: Deploy release
         run: |
-          ENV_NAME=${{inputs.env_name:-dev}}
+          ENV_NAME=${${{inputs.env_name}}:-dev}
           make release-deploy ENV_NAME=$ENV_NAME

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,10 +17,10 @@ on:
           - prod
 
 env:
-  ENV_NAME: ${{ inputs.env_name }} || "dev"
+  ENV_NAME: ${{ inputs.env_name || 'dev' }}
 
-concurrency:
-  group: cd-${{ env.ENV_NAME }}
+# Need to repeat the expression since env.ENV_NAME is not accessible in this context
+concurrency: cd-${{ inputs.env_name || 'dev' }}
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Deploy release
         run: |
-          ENV_NAME_INPUT=${{inputs.env_name}}
-          ENV_NAME=${ENV_NAME_INPUT:-dev}
-          make release-deploy ENV_NAME=$ENV_NAME
+          ENV_NAME_INPUT="${{inputs.env_name}}"
+          ENV_NAME="${ENV_NAME_INPUT:-dev}"
+          make release-deploy ENV_NAME="$ENV_NAME"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,4 +40,6 @@ jobs:
         run: make release-publish
 
       - name: Deploy release
-        run: make release-deploy ENV_NAME=${{ inputs.env_name }}
+        run: |
+          ENV_NAME=${{inputs.env_name:-dev}}
+          make release-deploy ENV_NAME=$ENV_NAME

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ on:
           - prod
 
 env:
-  ENV_NAME: ${{ inputs.env_name || "dev" }}
+  ENV_NAME: ${{ inputs.env_name }} || "dev"
 
 concurrency:
   group: cd-${{ env.ENV_NAME }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,11 +20,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Build release
         run: make release-build
+
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+      #     aws-region: us-east-1
 
       - name: Publish release
         run: make release-publish

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,5 +41,6 @@ jobs:
 
       - name: Deploy release
         run: |
-          ENV_NAME=${${{inputs.env_name}}:-dev}
+          ENV_NAME_INPUT=${{inputs.env_name}}
+          ENV_NAME=${ENV_NAME_INPUT:-dev}
           make release-deploy ENV_NAME=$ENV_NAME

--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,5 @@ ifneq ($(filter $(ENV_NAME),$(ENVIRONMENTS)),)
 	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENV_NAME)
 else
 	@echo "Please enter: make release-deploy ENV_NAME=<env_name>. The value for env_name must be one of these: $(ENVIRONMENTS)"
+	exit 1
 endif


### PR DESCRIPTION
## Ticket

n/a

## Changes
* Authenticate with AWS in CD
* Set default environment when deploying from push event
* Limit CD concurrency based on environment being deployed to

## Context for reviewers
As I was testing out CD I saw that [CD errored out](https://github.com/navapbc/platform-test/actions/runs/3516675391/jobs/5893536990) which made me realize that we didn't authenticate github actions with AWS. This PR adds that authentication.

Then as I tested again I realized that input.env_name doesn't exist on push events, so I added that as a default parameter.

Finally, as I was testing rapidly I realize that we're going to run into concurrency issues if multiple people merge to main soon after each other, so I added a concurrency limit based on the environment being deployed to.

## Testing
I made these same changes in the platform-test repo and pushed to main, and saw that the [resulting CD run passed](https://github.com/navapbc/platform-test/actions/runs/3517923086/jobs/5896250512), and saw that the change was deployed at this URL: http://platform-test-app-dev-751272791.us-east-1.elb.amazonaws.com/

<img width="701" alt="image" src="https://user-images.githubusercontent.com/447859/203154696-5b94d6c7-82a1-441c-bfe2-39be88ab4a31.png">
