### PR TITLE
Remove workaround for aws_s3_bucket_logging race condition

### DIFF
--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     paths:
+      - bin/**
       - template-only-infra/**
       - infra/modules/**
       - template-only-test/**

--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -79,35 +79,9 @@ terraform init \
 # Import the S3 bucket that was created in the previous step so we don't recreate it
 terraform import module.backend.aws_s3_bucket.tf_state $TF_STATE_BUCKET_NAME
 
-
-# Wrap terraform apply in a retry loop.
-#
-# This is a workaround to a race condition that seems to have been recently introduced
-# by AWS S3 and at the time of writing (2023-05-09) has yet to be resolved.
-# See https://github.com/hashicorp/terraform-provider-aws/issues/31139 for more details
-# about the issue.
-# There is an outstanding PR in the Terraform AWS provider created on Apr 24, 2023 that
-# may resolve this issue: https://github.com/hashicorp/terraform-provider-aws/pull/30916
-#
-# Once the issue is resolved, this retry loop can be removed and we can run terraform apply
-# directly.
-MAX_RETRIES=5
-
-# Define the command to execute
-COMMAND="terraform apply \
+terraform apply \
   -input=false \
-  -auto-approve"
-
-# Loop until the command succeeds or the maximum number of retries is reached
-for i in $(seq 1 $MAX_RETRIES); do
-  if $COMMAND; then
-    break
-  else
-    echo "Terraform apply failed. Sleeping and retrying..."
-    sleep 3
-  fi
-done
-
+  -auto-approve
 
 cd -
 

--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.20.1"
+      version = "~>5.6.0"
     }
   }
 


### PR DESCRIPTION
## Ticket

Resolves #259 

## Changes

* Upgrade AWS provider version for infra/accounts to 5.6.0
* Remove retry loop workaround

## Context

A fix for a race condition in the Terraform AWS provider has been merged. The fix was in this PR: https://github.com/hashicorp/terraform-provider-aws/pull/30916 and was released as part of AWS provider version 5.6.0.

## Testing

