### PR TITLE
Templatize github actions role ARN in cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::430004246987:role/platform-test-github-actions
+          # !! Update the role-to-assume with the GitHub actions role ARN
+          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
           aws-region: us-east-1
 
       - name: Publish release

--- a/template-only-docs/set-up-cd.md
+++ b/template-only-docs/set-up-cd.md
@@ -1,3 +1,6 @@
 # Set up CD
 
-Once you have set up your application environments, you can enable continuous deployment in [cd.yml](../.github/workflows/cd.yml) by searching for `!!` and uncommenting the `on: push: ["main]` workflow trigger. This will trigger the deployment workflow on every merge to `main`.
+Once you have set up your application environments, you can enable continuous deployment in [cd.yml](../.github/workflows/cd.yml) by searching for `!!` and following the instructions to:
+
+1. Update the `role-to-assume` with the GitHub actions ARN.
+2. Uncomment the `on: push: ["main]` workflow trigger. This will trigger the deployment workflow on every merge to `main`.


### PR DESCRIPTION
## Ticket

n/a

## Changes
* Templatize github actions role ARN in cd workflow
* Add instructions to set-up-cd to update github actions role ARN

## Context for reviewers
I just realized I hardcoded the github actions ARN, it should be templatized

## Testing
n/a