### PR TITLE
Allow manual run of template-only-ci-infra

### DIFF
--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -11,6 +11,7 @@ on:
       - template-only-test/**
       - .github/workflows/template-only-ci-infra.yml
       - app/Dockerfile
+  workflow_dispatch:
 
 # For now, only allow one workflow run at a time, since this actually provisions infra.
 concurrency: platform-template-only-ci-infra


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
We're having issues getting CI to pass so this change allows us to manually run it from main to try to get a clean run.

## Testing
CI shows a clean run