### PR TITLE
Use default severity cutoff for anchor-scan

### DIFF
--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -79,8 +79,7 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: ${{ steps.build-image.outputs.image }}
-          severity-cutoff: "negligible" # Will ignore any findings that are negligible or lower
-          output-format: "table" # Can be table, json, or sarif
+          output-format: "table"
 
   dockle-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context
We don't need to care about "low" or "negligible" by default. Projects can dial up the strictness if needed.

## Testing
CI