### PR TITLE
Explain how to fix default table permissions in app

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -30,6 +30,16 @@ def health():
     conn.execute("SELECT 1")
     return "OK"
 
+@app.route("/migrations")
+def migrations():
+    conn = get_db_connection()
+    cur = conn.execute("SELECT last_migration_date FROM migrations")
+    row = cur.fetchone
+    if row is None:
+        return "No migrations run"
+    else:
+        last_migration_date = cur.fetchone()[0]
+        return f"Last migration on {last_migration_date}"
 
 def get_db_token(host, port, user):
     region = os.environ.get("AWS_REGION")

--- a/app/migrations.sql
+++ b/app/migrations.sql
@@ -6,11 +6,17 @@ This simulates a simpler version of what most migration frameworks do,
 which is to create a version table that stores the current state of the database.
 */
 
+/*
+Hardcoded the app username since couldn't figure out
+a simple way to pull it from environment variable
+*/
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app;
+
+DROP TABLE IF EXISTS migrations;
+
 CREATE TABLE IF NOT EXISTS migrations (
     last_migration_date TIMESTAMP
 );
-
-TRUNCATE TABLE migrations;
 
 INSERT INTO migrations (last_migration_date)
 VALUES (NOW());

--- a/app/migrations.sql
+++ b/app/migrations.sql
@@ -7,11 +7,15 @@ which is to create a version table that stores the current state of the database
 */
 
 /*
-Hardcoded the app username since couldn't figure out
+Hardcode the app username since we couldn't figure out
 a simple way to pull it from environment variable
 */
 ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app;
 
+/*
+Drop the table rather than truncate it to test
+out default privileges for newly created tables
+*/
 DROP TABLE IF EXISTS migrations;
 
 CREATE TABLE IF NOT EXISTS migrations (

--- a/docs/infra/set-up-database.md
+++ b/docs/infra/set-up-database.md
@@ -65,9 +65,17 @@ The Lambda function's response should describe the resulting PostgreSQL roles an
 }
 ```
 
-### Note on Postgres table permissions
+### Important note on Postgres table permissions
 
-The `migrator` role will be used by the migration task to run database migrations (creating tables, altering tables, etc.), while the `app` role will be used by the web service to access the database. In Postgres, new tables won't automatically be accessible by roles other than the creator unless specifically granted, even if those other roles have usage access to the schema that the tables are created in. In other words if the `migrator` user created a new table `foo` in the `app` schema, the `app` user will not have automatically be able to access it. The way to change this is for the migrator user to run the SQL command `ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app`. This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](/app/migrations.sql).
+Before creating migrations that create tables, first create a migration that includes the following SQL command (or equivalent if your migrations are written in a general purpose programming language):
+
+```sql
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app
+```
+
+This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](/app/migrations.sql).
+
+Why is this needed? The reason is because the `migrator` role will be used by the migration task to run database migrations (creating tables, altering tables, etc.), while the `app` role will be used by the web service to access the database. Moreover, in Postgres, new tables won't automatically be accessible by roles other than the creator unless specifically granted, even if those other roles have usage access to the schema that the tables are created in. In other words if the `migrator` user created a new table `foo` in the `app` schema, the `app` user will not have automatically be able to access it by default.
 
 ## Set up application environments
 

--- a/docs/infra/set-up-database.md
+++ b/docs/infra/set-up-database.md
@@ -65,6 +65,10 @@ The Lambda function's response should describe the resulting PostgreSQL roles an
 }
 ```
 
+### Note on Postgres table permissions
+
+The `migrator` role will be used by the migration task to run database migrations (creating tables, altering tables, etc.), while the `app` role will be used by the web service to access the database. In Postgres, new tables won't automatically be accessible by roles other than the creator unless specifically granted, even if those other roles have usage access to the schema that the tables are created in. In other words if the `migrator` user created a new table `foo` in the `app` schema, the `app` user will not have automatically be able to access it. The way to change this is for the migrator user to run the SQL command `ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app`. This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](/app/migrations.sql).
+
 ## Set up application environments
 
 Once you set up the deployment process, you can proceed to [set up the application service](./set-up-app-env.md)

--- a/infra/modules/database/role_manager/role_manager.py
+++ b/infra/modules/database/role_manager/role_manager.py
@@ -134,24 +134,6 @@ def configure_schema(conn: Connection, schema_name: str, migrator_username: str,
     logger.info("Granting schema usage privileges: schema_name=%s role=%s", schema_name, app_username)
     conn.run(f"GRANT USAGE ON SCHEMA {identifier(schema_name)} TO {identifier(app_username)}")
 
-    logger.info("Granting all table privileges on future tables: schema_name=%s role=%s", schema_name, app_username)
-    conn.run(f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON TABLES TO {identifier(app_username)}")
-
-    logger.info("Granting all table privileges on existing tables: schema_name=%s role=%s", schema_name, app_username)
-    conn.run(f"GRANT ALL ON ALL TABLES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}")
-
-    logger.info("Granting all sequence privileges: schema_name=%s role=%s", schema_name, app_username)
-    conn.run(
-        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON SEQUENCES TO {identifier(app_username)}"
-    )
-    conn.run(f"GRANT ALL ON ALL SEQUENCES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}")
-
-    logger.info("Granting all routine privileges: schema_name=%s role=%s", schema_name, app_username)
-    conn.run(
-        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON ROUTINES TO {identifier(app_username)}"
-    )
-    conn.run(f"GRANT ALL ON ALL ROUTINES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}")
-
 
 def print_roles(roles: list[str]) -> None:
     logger.info("Roles")


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

- Revert previous change that didn't properly fix table permissions
- Add migrations route to test app to test access to a table created by migrator
- Update migrations file to alter default privileges for tables created by migrator role
- Update instructions to explain the gotcha

## Context for reviewers

We recently merged #373 to attempt to fix an issue with table privileges but that didn't actually solve the problem. This PR removes the previous change and shows an example of a proper fix that needs to be implemented in the application migrations, updates the example app's migrations, and added instructions in the db-setup to call this gotcha out.

## Testing

Tested this out on platform-test repo https://github.com/navapbc/platform-test/pull/26