### PR TITLE
Fix regression for us-east-1

### DIFF
--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -50,7 +50,7 @@ echo "--------------------------------------------------------------------------
 echo 
 echo "Creating bucket: $TF_STATE_BUCKET_NAME"
 CREATE_BUCKET_CONFIGURATION=""
-if [ $REGION = "us-east-1" ]; then
+if [ $REGION != "us-east-1" ]; then
   CREATE_BUCKET_CONFIGURATION="--create-bucket-configuration LocationConstraint=$REGION"
 fi
 aws s3api create-bucket --bucket $TF_STATE_BUCKET_NAME --region $REGION $CREATE_BUCKET_CONFIGURATION > /dev/null

--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -49,7 +49,11 @@ echo "Bootstrapping the account by creating an S3 backend with minimal configura
 echo "------------------------------------------------------------------------------"
 echo 
 echo "Creating bucket: $TF_STATE_BUCKET_NAME"
-aws s3api create-bucket --bucket $TF_STATE_BUCKET_NAME --region $REGION --create-bucket-configuration LocationConstraint=$REGION > /dev/null
+CREATE_BUCKET_CONFIGURATION=""
+if [ $REGION = "us-east-1" ]; then
+  CREATE_BUCKET_CONFIGURATION="--create-bucket-configuration LocationConstraint=$REGION"
+fi
+aws s3api create-bucket --bucket $TF_STATE_BUCKET_NAME --region $REGION $CREATE_BUCKET_CONFIGURATION > /dev/null
 echo
 echo "----------------------------------"
 echo "Creating rest of account resources"

--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -49,6 +49,9 @@ echo "Bootstrapping the account by creating an S3 backend with minimal configura
 echo "------------------------------------------------------------------------------"
 echo 
 echo "Creating bucket: $TF_STATE_BUCKET_NAME"
+# For creating buckets outside of us-east-1, a LocationConstraint needs to be set
+# For creating buckets in us-east-1, LocationConstraint cannot be set
+# See https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html
 CREATE_BUCKET_CONFIGURATION=""
 if [ $REGION != "us-east-1" ]; then
   CREATE_BUCKET_CONFIGURATION="--create-bucket-configuration LocationConstraint=$REGION"


### PR DESCRIPTION
## Ticket

N/A

## Changes
Fix regression introduced by #292

## Context for reviewers
I was careless and didn't test for us-east-1 after fixing for us-west-1 since I assumed CI ran but it actually didn't until merged to main. This change fixes the regression.

(As an aside, I think it's silly that the AWS CLI interface requires this separate parameter for regions different from us-east-1 but doesn't allow it for us-east-1)

## Testing

1. Configured project-config/main.tf to use us-east-1
2. Ran `make infra-set-up-account ACCOUNT_NAME=dev`
3. Destroyed everything with `make -f template-only.mak destroy-account`

Cleaned up the repo and did the following steps for testing us-west-1:

1. Changed my AWS config to default to us-west-1
2. Changed project-config/main.tf to use us-west-1 as default region
3. Ran `make infra-set-up-account ACCOUNT_NAME=dev`
4. Destroyed everything with `make -f template-only.mak destroy-account`
