### PR TITLE
Use kms arn instead key_id of to avoid forcing replacement

### DIFF
--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -12,7 +12,8 @@ on:
       - .github/workflows/template-only-ci-infra.yml
       - app/Dockerfile
 
-# For now, only allow one workflow run at a time, since this actually provisions infra.
+# For now, only allow one workflow run at a time, since this provisions an OIDC
+# provider for github actions and only one OIDC provider can exist at a time.
 concurrency: platform-template-only-ci-infra
 
 jobs:

--- a/infra/modules/container-image-repository/main.tf
+++ b/infra/modules/container-image-repository/main.tf
@@ -14,7 +14,7 @@ resource "aws_ecr_repository" "app" {
 
   encryption_configuration {
     encryption_type = "KMS"
-    kms_key         = aws_kms_key.ecr_kms.key_id
+    kms_key         = aws_kms_key.ecr_kms.arn
   }
 }
 


### PR DESCRIPTION
## Ticket

N/A

## Changes
see title

## Context for reviewers
It looks like assigning `kms_key = key_id` causes the terraform plan to detect a change. We need to be using the ARN instead:

With key_id
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/447859/229662439-6e7efd64-813a-4c11-b963-8e263bac1e25.png">

With arn
<img width="772" alt="image" src="https://user-images.githubusercontent.com/447859/229662504-fb752c07-b599-4b7f-9a97-c8aae2941f75.png">

## Testing
Ran terraform plan in `platform-test` repo with and without the change