### PR TITLE
Add scanner config files to update script and added helper commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,5 +113,39 @@ release-image-name: ## Prints the image name of the release image
 release-image-tag: ## Prints the image tag of the release image
 	@echo $(IMAGE_TAG)
 
+########################
+## Scripts and Helper ##
+########################
+_get-changes:
+	find * ! -name '*template*' -not -path "*template*" -print0 | \
+		xargs -0 git diff ${CHANGES_IN_REPO} ${ORIGINAL_REPO} ${DIFF_FLAGS}
+
+get-last-changes-summary: ## Displays the number of changes to what files in the last commit to non-template files
+get-last-changes-summary: CHANGES_IN_REPO = HEAD^^ 
+get-last-changes-summary: ORIGINAL_REPO = HEAD
+get-last-changes-summary: DIFF_FLAGS = --compact-summary
+get-last-changes-summary: _get-changes
+
+get-last-changes: ## Displays the changes to what files in the last commit to non-template files
+get-last-changes: CHANGES_IN_REPO = HEAD^^ 
+get-last-changes: ORIGINAL_REPO = HEAD
+get-last-changes: DIFF_FLAGS = 
+get-last-changes: _get-changes
+
+get-local-changes-summary: ## Displays the number of changes to what files in the last pull from main to non-template files
+get-local-changes-summary: CHANGES_IN_REPO = main
+get-local-changes-summary: ORIGINAL_REPO = origin/main
+get-local-changes-summary: DIFF_FLAGS = --compact-summary
+get-local-changes-summary: _get-changes
+
+get-local-changes: ## Displays the changes to what files in the last pull from main to non-template files
+get-local-changes: CHANGES_IN_REPO = main
+get-local-changes: ORIGINAL_REPO = origin/main
+get-local-changes: DIFF_FLAGS =
+get-local-changes: _get-changes
+
+update-template: ## Runs the script that pulls the specified updated files from the template repo
+	sh ./template-only-bin/download-and-install-template.sh
+
 help: ## Prints the help documentation and info about each command
 	@grep -E '^[/a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -116,36 +116,6 @@ release-image-tag: ## Prints the image tag of the release image
 ########################
 ## Scripts and Helper ##
 ########################
-_get-changes:
-	find * ! -name '*template*' -not -path "*template*" -print0 | \
-		xargs -0 git diff ${CHANGES_IN_REPO} ${ORIGINAL_REPO} ${DIFF_FLAGS}
-
-get-last-changes-summary: ## Displays the number of changes to what files in the last commit to non-template files
-get-last-changes-summary: CHANGES_IN_REPO = HEAD^^ 
-get-last-changes-summary: ORIGINAL_REPO = HEAD
-get-last-changes-summary: DIFF_FLAGS = --compact-summary
-get-last-changes-summary: _get-changes
-
-get-last-changes: ## Displays the changes to what files in the last commit to non-template files
-get-last-changes: CHANGES_IN_REPO = HEAD^^ 
-get-last-changes: ORIGINAL_REPO = HEAD
-get-last-changes: DIFF_FLAGS = 
-get-last-changes: _get-changes
-
-get-local-changes-summary: ## Displays the number of changes to what files in the last pull from main to non-template files
-get-local-changes-summary: CHANGES_IN_REPO = main
-get-local-changes-summary: ORIGINAL_REPO = origin/main
-get-local-changes-summary: DIFF_FLAGS = --compact-summary
-get-local-changes-summary: _get-changes
-
-get-local-changes: ## Displays the changes to what files in the last pull from main to non-template files
-get-local-changes: CHANGES_IN_REPO = main
-get-local-changes: ORIGINAL_REPO = origin/main
-get-local-changes: DIFF_FLAGS =
-get-local-changes: _get-changes
-
-update-template: ## Runs the script that pulls the specified updated files from the template repo
-	sh ./template-only-bin/download-and-install-template.sh
 
 help: ## Prints the help documentation and info about each command
 	@grep -E '^[/a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -16,6 +16,10 @@ cp -r \
   docs \
   infra \
   Makefile \
+  .dockleconfig \
+  .grype.yml \
+  .hadolint.yaml \
+  .trivyignore \
   $CUR_DIR
 cd -
 


### PR DESCRIPTION
## Ticket

{LINK TO TICKET}

## Changes
 - Added the image scanner config files to the `template-only-bin/download-and-install-template.sh` file so that any repos that use the scanners will have them
 - Added make command to run the above script
 - Added make commands to check changes from last commit (`get-last-changes` and `get-last-changes-summary`)
 - Added make commands to check changes since last pull from main (`get-local-changes` and `get-local-changes-summary`)

## Context for reviewers
The main point of this PR was to setup the image scanner configs to be copied when running the template script. I added the make commands as a QoL improvement as well so that you can run the command to update the repo if you have already pulled it. The other make commands were just so that people can see the changes they have since their last pull from main, or in the last merge to main

## Testing
The tweaks to the shell script will copy the config files over, and the make commands have been tested