### PR TITLE
Disable alibaba secret scanning

### DIFF
--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -63,19 +63,16 @@ jobs:
         with:
           scan-type: image
           image-ref: ${{ steps.build-image.outputs.image }}
-          format: json
+          format: table
           exit-code: 1
           ignore-unfixed: true
           vuln-type: os
           scanners: vuln,secret
-          output: trivy_results.json
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          echo "```json" >> $GITHUB_STEP_SUMMARY
-          cat trivy_results.json >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "View results in GitHub Action logs" >> $GITHUB_STEP_SUMMARY
 
   anchore-scan:
     runs-on: ubuntu-latest
@@ -100,7 +97,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          echo "Click on the anchore-scan job in the top left Jobs section to view the results" >> $GITHUB_STEP_SUMMARY
+          echo "View results in GitHub Action logs" >> $GITHUB_STEP_SUMMARY
 
   dockle-scan:
     runs-on: ubuntu-latest

--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,5 +1,21 @@
-# Truvy recommends specifying either enable-builin-rules or disable-rules
+# Trivy recommends specifying either enable-builin-rules or disable-rules
 # See https://aquasecurity.github.io/trivy/v0.27.1/docs/secret/configuration/
-disable-rules:
-  - alibaba-access-key-id
-  - alibaba-secret-key
+# For list of all available rules, see
+# https://github.com/aquasecurity/fanal/blob/main/secret/builtin-rules.go
+enable-builtin-rules:
+  - aws-access-key-id
+  - aws-account-id
+  - aws-secret-access-key
+  - github-pat
+  - github-oauth
+  - github-app-token
+  - github-refresh-token
+  - gitlab-pat
+  - private-key
+  - slack-access-token
+  - slack-web-hook
+  - atlassian-api-token
+  - hashicorp-tf-api-token
+  - new-relic-user-api-key
+  - new-relic-user-api-id
+  - new-relic-browser-api-token

--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,3 +1,5 @@
+# Truvy recommends specifying either enable-builin-rules or disable-rules
+# See https://aquasecurity.github.io/trivy/v0.27.1/docs/secret/configuration/
 disable-rules:
   - alibaba-access-key-id
   - alibaba-secret-key

--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,0 +1,3 @@
+disable-rules:
+  - alibaba-access-key-id
+  - alibaba-secret-key


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-application-nextjs/issues/165

## Changes
* Disable alibaba secret scanning
* Output trivy scans to table format

## Context for reviewers
Vulnerability scans were failing for platform-test-nextjs.

First, I needed to output not to a file since the runs weren't showing any output. See https://github.com/navapbc/platform-test-nextjs/actions/runs/5418384398

So I made the logs output to stdout instead of to a file. And I changed back to table format which is better than JSON.

It turns out the reason for the failure was a false positive scan for alibaba secret.

<img width="1440" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/02cde2fa-569d-4cb0-952c-0ff389c6bc27">

Since I don't see any situation where our project would be using alibaba I figure we should disable it. Trivy recommends specifying either enable rules or disable rules: https://aquasecurity.github.io/trivy/v0.27.1/docs/secret/configuration/#disable-rules

Thinking about it, I think we should just focus on the secrets that are likely to be relevant to projects and leave out all the rest like facebook, linkedin, etc that are a waste of time to scan for. Projects can always add more if they need to. So this change adds an enable list.

## Testing
I made the change in platform-test-nextjs where the false positive was showing up: see https://github.com/navapbc/platform-test-nextjs/pull/77

The trivy scan now passes:
<img width="1011" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/e7a663fb-edcd-4a09-a7cb-700d85735158">

Fixing Anchor scan is out of scope of this PR, that's an application fix which should be in a template-application-nextjs