### PR TITLE
Add make target parameter checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ infra-configure-app-build-repository:
 	./bin/configure-app-build-repository.sh $(APP_NAME)
 
 infra-configure-app-service:
+	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	./bin/configure-app-service.sh $(APP_NAME) $(ENVIRONMENT)
@@ -68,10 +69,12 @@ infra-update-current-account:
 	./bin/terraform-init-and-apply.sh infra/accounts `./bin/current-account-config-name.sh`
 
 infra-update-app-build-repository:
+	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	./bin/terraform-init-and-apply.sh infra/$(APP_NAME)/build-repository shared
 
 infra-update-app-service:
+	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	./bin/terraform-init-and-apply.sh infra/$(APP_NAME)/service $(ENVIRONMENT)

--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,20 @@ infra-configure-app-build-repository:
 	./bin/configure-app-build-repository.sh $(APP_NAME)
 
 infra-configure-app-service:
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
+	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	./bin/configure-app-service.sh $(APP_NAME) $(ENVIRONMENT)
 
 infra-update-current-account:
 	./bin/terraform-init-and-apply.sh infra/accounts `./bin/current-account-config-name.sh`
 
 infra-update-app-build-repository:
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	./bin/terraform-init-and-apply.sh infra/$(APP_NAME)/build-repository shared
 
 infra-update-app-service:
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
+	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	./bin/terraform-init-and-apply.sh infra/$(APP_NAME)/service $(ENVIRONMENT)
 
 


### PR DESCRIPTION
## Ticket

Resolves #263 

## Changes
see title

## Context for reviewers
This change improves the developer experience by adding
parameter checks to the Makefile so a developer can more
easily remember fix their Make command without having to
look into the Makefile itself

## Testing
Ran the commands without passing in params
<img width="993" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/d59e0aab-7acf-4517-82ee-db847ca48754">

CI still works (CI runs the commands with the parameters)