### PR TITLE
Don't overwrite build-and-publish in update.sh

### DIFF
--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -17,6 +17,7 @@ $SCRIPT_DIR/install-template.sh
 echo "Restore modified project files"
 git checkout HEAD -- \
   .dockleconfig \
+  .github/workflows/build-and-publish.yml \
   .github/workflows/cd.yml \
   .github/workflows/ci-infra.yml \
   .grype.yml \


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
In #297 we extracted build-and-publish to a separate workflow but I forgot to add that workflow to the list of files we restore in update-template.sh. If we don't list that file in update-template.sh, then every time we merge something to main in template-infra, we'll overwrite the role-to-assume variable in the file for all the test projects (platform-test, platform-test-nextjs, and platform-test-flask)

## Testing
