### PR TITLE
Add branch and environment to deploy run name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,10 @@
 name: Deploy
-run-name: Deploy ${{ github.ref_name }} to ${{ env.ENVIRONMENT }}
+# Need to set a default value for when the workflow is triggered from a git push,
+# which bypasses the default configuration for inputs and cannot use env.ENVIRONMENT
+# since env context is not accessible in this context
+run-name: Deploy ${{ github.ref_name }} to ${{ inputs.environment || 'dev' }}
+
+concurrency: cd-${{ inputs.environment || 'dev' }}
 
 on:
   # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
@@ -27,7 +32,7 @@ env:
   # which bypasses the default configuration for inputs
   ENVIRONMENT: ${{ inputs.environment || 'dev' }}
 
-# Need to repeat the expression since env.ENV_NAME is not accessible in this context
+# Need to repeat the expression since env.ENVIRONMENT is not accessible in this context
 concurrency: cd-${{ inputs.environment || 'dev' }}
 
 jobs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,5 @@
 name: Deploy
+run-name: Deploy ${{ github.ref_name }} to ${{ env.ENVIRONMENT }}
 
 on:
   # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,8 +4,6 @@ name: Deploy
 # since env context is not accessible in this context
 run-name: Deploy ${{ github.ref_name }} to ${{ inputs.environment || 'dev' }}
 
-concurrency: cd-${{ inputs.environment || 'dev' }}
-
 on:
   # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
   # push:


### PR DESCRIPTION
## Ticket

Resolves #317 

## Changes
see title

## Context for reviewers
A lot of times for development and testing we need to manually trigger deploys so I thought this would be good to do sooner than later to improve the developer experience of working on the platform.

## Testing
To test this I just manually triggered the deploy script directly on this template repo since I don't really care if the deploy itself succeeds. Just trying to see if the name is rendered properly, not changing anything else about the workflow.

Here's the manual run I triggered: https://github.com/navapbc/template-infra/actions/runs/5351170243
<img width="1425" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/e7a0e6fe-7212-439b-b297-f5ff7863d239">

