### PR TITLE
Don't overwrite project scanner configs on update

### DIFF
--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -16,11 +16,15 @@ $SCRIPT_DIR/install-template.sh
 # Updates in any of these files need to be manually applied to the projects
 echo "Restore modified project files"
 git checkout HEAD -- \
-  infra/project-config/main.tf \
+  .dockleconfig \
+  .github/workflows/cd.yml \
+  .grype.yml \
+  .hadolint.yaml \
+  .trivyignore
   infra/accounts/account/main.tf \
   infra/app/build-repository/main.tf \
   infra/app/envs/dev/main.tf \
   infra/app/envs/prod/main.tf \
   infra/app/envs/staging/main.tf \
+  infra/project-config/main.tf \
   Makefile \
-  .github/workflows/cd.yml


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title 

## Context for reviewers
Flask and Nextjs each have different scanner configs so the template should copy over the template on initial install but not overwrite it when updating the template

## Testing
I didn't do testing but the change I think is simple enough, and low-risk / reversible
