### PR TITLE
Fix CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,8 @@ on:
   #     - 'infra/**'
   workflow_dispatch:
     inputs:
-      env_name:
-        description: "env_name input"
+      environment:
+        description: "environment input"
         required: true
         default: "dev"
         type: choice
@@ -22,10 +22,10 @@ on:
           - prod
 
 env:
-  ENV_NAME: ${{ inputs.env_name || 'dev' }}
+  ENVIRONMENT: ${{ inputs.environment || 'dev' }}
 
 # Need to repeat the expression since env.ENV_NAME is not accessible in this context
-concurrency: cd-${{ inputs.env_name || 'dev' }}
+concurrency: cd-${{ inputs.environment || 'dev' }}
 
 jobs:
   deploy:
@@ -52,4 +52,4 @@ jobs:
         run: make release-publish
 
       - name: Deploy release
-        run: make release-deploy ENV_NAME="$ENV_NAME"
+        run: make release-deploy ENVIRONMENT="$ENVIRONMENT"

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,6 @@ CURRENT_ACCOUNT_ID = $(./bin/current-account-id.sh)
 # in infra/modules and then stripping out the "infra/modules/" prefix
 MODULES := $(notdir $(wildcard infra/modules/*))
 
-# Get the list of accounts and environments in a manner similar to MODULES above
-ACCOUNTS := $(notdir $(wildcard infra/accounts/*))
-ENVIRONMENTS := $(notdir $(wildcard infra/app/envs/*))
-
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.
 #
@@ -140,13 +136,8 @@ release-publish:
 	./bin/publish-release.sh $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG)
 
 release-deploy:
-# check the variable against the list of enviroments and suggest one of the correct envs.
-ifneq ($(filter $(ENVIRONMENT),$(ENVIRONMENTS)),)
+	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
 	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
-else
-	@echo "Please enter: make release-deploy ENVIRONMENT=<environment>. The value for environment must be one of these: $(ENVIRONMENTS)"
-	exit 1
-endif
 
 release-image-name: ## Prints the image name of the release image
 	@echo $(IMAGE_NAME)


### PR DESCRIPTION
## Ticket

N/A

## Changes
* Remove obsolete Makefile variables
* Replace old environment variable check

## Context for reviewers
Fixes an issue introduced by #242 

A rename of a Makefile parameter from ENV_NAME to ENVIRONMENT caused cd workflow to break as part of the refactor to seprate tfbackend configs into separate files. See https://github.com/navapbc/platform-test/actions/runs/4984413454

Moreover, the ENVIRONMENTS variable no longer works since the `envs` folder has been deleted

## Testing
Tested the change in platform-test (see https://github.com/navapbc/platform-test/pull/11 and successful run https://github.com/navapbc/platform-test/actions/runs/4985476603)
made the same change in platform-test-nextjs (see successful run here: https://github.com/navapbc/platform-test-nextjs/actions/runs/4985529639)