### PR TITLE
Add maybe missing database outputs

### DIFF
--- a/docs/infra/set-up-database.md
+++ b/docs/infra/set-up-database.md
@@ -28,7 +28,7 @@ make infra-configure-app-database APP_NAME=app ENVIRONMENT=<ENVIRONMENT>
 
 ## 2. Create database resources
 
-Now run the following commands to create the resources. Review the terraform before confirming "yes" to apply the changes.
+Now run the following commands to create the resources. Review the terraform before confirming "yes" to apply the changes. This can take over 5 minutes.
 
 ```bash
 make infra-update-app-database APP_NAME=app ENVIRONMENT=<ENVIRONMENT>

--- a/infra/app/database/outputs.tf
+++ b/infra/app/database/outputs.tf
@@ -1,0 +1,3 @@
+output "role_manager_function_name" {
+  value = module.database.role_manager_function_name
+}

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -304,10 +304,6 @@ resource "aws_lambda_function" "role_manager" {
   # checkov:skip=CKV_AWS_116:Dead letter queue (DLQ) configuration is only relevant for asynchronous invocations
 }
 
-output "role_manager_function_name" {
-  value = aws_lambda_function.role_manager.function_name
-}
-
 # Installs python packages needed by the role manager lambda function before
 # creating the zip archive. Reinstalls whenever requirements.txt changes
 resource "terraform_data" "role_manager_python_vendor_packages" {

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -304,6 +304,10 @@ resource "aws_lambda_function" "role_manager" {
   # checkov:skip=CKV_AWS_116:Dead letter queue (DLQ) configuration is only relevant for asynchronous invocations
 }
 
+output "role_manager_function_name" {
+  value = aws_lambda_function.role_manager.function_name
+}
+
 # Installs python packages needed by the role manager lambda function before
 # creating the zip archive. Reinstalls whenever requirements.txt changes
 resource "terraform_data" "role_manager_python_vendor_packages" {

--- a/infra/modules/database/outputs.tf
+++ b/infra/modules/database/outputs.tf
@@ -1,0 +1,3 @@
+output "role_manager_function_name" {
+  value = aws_lambda_function.role_manager.function_name
+}


### PR DESCRIPTION
## Context for reviewers

I think this output was missing? Not super familiar with Terraform. 

## Testing

When I was following the instructions to setup the DB, I ran into a warning about no outputs when I ran `make infra-update-app-database-roles APP_NAME=app ENVIRONMENT=<ENVIRONMENT>`

The make script internally runs `terraform -chdir=infra/$APP_NAME/database output -raw role_manager_function_name`.

Before this change:

<img width="1831" alt="CleanShot 2023-08-04 at 15 28 56@2x" src="https://github.com/navapbc/template-infra/assets/371943/657d91bf-ad88-42b8-8b47-1b9a8555aa92">

After this change:

<img width="996" alt="CleanShot 2023-08-04 at 15 29 14@2x" src="https://github.com/navapbc/template-infra/assets/371943/061c3442-99e0-48e0-88dd-16cb4fa2f815">
