### PR TITLE
Relax terraform core version constraint

### DIFF
--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -16,7 +16,7 @@ locals {
 
 terraform {
 
-  required_version = ">=1.2.0"
+  required_version = ">= 1.2.0, < 2.0.0"
 
   required_providers {
     aws = {

--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -16,7 +16,7 @@ locals {
 
 terraform {
 
-  required_version = "~>1.2.0"
+  required_version = ">=1.2.0"
 
   required_providers {
     aws = {

--- a/infra/app/build-repository/main.tf
+++ b/infra/app/build-repository/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 terraform {
-  required_version = ">=1.2.0"
+  required_version = ">= 1.2.0, < 2.0.0"
 
   required_providers {
     aws = {

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -28,7 +28,7 @@ locals {
 }
 
 terraform {
-  required_version = ">=1.2.0"
+  required_version = ">= 1.2.0, < 2.0.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Ticket

N/A

## Changes
see title

## Context for reviewers
Elsewhere in the codebase we have `required_version = ">=1.2.0"` but for accounts it's `~>1.2.0` which is too restrictive, especially since we require 1.4.6 as part of the database work.

I ran into this issue while testing out the template infra on a test account while running `make infra-set-up-account`:
<img width="1446" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/df4c515c-79a9-45cf-92f7-f20c2090b2bb">

## Testing
Made the same change in my test repo and re-ran `make infra-set-up-account` and saw that it succeeded

