### PR TITLE
Add location for buckets outside of us-east-1

### DIFF
--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -49,7 +49,7 @@ echo "Bootstrapping the account by creating an S3 backend with minimal configura
 echo "------------------------------------------------------------------------------"
 echo 
 echo "Creating bucket: $TF_STATE_BUCKET_NAME"
-aws s3api create-bucket --bucket $TF_STATE_BUCKET_NAME --region $REGION > /dev/null
+aws s3api create-bucket --bucket $TF_STATE_BUCKET_NAME --region $REGION --create-bucket-configuration LocationConstraint=$REGION > /dev/null
 echo
 echo "----------------------------------"
 echo "Creating rest of account resources"


### PR DESCRIPTION
## Ticket

Resolves #291 

## Changes
see title

## Context
Encountered this bug while testing with `us-west-1`

## Testing
Made the same change in my test account and re-ran `make infra-set-up-account` and it got past the s3 bucket creation step:

<img width="781" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/41b303bb-5df2-4a16-a776-9821438a15b9">
