### PR TITLE
Don't overwrite ci-infra on template deploy

### DIFF
--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -18,6 +18,7 @@ echo "Restore modified project files"
 git checkout HEAD -- \
   .dockleconfig \
   .github/workflows/cd.yml \
+  .github/workflows/ci-infra.yml \
   .grype.yml \
   .hadolint.yaml \
   .trivyignore \


### PR DESCRIPTION
## Ticket

Resolves #279 

## Changes
see title

## Context
The template-only-cd.yml workflow is buggy. It currently overwrites .github/workflows/ci-infra.yml, which causes the infra e2e tests to be commented out. As an example, see this latest commit on platform-test: https://github.com/navapbc/platform-test-nextjs/commit/5b8b9f22d2c4bb5ca4f9717adde60b51c49dffb9#diff-c871e126464447bfd392c61d9679ad5715b9bb292caa88dd214e27bc5ae46075

<img width="1869" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/5be4b9e2-3647-47ac-872c-e05168b6cf42">

This change adds ci-infra.yml to the list of files not to touch during the CI deploy's update-template.sh step.

## Testing
Didn't test this since it's a low risk change to make
