### PR TITLE
Create schema and roles in correct database

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -287,6 +287,7 @@ resource "aws_lambda_function" "role_manager" {
       DB_HOST                = aws_rds_cluster.db.endpoint
       DB_PORT                = aws_rds_cluster.db.port
       DB_USER                = local.master_username
+      DB_NAME                = aws_rds_cluster.db.database_name
       DB_PASSWORD_PARAM_NAME = aws_ssm_parameter.random_db_password.name
       SCHEMA_NAME            = local.schema_name
       APP_USER               = local.app_username

--- a/infra/modules/database/role_manager/role_manager.py
+++ b/infra/modules/database/role_manager/role_manager.py
@@ -41,18 +41,19 @@ def lambda_handler(event, context):
     }
 
 def connect() -> Connection:
-    user = os.environ.get("DB_USER")
-    host = os.environ.get("DB_HOST")
-    port = os.environ.get("DB_PORT")
+    user = os.environ["DB_USER"]
+    host = os.environ["DB_HOST"]
+    port = os.environ["DB_PORT"]
+    database = os.environ["DB_NAME"]
     password = get_password()
 
-    logger.info("Connecting to database: user=%s host=%s port=%s", user, host, port)
-    return Connection(user=user, host=host, port=port, password=password)
+    logger.info("Connecting to database: user=%s host=%s port=%s database=%s", user, host, port, database)
+    return Connection(user=user, host=host, port=port, database=database, password=password)
 
 
 def get_password() -> str:
     ssm = boto3.client("ssm")
-    param_name = os.environ.get("DB_PASSWORD_PARAM_NAME")
+    param_name = os.environ["DB_PASSWORD_PARAM_NAME"]
     logger.info("Fetching password from parameter store")
     result = ssm.get_parameter(
         Name=param_name,


### PR DESCRIPTION
## Ticket

Resolves #326 

## Changes
* Connect to app database rather than postgres database when creating schema and roles

## Context for reviewers
We were getting a migration error when running the flask template migrations with the template infrastructure. The migration error says
> sqlalchemy.exc.ProgrammingError: (psycopg2.errors.InvalidSchemaName) no schema has been selected to create in

It turns out that the role_manager that created the schema and roles created them in the wrong database, so when the application migrations task connected to the correct database and tried to run migrations, the schema it was expecting to exist didn't actually exist.

This change fixes this by connecting the role manager to the correct database. It also changes the way the role manager accesses environment variables to fail immediately if any environment variable is missing.

As a side note, the reason why we did not see the same failure on the platform-test repo was because the way the example app's db-migrate script connected to the database didn't restrict the postgres search_path to app, so the creation of the table still worked because the script still had access to the `public` schema. Once we implement this ticket https://github.com/navapbc/template-infra/issues/300 to lock down the `public` schema that would no longer be an issue.

## Testing
I developed and tested this on the platform-test-flask repo in this PR: https://github.com/navapbc/platform-test-flask/pull/2

I copied the test plan and results below:

----

I updated the role manager lambda function by running `make infra-update-app-database APP_NAME=app ENVIRONMENT=dev`, then I re-ran the role manager lambda function with `make infra-update-app-database-roles APP_NAME=app ENVIRONMENT=dev` which should have created the schema/roles in the correct datagbase, then I re-ran migrations with `make release-run-database-migrations APP_NAME=app ENVIRONMENT=dev`

Here are the cloudwatch logs from the successful run:
<img width="1614" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/f10f27ef-ca53-4967-b669-973c908dec45">
