### PR TITLE
Refactor infra tests to prepare for db tests

### DIFF
--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -14,6 +14,7 @@ on:
   #     - infra/*/service/**
   #     - test/**
   #     - .github/workflows/ci-infra-service.yml
+  workflow_dispatch:
 
 jobs:
   infra-test-e2e:

--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -1,0 +1,47 @@
+name: CI Infra Service Checks
+
+on:
+  # !! Uncomment to trigger automated infra tests once dev environment is set up
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - infra/*/service/**
+  #     - test/**
+  #     - .github/workflows/ci-infra-service.yml
+  # pull_request:
+  #   paths:
+  #     - infra/*/service/**
+  #     - test/**
+  #     - .github/workflows/ci-infra-service.yml
+
+jobs:
+  infra-test-e2e:
+    name: Test service
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.2.1
+          terraform_wrapper: false
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.0"
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: app
+          # Run infra CI on dev environment
+          environment: dev
+
+      - name: Run Terratest
+        run: make infra-test-service

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
     paths:
       - infra/**
-      - test/**
       - .github/workflows/ci-infra.yml
 
 jobs:
@@ -71,33 +70,3 @@ jobs:
         uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
         with:
           github_token: ${{ github.token }}
-  # !! Uncomment to trigger automated infra tests once dev environment is set up
-  # infra-test-e2e:
-  #   name: End-to-end tests
-  #   runs-on: ubuntu-latest
-  #
-  #   permissions:
-  #     contents: read
-  #     id-token: write
-  #
-  #   steps:
-  #     - uses: actions/checkout@v3
-
-  #     - uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         terraform_version: 1.2.1
-  #         terraform_wrapper: false
-
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ">=1.19.0"
-
-  #     - name: Configure AWS credentials
-  #       uses: ./.github/actions/configure-aws-credentials
-  #       with:
-  #         app_name: app
-  #         # Run infra CI on dev environment
-  #         environment: dev
-
-  #     - name: Run Terratest
-  #       run: make infra-test

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ infra-lint: ## Lint infra code
 infra-format: ## Format infra code
 	terraform fmt -recursive infra
 
-infra-test: ## Run end-to-end infra Terratest test suite
-	cd infra/test && go test -v -timeout 30m
+infra-test-service: ## Run service layer infra test suite
+	cd infra/test && go test -run TestService -v -timeout 30m
 
 ########################
 ## Release Management ##

--- a/infra/modules/service/access_logs.tf
+++ b/infra/modules/service/access_logs.tf
@@ -21,7 +21,7 @@ locals {
 
 resource "aws_s3_bucket" "access_logs" {
   bucket_prefix = "${var.service_name}-access-logs"
-  force_destroy = true
+  force_destroy = false
   # checkov:skip=CKV2_AWS_62:Event notification not necessary for this bucket expecially due to likely use of lifecycle rules
   # checkov:skip=CKV_AWS_18:Access logging was not considered necessary for this bucket
   # checkov:skip=CKV_AWS_144:Not considered critical to the point of cross region replication

--- a/infra/modules/service/access_logs.tf
+++ b/infra/modules/service/access_logs.tf
@@ -21,7 +21,7 @@ locals {
 
 resource "aws_s3_bucket" "access_logs" {
   bucket_prefix = "${var.service_name}-access-logs"
-  force_destroy = false
+  force_destroy = true
   # checkov:skip=CKV2_AWS_62:Event notification not necessary for this bucket expecially due to likely use of lifecycle rules
   # checkov:skip=CKV_AWS_18:Access logging was not considered necessary for this bucket
   # checkov:skip=CKV_AWS_144:Not considered critical to the point of cross region replication

--- a/infra/test/helpers.go
+++ b/infra/test/helpers.go
@@ -1,0 +1,20 @@
+// Common functions used by test files
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+// Wrapper function for terraform init using a passed in backend config file. This is needed since
+// terratest currently does not support passing a file as the -backend-config option
+// so we need to manually call terraform rather than using terraform.Init
+// see https://github.com/gruntwork-io/terratest/issues/517
+// it looks like this PR would add functionality for this: https://github.com/gruntwork-io/terratest/pull/558
+// after which we add BackendConfig: []string{"dev.s3.tfbackend": terraform.KeyOnly} to terraformOptions
+// and replace the call to terraform.RunTerraformCommand with terraform.Init
+func TerraformInit(t *testing.T, terraformOptions *terraform.Options, backendConfig string) {
+	terraform.RunTerraformCommand(t, terraformOptions, "init", fmt.Sprintf("-backend-config=%s", backendConfig))
+}

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestDev(t *testing.T) {
+var uniqueId = strings.ToLower(random.UniqueId())
+var workspaceName = fmt.Sprintf("t-%s", uniqueId)
+
+func TestService(t *testing.T) {
 	BuildAndPublish(t)
 
-	uniqueId := strings.ToLower(random.UniqueId())
-	workspaceName := fmt.Sprintf("t-%s", uniqueId)
 	imageTag := shell.RunCommandAndGetOutput(t, shell.Command{
 		Command:    "git",
 		Args:       []string{"rev-parse", "HEAD"},
@@ -31,8 +32,14 @@ func TestDev(t *testing.T) {
 		},
 	})
 
-	defer DestroyDevEnvironmentAndWorkspace(t, terraformOptions, workspaceName)
-	CreateDevEnvironmentInWorkspace(t, terraformOptions, workspaceName)
+	TerraformInit(t, terraformOptions, "dev.s3.tfbackend")
+
+	defer terraform.WorkspaceDelete(t, terraformOptions, workspaceName)
+	terraform.WorkspaceSelectOrNew(t, terraformOptions, workspaceName)
+
+	defer DestroyService(t, terraformOptions)
+	terraform.Apply(t, terraformOptions)
+
 	WaitForServiceToBeStable(t, workspaceName)
 	RunEndToEndTests(t, terraformOptions)
 }
@@ -44,9 +51,9 @@ func BuildAndPublish(t *testing.T) {
 	// it looks like this PR would add functionality for this: https://github.com/gruntwork-io/terratest/pull/558
 	// after which we add BackendConfig: []string{"dev.s3.tfbackend": terraform.KeyOnly} to terraformOptions
 	// and replace the call to terraform.RunTerraformCommand with terraform.Init
-	terraform.RunTerraformCommand(t, &terraform.Options{
+	TerraformInit(t, &terraform.Options{
 		TerraformDir: "../app/build-repository/",
-	}, "init", "-backend-config=shared.s3.tfbackend")
+	}, "shared.s3.tfbackend")
 
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
@@ -59,21 +66,6 @@ func BuildAndPublish(t *testing.T) {
 		Args:       []string{"release-publish"},
 		WorkingDir: "../../",
 	})
-}
-
-func CreateDevEnvironmentInWorkspace(t *testing.T, terraformOptions *terraform.Options, workspaceName string) {
-	fmt.Printf("::group::Create dev environment in new workspace '%s\n'", workspaceName)
-
-	// terratest currently does not support passing a file as the -backend-config option
-	// so we need to manually call terraform rather than using terraform.Init
-	// see https://github.com/gruntwork-io/terratest/issues/517
-	// it looks like this PR would add functionality for this: https://github.com/gruntwork-io/terratest/pull/558
-	// after which we add BackendConfig: []string{"dev.s3.tfbackend": terraform.KeyOnly} to terraformOptions
-	// and replace the call to terraform.RunTerraformCommand with terraform.Init
-	terraform.RunTerraformCommand(t, terraformOptions, "init", "-backend-config=dev.s3.tfbackend")
-	terraform.WorkspaceSelectOrNew(t, terraformOptions, workspaceName)
-	terraform.Apply(t, terraformOptions)
-	fmt.Println("::endgroup::")
 }
 
 func WaitForServiceToBeStable(t *testing.T, workspaceName string) {
@@ -98,7 +90,7 @@ func RunEndToEndTests(t *testing.T, terraformOptions *terraform.Options) {
 	fmt.Println("::endgroup::")
 }
 
-func EnableDestroy(t *testing.T, terraformOptions *terraform.Options, workspaceName string) {
+func EnableDestroyService(t *testing.T, terraformOptions *terraform.Options) {
 	fmt.Println("::group::Setting force_destroy = true and prevent_destroy = false for s3 buckets")
 	shell.RunCommand(t, shell.Command{
 		Command: "sed",
@@ -118,15 +110,10 @@ func EnableDestroy(t *testing.T, terraformOptions *terraform.Options, workspaceN
 		},
 		WorkingDir: "../../",
 	})
-	terraform.RunTerraformCommand(t, terraformOptions, "init", "-backend-config=dev.s3.tfbackend")
 	terraform.Apply(t, terraformOptions)
 }
 
-func DestroyDevEnvironmentAndWorkspace(t *testing.T, terraformOptions *terraform.Options, workspaceName string) {
-	EnableDestroy(t, terraformOptions, workspaceName)
-	fmt.Println("::group::Destroy environment and workspace")
-	terraform.RunTerraformCommand(t, terraformOptions, "init", "-backend-config=dev.s3.tfbackend")
+func DestroyService(t *testing.T, terraformOptions *terraform.Options) {
+	EnableDestroyService(t, terraformOptions)
 	terraform.Destroy(t, terraformOptions)
-	terraform.WorkspaceDelete(t, terraformOptions, workspaceName)
-	fmt.Println("::endgroup::")
 }

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -18,7 +18,7 @@ echo "Restore modified project files"
 git checkout HEAD -- \
   .dockleconfig \
   .github/workflows/cd.yml \
-  .github/workflows/ci-infra.yml \
+  .github/workflows/ci-infra-service.yml \
   .grype.yml \
   .hadolint.yaml \
   .trivyignore \

--- a/template-only-docs/set-up-ci.md
+++ b/template-only-docs/set-up-ci.md
@@ -18,6 +18,6 @@ After [setting up the AWS account](/docs/infra/set-up-aws-account.md) update the
 
 After [setting up the app environment](/docs/infra/set-up-app-env.md):
 
-* Uncomment the infra end-to-end tests in [ci-infra.yml](/.github/workflows/ci-infra.yml). You can verify that CI is running and passing by clicking into the Actions tab in GitHub. Note that this repo only contains CI for infra (`ci-infra.yml`). Application CI (`ci-app.yml`) is included as part of the application templates.
+* Uncomment the infra end-to-end tests by searching for `!!` in [ci-infra-service.yml](/.github/workflows/ci-infra-service.yml). You can verify that CI is running and passing by clicking into the Actions tab in GitHub. Note that this repo only contains CI for infra. Application CI (`ci-app.yml`) is included as part of the application templates.
 * Uncomment the push trigger in [cd.yml](/.github/workflows/cd.yml)
 * If you setup your AWS account in a different region than `us-east-1`, update the `aws-region` workflow settings to match your region.


### PR DESCRIPTION
## Ticket

n/a

## Changes

* Add helpers.go file for helper functions for tests
* Create TerraformInit helper function
* Rename TestDev to TestService
* Separate service e2e infra tests into its own ci-infra-service.yml workflow
* Rename make infra-test to make infra-test-service

## Context for reviewers

This is in preparation to add db tests. Databases take too long to spin up and down so I want to have separate CI job for db that only runs when there are changes to db files.

## Testing

I did the refactoring in a PR in platform-test and the CI checks still run and pass. See this PR: https://github.com/navapbc/platform-test/pull/30

The small differences in line changes between this PR and the one in platform-test are due to:
* the fact that the infra tests start out commented out in template-infra
* the updates to template-only-docs/set-up-ci.md
