### PR TITLE
fix: remove attribute causing alerts breach when there is not data

### DIFF
--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -21,7 +21,6 @@ resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
   alarm_description         = "High HTTP service 5XX error count"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
-  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -40,7 +39,6 @@ resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
   alarm_description         = "High HTTP ELB 5XX error count"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
-  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -59,7 +57,6 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
   alarm_description         = "High target latency alert"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
-  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -10,18 +10,18 @@ resource "aws_sns_topic" "this" {
 # Create CloudWatch alarms for the service
 
 resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
-  alarm_name                = "${var.service_name}-high-app-5xx-count"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = 5
-  metric_name               = "HTTPCode_Target_5XX_Count"
-  namespace                 = "AWS/ApplicationELB"
-  period                    = 60
-  statistic                 = "Sum"
-  threshold                 = 1
-  alarm_description         = "High HTTP service 5XX error count"
-  treat_missing_data        = "notBreaching"
-  alarm_actions             = [aws_sns_topic.this.arn]
-  ok_actions                = [aws_sns_topic.this.arn]
+  alarm_name          = "${var.service_name}-high-app-5xx-count"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "High HTTP service 5XX error count"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.this.arn]
+  ok_actions          = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -29,18 +29,18 @@ resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
-  alarm_name                = "${var.service_name}-high-load-balancer-5xx-count"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = 5
-  metric_name               = "HTTPCode_ELB_5XX_Count"
-  namespace                 = "AWS/ApplicationELB"
-  period                    = 60
-  statistic                 = "Sum"
-  threshold                 = 1
-  alarm_description         = "High HTTP ELB 5XX error count"
-  treat_missing_data        = "notBreaching"
-  alarm_actions             = [aws_sns_topic.this.arn]
-  ok_actions                = [aws_sns_topic.this.arn]
+  alarm_name          = "${var.service_name}-high-load-balancer-5xx-count"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "High HTTP ELB 5XX error count"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.this.arn]
+  ok_actions          = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -22,7 +22,6 @@ resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
   treat_missing_data        = "notBreaching"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
-  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -42,7 +41,6 @@ resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
   treat_missing_data        = "notBreaching"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
-  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
   statistic                 = "Sum"
   threshold                 = 1
   alarm_description         = "High HTTP service 5XX error count"
-  treat_missing_data        = notBreaching
+  treat_missing_data        = "notBreaching"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
   insufficient_data_actions = [aws_sns_topic.this.arn]
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
   statistic                 = "Sum"
   threshold                 = 1
   alarm_description         = "High HTTP ELB 5XX error count"
-  treat_missing_data        = notBreaching
+  treat_missing_data        = "notBreaching"
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
   insufficient_data_actions = [aws_sns_topic.this.arn]

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -22,7 +22,6 @@ resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
   insufficient_data_actions = [aws_sns_topic.this.arn]
-  treat_missing_data        = "breaching"
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -42,7 +41,6 @@ resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
   insufficient_data_actions = [aws_sns_topic.this.arn]
-  treat_missing_data        = "breaching"
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -19,8 +19,10 @@ resource "aws_cloudwatch_metric_alarm" "high_app_http_5xx_count" {
   statistic                 = "Sum"
   threshold                 = 1
   alarm_description         = "High HTTP service 5XX error count"
+  treat_missing_data        = notBreaching
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
+  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -37,8 +39,10 @@ resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
   statistic                 = "Sum"
   threshold                 = 1
   alarm_description         = "High HTTP ELB 5XX error count"
+  treat_missing_data        = notBreaching
   alarm_actions             = [aws_sns_topic.this.arn]
   ok_actions                = [aws_sns_topic.this.arn]
+  insufficient_data_actions = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -46,17 +50,17 @@ resource "aws_cloudwatch_metric_alarm" "high_load_balancer_http_5xx_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
-  alarm_name                = "${var.service_name}-high-app-response-time"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = 5
-  metric_name               = "TargetResponseTime"
-  namespace                 = "AWS/ApplicationELB"
-  period                    = 60
-  statistic                 = "Average"
-  threshold                 = 0.2
-  alarm_description         = "High target latency alert"
-  alarm_actions             = [aws_sns_topic.this.arn]
-  ok_actions                = [aws_sns_topic.this.arn]
+  alarm_name          = "${var.service_name}-high-app-response-time"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 0.2
+  alarm_description   = "High target latency alert"
+  alarm_actions       = [aws_sns_topic.this.arn]
+  ok_actions          = [aws_sns_topic.this.arn]
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix


### PR DESCRIPTION
## Changes

Alert attribute treat_missing_data = "notBreaching" added for 5xx errors. Alerts should change status to OK when there are no errors.


