### PR TITLE
Fix deploys when triggered from pushes to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,8 @@ on:
           - prod
 
 env:
+  # Need to set a default value for when the workflow is triggered from a git push,
+  # which bypasses the default configuration for inputs
   ENVIRONMENT: ${{ inputs.environment || 'dev' }}
 
 # Need to repeat the expression since env.ENV_NAME is not accessible in this context
@@ -34,7 +36,7 @@ jobs:
     name: Database migrations
     uses: ./.github/workflows/database-migrations.yml
     with:
-      environment: ${{ inputs.environment }}
+      environment: ${{ env.ENVIRONMENT }}
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -1,13 +1,6 @@
 name: Database migrations
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'app/**'
-      - 'bin/**'
-      - 'infra/**'
   workflow_call:
     inputs:
       app_name:


### PR DESCRIPTION
## Ticket

n/a

## Changes
* Add comment explaining why we need extra default value for deploy target tenvironment
* Use correct variable for deploy target environment
* Don't automatically run db migrations on pushes

## Context for reviewers
I broke CD. The deploy workflow works when you run it manually but it doesn't work anymore when triggered from a push to `main`, since the `environment` variable isn't properly set. This change fixes that and also adds a comment explaining why we need to use `env.ENVIRONMENT` instead of `inputs.environments` in the case where the workflow is triggered from a git push.

This change also removes automatically running database migrations on merges to main, since they are already run automatically as part of CD.

## Testing
Already made the changes directly in platform-test/platform-test-nextjs/platform-test-flask repos (I would need to make those changes manually anyways since those don't propagate due to update-template.sh not updating cd.yml and database-migrations.yml). Here are the successful runs from those pushes:

* platform-test run: https://github.com/navapbc/platform-test/actions/runs/5295174067
* platform-test-nextjs run: https://github.com/navapbc/platform-test-nextjs/actions/runs/5295175960
* platform-test-flask run: https://github.com/navapbc/platform-test-flask/actions/runs/5295175506

You'll see that it no longer errors on the database migrations job.

