### PR TITLE
Update decision index

### DIFF
--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -4,7 +4,12 @@ This log lists the architectural decisions for [project name].
 
 <!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->
 
-- [ADR-0000](infra/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+* [ADR-0000](infra/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+* [ADR-0001](infra/0001-ci-cd-interface.md) - CI/CD Interface
+* [ADR-0002](infra/0002-use-custom-implementation-of-github-oidc.md) - Use custom implementation of GitHub OIDC to authenticate GitHub actions with AWS rather than using module in Terraform Registry
+* [ADR-0003](infra/0003-manage-ecr-in-prod-account-module.md) - Manage ECR in prod account module
+* [ADR-0004](infra/0004-separate-terraform-backend-configs-into-separate-config-files.md) - Separate tfbackend configs into separate files
+* [ADR-1](template.md) - [short title of solved problem and solution]
 
 <!-- adrlogstop -->
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -4,7 +4,7 @@ This log lists the architectural decisions for [project name].
 
 <!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->
 
-- [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+- [ADR-0000](infra/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
## Changes
This updates the decision index using adr.

This could be added as a [pre-commit for adr docs](https://github.com/trussworks/pre-commit-hooks/blob/main/pre-commit-gen-docs) so this step does not get missed in the future.

## Testing

Click through index.md and see that links work correctly.