### PR TITLE
Add workaround for empty logging race condition

### DIFF
--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -268,9 +268,29 @@ resource "aws_s3_bucket_policy" "tf_log" {
   policy = data.aws_iam_policy_document.tf_log.json
 }
 
+# This is a workaround to a race condition that seems to have been recently introduced
+# by AWS S3 and at the time of writing (2023-05-09) has yet to be resolved.
+# See https://github.com/hashicorp/terraform-provider-aws/issues/31139 for more details
+# about the issue.
+# There is an outstanding PR in the Terraform AWS provider created on Apr 24, 2023 that
+# may resolve this issue: https://github.com/hashicorp/terraform-provider-aws/pull/30916
+resource "null_resource" "logging_empty_output_workaround" {
+  provisioner "local-exec" {
+    command = "sleep 15"
+  }
+
+  triggers = {
+    bucket = aws_s3_bucket.tf_state.bucket
+  }
+
+  depends_on = [aws_s3_bucket.tf_state]
+}
+
 resource "aws_s3_bucket_logging" "tf_state" {
   bucket = aws_s3_bucket.tf_state.id
 
   target_bucket = aws_s3_bucket.tf_log.id
   target_prefix = "logs/${aws_s3_bucket.tf_state.bucket}/"
+
+  depends_on = [null_resource.logging_empty_output_workaround]
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/258

## Changes
see title

## Context for reviewers
It seems that AWS recently introduced a change to the S3 service that created a race condition in the Terraform S3 provider that causes the S3 logging configuration to sometimes return an empty output when Terraform's AWS provider tries to read it. This causes the templata-infra CI to fail intermittently which is a pain since it also means that the template-infra CI can't clean up resources properly and that resources needed to be cleaned up manually.

This bug was reported on the terraform aws provider repo at https://github.com/hashicorp/terraform-provider-aws/issues/31139

There seems to be a related PR on that repo created on April 24, 2023 that adds retries that should hopefully resolve this issue, but at time of writing (May 9, 2023) it has not yet been merged: https://github.com/hashicorp/terraform-provider-aws/pull/30916

This PR adds the workaround documented in the first link.

I created https://github.com/navapbc/template-infra/issues/259 as a tech debt item to remove the workaround once proper fixes are ready

## Testing
CI