### PR TITLE
Remove unnecessary env vars from run-database-migrations script

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -47,23 +47,13 @@ echo
 echo 'Step 2. Run "db-migrate" command'
 
 ./bin/terraform-init.sh infra/$APP_NAME/database $ENVIRONMENT
-DB_HOST=$(terraform -chdir=infra/$APP_NAME/database output -raw database_host)
-DB_PORT=$(terraform -chdir=infra/$APP_NAME/database output -raw database_port)
 DB_MIGRATOR_USER=$(terraform -chdir=infra/$APP_NAME/database output -raw migrator_username)
-DB_NAME=$(terraform -chdir=infra/$APP_NAME/database output -raw database_name)
-DB_SCHEMA=$(terraform -chdir=infra/$APP_NAME/database output -raw schema_name)
 
 COMMAND='["db-migrate"]'
 
 # Indent the later lines more to make the output of run-command prettier
 ENVIRONMENT_VARIABLES=$(cat << EOF
-[
-        { "name" : "DB_HOST", "value" : "$DB_HOST" },
-        { "name" : "DB_PORT", "value" : "$DB_PORT" },
-        { "name" : "DB_USER", "value" : "$DB_MIGRATOR_USER" },
-        { "name" : "DB_NAME", "value" : "$DB_NAME" },
-        { "name" : "DB_SCHEMA", "value" : "$DB_SCHEMA" }
-      ]
+[{ "name" : "DB_USER", "value" : "$DB_MIGRATOR_USER" }]
 EOF
 )
 


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
Most of the env vars in run-database-migrations.sh are already defined in the container task definition. The only one that needs to be overwritten is DB_USER, which should be set the user to the migrator user rather than the app user.

## Testing
Ran migrations script locally on the platform-test repo after making these changes in this PR: https://github.com/navapbc/platform-test/pull/18

Here are the logs from the migration run:
<img width="1006" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/7f856009-a703-4193-a844-070f68e37490">

