### PR TITLE
Move role-to-assume into separate config file

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
 
+env:
+  APP_NAME: app
+  ENVIRONMENT: shared
+
 jobs:
   build-and-publish:
     name: Build and publish
@@ -31,13 +35,14 @@ jobs:
       - name: Build release
         run: make release-build
 
+      - name: Get role to assume
+        run: echo "ROLE_TO_ASSUME=$(./bin/github-actions-role-to-assume.sh $APP_NAME $ENVIRONMENT)" >> "$GITHUB_ENV"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          # !! Update the role-to-assume with the GitHub actions role ARN
-          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           aws-region: us-east-1
 
       - name: Publish release
         run: make release-publish
-

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "environment input"
+        description: "target environment"
         required: true
         default: "dev"
         type: choice
@@ -22,6 +22,7 @@ on:
           - prod
 
 env:
+  APP_NAME: app
   ENVIRONMENT: ${{ inputs.environment || 'dev' }}
 
 # Need to repeat the expression since env.ENV_NAME is not accessible in this context
@@ -44,11 +45,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get role to assume
+        run: echo "ROLE_TO_ASSUME=$(./bin/github-actions-role-to-assume.sh $APP_NAME $ENVIRONMENT)" >> "$GITHUB_ENV"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          # !! Update the role-to-assume with the GitHub actions role ARN
-          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           aws-region: us-east-1
       - name: Deploy release
