### PR TITLE
Remove GitHub OIDC TLS certificate thumbprint

### DIFF
--- a/docs/decisions/infra/0002-use-custom-implementation-of-github-oidc.md
+++ b/docs/decisions/infra/0002-use-custom-implementation-of-github-oidc.md
@@ -2,7 +2,7 @@
 
 * Status: accepted
 * Deciders: @shawnvanderjagt @lorenyu @NavaTim
-* Date: 2022-10-05
+* Date: 2022-10-05 (Updated 2023-07-12)
 
 ## Context and Problem Statement
 
@@ -24,7 +24,7 @@
 
 We chose to use a custom implementation because it allowed for the simplest implementation that was easiest to understand while still being in our full control and therefore avoids security issues with external dependencies. It is also easy to upgrade to use the external module if circumstances change.
 
-## Pros and Cons of the Options <!-- optional -->
+## Pros and Cons of the Options
 
 The [unfunco/oidc-github](https://registry.terraform.io/modules/unfunco/oidc-github/aws/latest) module from Terraform registry is effectively what we need, but there are a few disadvantages to using it:
 
@@ -33,16 +33,6 @@ Cons of unfunco/oidc-github:
 * Dependency on an external module in the Terraform registry has negative security implications. Furthermore, the module isn't published by an "official" organization. It is maintained by a single developer, further increasing the security risk.
 * The module includes extra unnecessary options that make the code more difficult to read and understand
 * In particular, the module includes the option to attach the `AdminstratorAccess` policy to the GitHub actions IAM role, which isn't necessary and could raise concerns in an audit.
-* The module hardcodes the GitHub OIDC Provider thumbprint, which isn't as elegant as the method in the [Initial setup for CD draft PR #43](https://github.com/navapbc/template-infra/pull/43) from @shawnvanderjagt which simply pulls the thumbprint via:
-
-    ```terraform
-    data "tls_certificate" "github" {
-    url = "https://token.actions.githubusercontent.com"
-    }
-
-    locals {
-    oidc_thumbprint_github = data.tls_certificate.github.certificates.0.sha1_fingerprint
-    }
-    ```
+* ~~The module hardcodes the GitHub OIDC Provider thumbprint, which isn't as elegant as the method in the [Initial setup for CD draft PR #43](https://github.com/navapbc/template-infra/pull/43) from @shawnvanderjagt which simply pulls the thumbprint via:~~ (Update: July 12, 2023) Starting July 6, 2023, AWS began securing communication with GitHub’s OIDC identity provider (IdP) using GitHub's library of trusted root Certificate Authorities instead of using a certificate thumbprint to verify the IdP’s server certificate. This approach ensures that the GitHub OIDC configuration behaves correctly without disruption during future certificate rotations and changes. With this new validation approach in place, your legacy thumbprint(s) are longer be needed for validation purposes.
 
 Forking the module to the navapbc organization gets rid of the security issue, but the other issues remain.

--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -7,6 +7,8 @@ resource "aws_iam_openid_connect_provider" "github" {
   # so no thumbprints from intermediate certificates are needed
   # At the time of writing (July 12, 2023), the thumbprint_list parameter
   # is required to be a non-empty array, so we are passing an array with a dummy string that passes validation
+  # TODO(https://github.com/navapbc/template-infra/issues/350) Remove this parameter thumbprint_list is no
+  # longer required (see https://github.com/hashicorp/terraform-provider-aws/issues/32480)
   thumbprint_list = ["0000000000000000000000000000000000000000"]
 }
 

--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -1,8 +1,7 @@
 # Set up GitHub's OpenID Connect provider in AWS account
 resource "aws_iam_openid_connect_provider" "github" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [local.oidc_thumbprint_github]
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
 }
 
 # Create IAM role for GitHub Actions
@@ -21,18 +20,6 @@ resource "aws_iam_role_policy_attachment" "custom" {
 
   role       = aws_iam_role.github_actions.name
   policy_arn = var.iam_role_policy_arns[count.index]
-}
-
-# Get GitHub's OIDC provider's thumbprint
-# See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
-
-data "tls_certificate" "github" {
-  url = "https://token.actions.githubusercontent.com"
-}
-
-locals {
-  github_certificates    = data.tls_certificate.github.certificates
-  oidc_thumbprint_github = local.github_certificates[length(local.github_certificates) - 1].sha1_fingerprint
 }
 
 # Set up assume role policy for GitHub Actions to allow GitHub actions

--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -6,8 +6,8 @@ resource "aws_iam_openid_connect_provider" "github" {
   # AWS already trusts the GitHub OIDC identity provider's library of root certificate authorities
   # so no thumbprints from intermediate certificates are needed
   # At the time of writing (July 12, 2023), the thumbprint_list parameter
-  # is required to be a non-empty array, so we are passign an array with an empty string
-  thumbprint_list = [""]
+  # is required to be a non-empty array, so we are passing an array with a dummy string that passes validation
+  thumbprint_list = ["0000000000000000000000000000000000000000"]
 }
 
 # Create IAM role for GitHub Actions

--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -2,6 +2,10 @@
 resource "aws_iam_openid_connect_provider" "github" {
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
+
+  # AWS already trusts the GitHub OIDC identity provider's library of root certificate authorities
+  # so no thumbprints from intermediate certificates are needed
+  thumbprint_list = []
 }
 
 # Create IAM role for GitHub Actions

--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -5,7 +5,9 @@ resource "aws_iam_openid_connect_provider" "github" {
 
   # AWS already trusts the GitHub OIDC identity provider's library of root certificate authorities
   # so no thumbprints from intermediate certificates are needed
-  thumbprint_list = []
+  # At the time of writing (July 12, 2023), the thumbprint_list parameter
+  # is required to be a non-empty array, so we are passign an array with an empty string
+  thumbprint_list = [""]
 }
 
 # Create IAM role for GitHub Actions


### PR DESCRIPTION
## Ticket

Resolves #348 

## Changes
see title

## Context

On July 11, 2023, we received an IAM security notification that explains that the GitHub OIDC identity provider's TLS intermediate certificate thumbprint(s) no longer need to be specified in AWS OIDC configuration since GitHub's root certificate is now trusted by AWS. Here is the relevant excerpt:

> Starting July 6, 2023, AWS began securing communication with GitHub’s OIDC identity provider (IdP) using our library of trusted root Certificate Authorities instead of using a certificate thumbprint to verify the IdP’s server certificate. This approach ensures that your GitHub OIDC configuration behaves correctly without disruption during future certificate rotations and changes. With this new validation approach in place, your legacy thumbprint(s) will remain in your configuration but will no longer be needed for validation purposes.


## Testing
this change should be covered by CI