### PR TITLE
Check if image tag exists prior to build/publish

### DIFF
--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -25,6 +25,9 @@ echo "Authenticating Docker with ECR"
 aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
-echo "Publishing image"
+echo "Check if tag has already been published..."
+aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 || IMAGE_TAG_EXISTS=$?
+[ $IMAGE_TAG_EXISTS -eq 0 ] && echo "Image with tag $IMAGE_TAG already published" && exit 0
+echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -34,6 +34,7 @@ if [ ! -z "$RESULT" ];then
   exit 0
 fi
 
+
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 set -euo pipefail
 
@@ -30,9 +30,10 @@ echo "Check if tag has already been published..."
 RESULT=""
 RESULT=$(aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION 2> /dev/null ) || true
 if [ ! -z "$RESULT" ];then
-echo "Image with tag $IMAGE_TAG already published"
-exit 0
+  echo "Image with tag $IMAGE_TAG already published"
+  exit 0
 fi
+
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -x
+
 set -euo pipefail
 
 APP_NAME=$1
@@ -26,8 +27,12 @@ aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
 echo "Check if tag has already been published..."
-aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 || IMAGE_TAG_EXISTS=$?
-[ $IMAGE_TAG_EXISTS -eq 0 ] && echo "Image with tag $IMAGE_TAG already published" && exit 0
+RESULT=""
+RESULT=$(aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION 2> /dev/null ) || true
+if [ ! -z "$RESULT" ];then
+echo "Image with tag $IMAGE_TAG already published"
+exit 0
+fi
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-infra/issues/197

## Changes
Check if the image tag exists in AWS ECR. If so, do not republish

## Context for reviewers
On a Deploy failure, the image tag may get uploaded, resulting in a failure when the re-run tries to create a duplicate tag. This work will check for that tag first.

## Testing
https://github.com/navapbc/platform-test/pull/5