### PR TITLE
Deploy to platform-test-flask as part of CD

### DIFF
--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        project_repo: [navapbc/platform-test, navapbc/platform-test-nextjs]
+        project_repo:
+          - navapbc/platform-test
+          - navapbc/platform-test-flask
+          - navapbc/platform-test-nextjs
     steps:
       - name: Checkout template-infra repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## Ticket

Resolves #306 

## Changes
see title

## Context for reviewers
The template CD currently deploys to the integration test repos platform-test and platform-test-nextjs. This PR adds a new integration platform-test-flask.

## Testing
Manually triggered the workflow from this branch https://github.com/navapbc/template-infra/actions/runs/5225329852

<img width="1080" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/837d1d3f-ba86-4621-9fb9-e4f61d5e7bb3">
