### PR TITLE
Group template test logs for web service testing

### DIFF
--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -87,6 +87,7 @@ func SetUpBuildRepository(t *testing.T, projectName string) {
 }
 
 func SetUpDevEnvironment(t *testing.T) {
+	fmt.Println("::group::Creating web service dev environment")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"infra-configure-app-service", "APP_NAME=app", "ENVIRONMENT=dev"},
@@ -106,6 +107,7 @@ func SetUpDevEnvironment(t *testing.T) {
 		Env:        map[string]string{"TF_CLI_ARGS_apply": fmt.Sprintf("-input=false -auto-approve -var=image_tag=%s", imageTag)},
 		WorkingDir: "../",
 	})
+	fmt.Println("::endgroup::")
 }
 
 func ValidateAccountBackend(t *testing.T, region string, projectName string) {
@@ -152,6 +154,8 @@ func ValidateBuildRepository(t *testing.T, projectName string) {
 }
 
 func ValidateDevEnvironment(t *testing.T) {
+	fmt.Println("::group::Validating ability to call web service endpoint")
+
 	// Wait for service to be stable
 	appName := "app"
 	environmentName := "dev"
@@ -170,6 +174,7 @@ func ValidateDevEnvironment(t *testing.T) {
 	http_helper.HttpGetWithRetryWithCustomValidation(t, serviceEndpoint, nil, 10, 3*time.Second, func(responseStatus int, responseBody string) bool {
 		return responseStatus == 200
 	})
+	fmt.Println("::endgroup::")
 }
 
 func TeardownAccount(t *testing.T) {


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context

We were grouping all the other logs but didn't group the logs for when we spun up the web service, so it was really noisy.

## Testing

[Before:](https://github.com/navapbc/template-infra/actions/runs/5767379754/job/15636950869#step:6:1362)
<img width="1405" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/7259330f-5e4b-4a80-9ec4-43191fdfa212">

[After:](https://github.com/navapbc/template-infra/actions/runs/5790516517/job/15693714116?pr=370#step:6:1360)
Now the entire run fits in one screenshot, with the ability to expand
<img width="1521" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/cd57a229-ad8c-4b67-8427-19241d092a7f">
