### PR TITLE
#240-use aws_iam_account_alias to get account alias for s3 bucket naming

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Run Checkov check
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v10
         with:
           directory: infra
           framework: terraform

--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -5,7 +5,7 @@ data "aws_iam_account_alias" "current" {}
 
 locals {
   tf_state_bucket_name = "${var.project_name}-${data.aws_iam_account_alias.current.account_alias}-${data.aws_region.current.name}-tf-state"
-  tf_logs_bucket_name  = "${var.project_name}-${data.aws_iam_account_alias.current.account_alias}-${data.aws_region.current.name}-tf-logs"
+  tf_logs_bucket_name  = "${var.project_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-tf-logs"
   tf_locks_table_name  = "${var.project_name}-tf-state-locks"
 }
 

--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -55,41 +55,6 @@ resource "aws_s3_bucket" "tf_state" {
   }
 }
 
-data "aws_iam_policy_document" "topic" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
-    }
-
-    actions   = ["SNS:Publish"]
-    resources = ["arn:aws:sns:*:*:s3-event-notification-topic"]
-
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = [aws_s3_bucket.tf_state.arn]
-    }
-  }
-}
-
-resource "aws_sns_topic" "topic" {
-  name   = "s3-event-notification-topic"
-  policy = data.aws_iam_policy_document.topic.json
-}
-
-resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = aws_s3_bucket.tf_state.id
-
-  topic {
-    topic_arn     = aws_sns_topic.topic.arn
-    events        = ["s3:ObjectCreated:*"]
-    filter_suffix = ".log"
-  }
-}
-
 resource "aws_s3_bucket_versioning" "tf_state" {
   bucket = aws_s3_bucket.tf_state.id
   versioning_configuration {

--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -1,10 +1,11 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
+data "aws_iam_account_alias" "current" {}
 
 locals {
-  tf_state_bucket_name = "${var.project_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-tf-state"
-  tf_logs_bucket_name  = "${var.project_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-tf-logs"
+  tf_state_bucket_name = "${var.project_name}-${data.aws_iam_account_alias.current.account_alias}-${data.aws_region.current.name}-tf-state"
+  tf_logs_bucket_name  = "${var.project_name}-${data.aws_iam_account_alias.current.account_alias}-${data.aws_region.current.name}-tf-logs"
   tf_locks_table_name  = "${var.project_name}-tf-state-locks"
 }
 

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -116,7 +116,7 @@ func SetUpDevEnvironment(t *testing.T) {
 
 func ValidateAccountBackend(t *testing.T, region string, projectName string) {
 	fmt.Println("::group::Validating terraform backend for account")
-	expectedTfStateBucket := fmt.Sprintf("%s-368823044688-%s-tf-state", projectName, region)
+	expectedTfStateBucket := fmt.Sprintf("%s-nava-platform-%s-tf-state", projectName, region)
 	expectedTfStateKey := "infra/account.tfstate"
 	aws.AssertS3BucketExists(t, region, expectedTfStateBucket)
 	_, err := aws.GetS3ObjectContentsE(t, region, expectedTfStateBucket, expectedTfStateKey)


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-infra/issues/240

## Changes
> Updated s3 bucket naming convention to use account alias vs account_id

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
