### PR TITLE
Fix db migrations script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ release-build:
 release-publish:
 	./bin/publish-release.sh $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG)
 
-release-run-database-migrations:
+release-run-database-migrations: ## Run database migrations
 	./bin/run-database-migrations.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
 
 release-deploy:

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -36,6 +36,8 @@ if [ $HAS_DATABASE = "false" ]; then
   exit 0
 fi
 
+DB_MIGRATOR_USER=$(terraform -chdir=infra/$APP_NAME/app-config output -json environment_configs | jq -r ".dev.database_config.migrator_username")
+
 echo
 echo "Step 1. Update task definition without updating service"
 
@@ -45,9 +47,6 @@ TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_tas
 
 echo
 echo 'Step 2. Run "db-migrate" command'
-
-./bin/terraform-init.sh infra/$APP_NAME/database $ENVIRONMENT
-DB_MIGRATOR_USER=$(terraform -chdir=infra/$APP_NAME/database output -raw migrator_username)
 
 COMMAND='["db-migrate"]'
 

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -36,7 +36,7 @@ if [ $HAS_DATABASE = "false" ]; then
   exit 0
 fi
 
-DB_MIGRATOR_USER=$(terraform -chdir=infra/$APP_NAME/app-config output -json environment_configs | jq -r ".dev.database_config.migrator_username")
+DB_MIGRATOR_USER=$(terraform -chdir=infra/$APP_NAME/app-config output -json environment_configs | jq -r ".$ENVIRONMENT.database_config.migrator_username")
 
 echo
 echo "Step 1. Update task definition without updating service"


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
I accidentally broke db migrations (see failed run: https://github.com/navapbc/platform-test/actions/runs/5580152070)

It's because I missed the one reference to the database layer output that I deleted in #355 

This change makes the db migrations script get the migrator user from the db config rather than from the db layer output which no longer exists.

## Testing
I tested this out on platform-test repo after making the changes I ran `make release-run-database-migrations APP_NAME=app ENVIRONMENT=dev`, and here are the logs showing the successful migration

<img width="1616" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/a2e32975-50af-4f06-a716-fb4862893a28">
