### PR TITLE
Get github oidc thumbprint from last certificate

### DIFF
--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -31,7 +31,8 @@ data "tls_certificate" "github" {
 }
 
 locals {
-  oidc_thumbprint_github = data.tls_certificate.github.certificates.0.sha1_fingerprint
+  github_certificates    = data.tls_certificate.github.certificates
+  oidc_thumbprint_github = local.github_certificates[length(local.github_certificates) - 1].sha1_fingerprint
 }
 
 # Set up assume role policy for GitHub Actions to allow GitHub actions


### PR DESCRIPTION
## Ticket

Resolves #338 

## Changes
see title

## Context for reviewers
Recently some workflows started failing with an error:

> Error: OpenIDConnect provider's HTTPS certificate doesn't match configured thumbprint

(e.g. [this run](https://github.com/navapbc/platform-test-nextjs/actions/runs/5404401054/jobs/9818514745))
<img width="822" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/22955001-0a00-4605-aaf5-453292c07823">

Based on Amazon's docs – https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html – the OIDC provider thumbprint should be obtained from the last certificate in the chain, not the first one. Here's the relevant excerpt:

> If you see more than one certificate, find the last certificate displayed (at the end of the command output). This contains the certificate of the top intermediate CA in the certificate authority chain.

## Testing
I made the change on platform-test-nextjs repo and ran `make infra-update-current-account`, then re-ran one of the failed jobs and see that it now succeeds: https://github.com/navapbc/platform-test-nextjs/actions/runs/5404489757