### PR TITLE
Fix healthchecks

### DIFF
--- a/infra/modules/service/container-definitions.json.tftpl
+++ b/infra/modules/service/container-definitions.json.tftpl
@@ -11,7 +11,7 @@
     "healthcheck": {
       "command": [
         "CMD-SHELL",
-        "curl -f http://localhost:${container_port}/health || exit 1"
+        "wget --no-verbose --tries=1 --spider http://localhost:${container_port}/health || exit 1"
       ]
     },
     "environment": [

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -86,7 +86,7 @@ resource "aws_lb_listener_rule" "api_http_forward" {
 resource "aws_lb_target_group" "api_tg" {
   # you must use a prefix, to facilitate successful tg changes
   name_prefix          = "api-"
-  port                 = "8080"
+  port                 = var.container_port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
   target_type          = "ip"
@@ -94,7 +94,7 @@ resource "aws_lb_target_group" "api_tg" {
 
   health_check {
     path                = "/health"
-    port                = 8080
+    port                = var.container_port
     healthy_threshold   = 2
     unhealthy_threshold = 10
     interval            = 30

--- a/template-only-docs/application-requirements.md
+++ b/template-only-docs/application-requirements.md
@@ -5,6 +5,7 @@ In order to use the template infrastructure, you need an application that meets 
 * The application's source code lives in a folder that lives in the project root folder e.g. `/app`.
 * The application folder needs to have a `Makefile` that has a build target `release-build` that takes in a Makefile variable `OPTS`, and passes those `OPTS` as options to the `docker build` command. The top level [Makefile](./Makefile) in this repo will call the application's `release-build` make target passing in release tags to tag the docker image with.
 * The web application needs to listen on the port defined by the environment variable `PORT`, rather than hardcode the `PORT`. This allows the infrastructure to configure the application to listen on a container port specified by the infrastructure. See [The Twelve-Factor App](https://12factor.net/) to learn more about designing applications to be portable to different infrastructure environments using environment variables.
+* The web application needs to have a health check endpoint at `/health` that returns an HTTP 200 OK response when the application is healthy and ready to accept requests.
 
 ## Example Application
 


### PR DESCRIPTION
## Ticket

Resolves #205 

## Changes
* Fix container healthcheck to use wget rather than curl which isn't available in the container
* Fix ALB healthcheck to use port variable rather than hardcoded port

## Context for reviewers
I noticed sometimes the deployed test services would sometimes return 503. After some investigation, it looks like the container and ALB healthchecks weren't configured properly. This PR fixes those.

## Testing
Made the fixes on the [platform-test](https://github.com/navapbc/platform-test) repo and saw that it fixes things:

Load balancer target group now shows healthy hosts:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/447859/211409908-be157cab-6077-4609-b32c-47b2733e58f4.png">

And ECS shows task as healthy
<img width="612" alt="image" src="https://user-images.githubusercontent.com/447859/211409977-a7909fed-c080-4d96-914b-138ab256c059.png">