-        run: make release-deploy ENVIRONMENT="$ENVIRONMENT"
+        run: make release-deploy APP_NAME=$APP_NAME ENVIRONMENT="$ENVIRONMENT"

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -13,6 +13,11 @@ on:
       - test/**
       - .github/workflows/ci-infra.yml
 
+env:
+  APP_NAME: app
+  # Run infra CI on dev environment
+  ENVIRONMENT: dev
+
 jobs:
   check-terraform-format:
     name: Check Terraform format
@@ -88,11 +93,12 @@ jobs:
   #     - uses: actions/setup-go@v3
   #       with:
   #         go-version: ">=1.19.0"
+  #     - name: Get role to assume
+  #       run: echo "ROLE_TO_ASSUME=$(./bin/github-actions-role-to-assume.sh $APP_NAME $ENVIRONMENT)" >> "$GITHUB_ENV"
   #     - name: Configure AWS credentials
   #       uses: aws-actions/configure-aws-credentials@v1
   #       with:
-  #         # !! Update the role-to-assume with the GitHub actions role ARN
-  #         role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+  #         role-to-assume: ${{ env.ROLE_TO_ASSUME }}
   #         aws-region: us-east-1
   #     - name: Run Terratest
   #       run: make infra-test

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -38,11 +38,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get role to assume
+        run: echo "ROLE_TO_ASSUME=$(./bin/github-actions-role-to-assume.sh $INPUT_APP_NAME $INPUT_ENVIRONMENT)" >> "$GITHUB_ENV"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          # !! Update the role-to-assume with the GitHub actions role ARN
-          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           aws-region: us-east-1
       - name: Run migrations
         run: make release-run-database-migrations APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }}

--- a/bin/configure-app-build-repository.sh
+++ b/bin/configure-app-build-repository.sh
@@ -18,9 +18,9 @@ APP_NAME=$1
 #--------------------------------------
 
 MODULE_DIR="infra/$APP_NAME/build-repository"
-BACKEND_CONFIG_NAME="shared"
+CONFIG_NAME="shared"
 
-./bin/create-tfbackend.sh $MODULE_DIR $BACKEND_CONFIG_NAME
+./bin/create-tfbackend.sh $MODULE_DIR $CONFIG_NAME
 
 #--------------------
 # Create tfvars file
@@ -49,3 +49,9 @@ echo "Created file: $TF_VARS_FILE"
 echo "------------------ file contents ------------------"
 cat $TF_VARS_FILE
 echo "----------------------- end -----------------------"
+
+#---------------------------------------------
+# Configure role to assume for GitHub Actions
+#---------------------------------------------
+
+./bin/configure-github-actions-role-to-assume.sh $APP_NAME $CONFIG_NAME

--- a/bin/configure-app-service.sh
+++ b/bin/configure-app-service.sh
@@ -83,3 +83,9 @@ echo "Created file: $TF_VARS_FILE"
 echo "------------------ file contents ------------------"
 cat $TF_VARS_FILE
 echo "----------------------- end -----------------------"
+
+#---------------------------------------------
+# Configure role to assume for GitHub Actions
+#---------------------------------------------
+
+./bin/configure-github-actions-role-to-assume.sh $APP_NAME $ENVIRONMENT

--- a/bin/configure-github-actions-role-to-assume.sh
+++ b/bin/configure-github-actions-role-to-assume.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Configure GitHub Actions to assume the given IAM role for a particular
+# environment.
+#
+# Positional parameters:
+#   APP_NAME (required) – the name of subdirectory of /infra that holds the
+#     application's infrastructure code.
+#   ENVIRONMENT (required) – the name of the application environment,
+#     (e.g. dev, staging, prod), or "shared" for resources that are shared
+#     across environments
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+APP_NAME="$1"
+ENVIRONMENT="$2"
+
+CONFIG_FILE=infra/$APP_NAME/app-config/github-actions-role-to-assume.ini
+
+terraform -chdir=infra/project-config refresh > /dev/null
+PROJECT_NAME=$(terraform -chdir=infra/project-config output -raw project_name)
+ACCOUNT_ID=$(./bin/current-account-id.sh)
+ROLE_ARN="arn:aws:iam::$ACCOUNT_ID:role/$PROJECT_NAME-github-actions"
+
+echo "========================================"
+echo "Set up role-to-assume for GitHub Actions"
+echo "========================================"
+echo "Input parameters"
+echo "  APP_NAME=$APP_NAME"
+echo "  ENVIRONMENT=$ENVIRONMENT"
+echo
+echo "Target configuration"
+echo "  ROLE_ARN=$ROLE_ARN"
+echo
+# Remove any existing configuration for the environment
+sed -i.bak "/$ENVIRONMENT=/d" $CONFIG_FILE
+rm $CONFIG_FILE.bak
+
+# Add new configuration
+echo "$ENVIRONMENT=\"$ROLE_ARN\"" >> $CONFIG_FILE
+
+# Sort the file
+sort $CONFIG_FILE > sorted-config && mv sorted-config $CONFIG_FILE
+
+# Show result
+echo "Configured roles:"
+echo "-----------------"
+cat $CONFIG_FILE

--- a/bin/github-actions-role-to-assume.sh
+++ b/bin/github-actions-role-to-assume.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Print the IAM role that GitHub Actions needs to assume for the associated
+# application environment. This is used by GitHub Actions workflows.
+#
+# An alternative approach would be to leverage GitHub Environments variables,
+# but not all projects have access to GitHub environments.
+#
+# Positional parameters:
+#   APP_NAME (required) – the name of subdirectory of /infra that holds the
+#     application's infrastructure code.
+#   ENVIRONMENT is the name of the application environment (e.g. dev, staging, prod)
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+APP_NAME="$1"
+ENVIRONMENT="$2"
+
+# This file defines variables for each environment e.g.
+#   dev=...
+#   prod=...
+# where the value of each variable is an IAM role ARN
+source infra/$APP_NAME/app-config/github-actions-role-to-assume.ini
+
+# Evaluate the variable with the name given by $ENVIRONMENT.
+# So if $ENVIRONMENT = "dev", then let ROLE_TO_ASSUME_ARN=$dev
+ROLE_ARN=${!ENVIRONMENT:-}
+
+if [ -z $ROLE_ARN ]; then
+  echo "No role defined for environment: $ENVIRONMENT" >&2
+  exit 1
+fi
+
+echo -n $ROLE_ARN

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -17,6 +17,8 @@ $SCRIPT_DIR/install-template.sh
 echo "Restore modified project files"
 git checkout HEAD -- \
   .dockleconfig \
+  .github/workflows/cd.yml \
+  .github/workflows/ci-infra.yml \
   .grype.yml \
   .hadolint.yaml \
   .trivyignore \

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -17,9 +17,6 @@ $SCRIPT_DIR/install-template.sh
 echo "Restore modified project files"
 git checkout HEAD -- \
   .dockleconfig \
-  .github/workflows/build-and-publish.yml \
-  .github/workflows/cd.yml \
-  .github/workflows/ci-infra.yml \
   .grype.yml \
   .hadolint.yaml \
   .trivyignore \


### PR DESCRIPTION
## Ticket

Work for https://github.com/navapbc/template-infra/issues/314

## Changes
* Move role-to-assume to separate config file:
   infra/app/app-config/github-actions-role-to-assume.ini
* Add script bin/github-actions-role-to-assume.sh to fetch values from the config file
* Add script bin/configure-github-actions-role-to-assume.sh to update config file
* Update config file as part of app-build-repository and app-service configuration

Template changes
* Remove build-and-publish.yml and database-migrations.yml from the ignore list in update-template.sh
* Remove obsolete instructions for updating role-to-assume in GitHub workflow files

## Context
Whenever we have a GitHub workflow that needs to access AWS resources (e.g. through terraform), we need to have a "Configure AWS credentials" using aws-actions/configure-aws-credentials and pass in the IAM role that the GitHub Actions runner should assume. Currently this role is hardcoded directly into the workflow files themselves and updated manually by each project according to [these instructions](https://github.com/navapbc/template-infra/blob/main/template-only-docs/set-up-ci.md#after-setting-up-the-aws-account):

> After setting up the AWS account update the role-to-assume with the GitHub actions ARN by searching for !! in the following files:
>
> build-and-publish.yml
> cd.yml
> ci-infra.yml

The consequence of this is that the role ARN is duplicated across workflows, which creates more manual work when adding new workflows.

Furthermore, it means that the [template-infra update-template.sh script](https://github.com/navapbc/template-infra/blob/main/template-only-bin/update-template.sh) does not update these workflow files in order to avoid overwriting the manual updates made by projects.

These changes move the definition of the role-to-assume to a config file: infra/app/app-config/github-actions-role-to-assume.ini and automatically configures the roles as a part of the existing infra configuration steps.

Unfortunately we still need to leave cd.yml and ci-infra.yml in the list of files that don't get updated as part of update-template.sh since those files have sections that are commented out in the template.

## Testing
I developed and tested the changes in the platform-test repo in this PR: https://github.com/navapbc/platform-test/pull/16

I copied the test plan and results below:

- [x] Run make infra-configure-app-build-repository
   <img width="619" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/61de8847-aef0-4b6a-bad3-c0ee6d653e71">

- [x] Run make infra-configure-app-service
   <img width="664" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/d05b18e7-960a-49bd-b1bd-6b06d46ba800">

- [X] Run build-and-publish.yml from this branch
   https://github.com/navapbc/platform-test/actions/runs/5283405667

- [X] Run ci-infra.yml from this branch (this will happen automatically as part of CI)
- [X] Run cd.yml from this branch
   https://github.com/navapbc/platform-test/actions/runs/5283754174