### PR TITLE
Update link after rebuilding platform-test infra

### DIFF
--- a/template-only-docs/application-requirements.md
+++ b/template-only-docs/application-requirements.md
@@ -9,7 +9,7 @@ In order to use the template infrastructure, you need an application that meets 
 
 ## Example Application
 
-The infra template includes an example "hello, world" application that works with the template. This application is fully deployed and can be viewed at the endpoint <http://app-dev-1582588227.us-east-1.elb.amazonaws.com/>. The source code for this test application is at <https://github.com/navapbc/platform-test>.
+The infra template includes an example "hello, world" application that works with the template. This application is fully deployed and can be viewed at the endpoint <http://app-dev-2068097977.us-east-1.elb.amazonaws.com/>. The source code for this test application is at <https://github.com/navapbc/platform-test>.
 
 ## Template Applications
 


### PR DESCRIPTION
## Ticket

N/A

## Changes
> What was added, updated, or removed in this PR.

## Context for reviewers
Sorry, I realized I just did this in https://github.com/navapbc/template-infra/pull/267 but I have to update the link one more time. I ended up destroying all the infra in platform-test and rebuilding from scratch due to the major change that just got merged in template-infra.

## Testing
New link is at http://app-dev-2068097977.us-east-1.elb.amazonaws.com/ and should show the hello, world app