### PR TITLE
Bumping up ECS deploy timeout

### DIFF
--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -177,7 +177,7 @@ func ValidateDevEnvironment(t *testing.T) {
 		TerraformDir: "../infra/app/envs/dev/",
 	})
 	serviceEndpoint := terraform.Output(t, terraformOptions, "service_endpoint")
-	http_helper.HttpGetWithRetryWithCustomValidation(t, serviceEndpoint, nil, 5, 1*time.Second, func(responseStatus int, responseBody string) bool {
+	http_helper.HttpGetWithRetryWithCustomValidation(t, serviceEndpoint, nil, 10, 3*time.Second, func(responseStatus int, responseBody string) bool {
 		return responseStatus == 200
 	})
 }


### PR DESCRIPTION
## Ticket

No ticket

## Changes
This PR is in response to the latest deploy to main failing because of a timeout on waiting for the ECS deployed to become available
 - Bumped timeout retries from 5 to 10
 - Bumped timeout wait between retries from 1 second to 3 seconds

## Context for reviewers
The previous config from the ECS deploy was timing out, but was not previously. In the NJ project, we are seeing ECS task deploys taking anywhere from 1 second to 10 minutes, albeit using a GIthub Action and not a Go script like this. It would seem that there are times where the deploy might be slower than normal, and this **should** fix those cases

## Testing
I didn't test this since it is just bumping up the time limit, and I don't have access to the AWS account. But, this is just increasing the time limit
