### PR TITLE
Fix Trivy scan format

### DIFF
--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -63,17 +63,19 @@ jobs:
         with:
           scan-type: image
           image-ref: ${{ steps.build-image.outputs.image }}
-          format: table
+          format: json
           exit-code: 1
           ignore-unfixed: true
           vuln-type: os
           scanners: vuln,secret
-          output: trivy_results.txt
+          output: trivy_results.json
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          cat trivy_results.txt >> $GITHUB_STEP_SUMMARY
+          echo "```json" >> $GITHUB_STEP_SUMMARY
+          cat trivy_results.json >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
 
   anchore-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Ticket

{LINK TO TICKET}

## Changes

- Changed from `table` to `json` format on the Trivy scan

## Context for reviewers

After the change to display findings in the summary page, the [template NextJS repo](https://github.com/navapbc/platform-test-nextjs/actions/runs/5404489689) is failing, and it looks to be because of how the Trivy scan is formatting its findings. The `table` format is 2.1MB, so it can't be displayed in the summary, and fails because of that. Upon pulling that file up, there is a single row in the table, and is extremely long to where it isn't very legible. 

I tested all of the format options, and here is what I saw

- `table` -> File is too large and fails because of this, but locally has findings
- `json` -> Has findings, file size is 4.6KB, output is JSON, findings are in `Results` row of object
- `github` -> Has findings, file size is 4.6KB, output is JSON, but the findings are not there
  - I dug into the entire JSON object, and I didn't see the error from the `json` format anywhere
- `sarif` -> Has no findings, and shouldn't be used since the above options have findings

## Testing

Ran the tests in the template NextJS repo locally to see. You can do the same by installing `act` and running `act -j trivy-scan`
