### PR TITLE
Specify search_path during example app migrations

### DIFF
--- a/app/db-migrate
+++ b/app/db-migrate
@@ -7,6 +7,7 @@ psql \
   --port=$DB_PORT \
   --username=$DB_USER \
   --dbname=$DB_NAME \
-  --variable=ON_ERROR_STOP=1 \
+  --set=SEARCH_PATH=$DB_SCHEMA \
+  --set=ON_ERROR_STOP=1 \
   --echo-all \
   --file=migrations.sql

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -289,7 +289,7 @@ resource "aws_lambda_function" "role_manager" {
       DB_USER                = local.master_username
       DB_NAME                = aws_rds_cluster.db.database_name
       DB_PASSWORD_PARAM_NAME = aws_ssm_parameter.random_db_password.name
-      SCHEMA_NAME            = local.schema_name
+      DB_SCHEMA              = local.schema_name
       APP_USER               = local.app_username
       MIGRATOR_USER          = local.migrator_username
       PYTHONPATH             = "vendor"

--- a/infra/modules/database/role_manager/role_manager.py
+++ b/infra/modules/database/role_manager/role_manager.py
@@ -96,7 +96,7 @@ def configure_database(conn: Connection) -> None:
     logger.info("Configuring database")
     app_username = os.environ.get("APP_USER")
     migrator_username = os.environ.get("MIGRATOR_USER")
-    schema_name = os.environ.get("SCHEMA_NAME")
+    schema_name = os.environ.get("DB_SCHEMA")
 
     configure_roles(conn, [migrator_username, app_username])
     configure_schema(conn, schema_name, migrator_username, app_username)


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
PR #327 fixed an issue that wasn't detected on the platform-test repo since platform-test didn't specify the search path when logging in to the database, so the migrations table still created successfully on the `public` schema.

This change specifies the search path to restrict table creations to the app schema as specified by the DB_SCHEMA environment variable

## Testing
developed and testing the change on the platform-test repo by running the Deploy workflow directly from the feature branch: see PR https://github.com/navapbc/platform-test/pull/21


Ran deploy manually from the branch on platform-test