### PR TITLE
Require APP_NAME in relevant make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 PROJECT_ROOT ?= $(notdir $(PWD))
 
-# For now only support a single app in the folder `app/` within the repo
-# In the future, support multiple apps, and which app is being operated
-# on will be determined by the APP_NAME Makefile argument
-APP_NAME ?= app
-
 # Use `=` instead of `:=` so that we only execute `./bin/current-account-alias.sh` when needed
 # See https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors
 CURRENT_ACCOUNT_ALIAS = `./bin/current-account-alias.sh`
@@ -52,6 +47,7 @@ infra-set-up-account: ## Configure and create resources for current AWS profile 
 	./bin/set-up-current-account.sh $(ACCOUNT_NAME)
 
 infra-configure-app-build-repository: ## Configure infra/$APP_NAME/build-repository tfbackend and tfvars files
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	./bin/configure-app-build-repository.sh $(APP_NAME)
 
 infra-configure-app-database: ## Configure infra/$APP_NAME/database module's tfbackend and tfvars files for $ENVIRONMENT
@@ -60,6 +56,7 @@ infra-configure-app-database: ## Configure infra/$APP_NAME/database module's tfb
 	./bin/configure-app-database.sh $(APP_NAME) $(ENVIRONMENT)
 
 infra-configure-monitoring-secrets: ## Set $APP_NAME's incident management service integration URL for $ENVIRONMENT
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	@:$(call check_defined, URL, incident management service (PagerDuty or VictorOps) integration URL)
 	./bin/configure-monitoring-secret.sh $(APP_NAME) $(ENVIRONMENT) $(URL)
@@ -155,20 +152,25 @@ DATE := $(shell date -u '+%Y%m%d.%H%M%S')
 INFO_TAG := $(DATE).$(USER)
 
 release-build: ## Build release for $APP_NAME and tag it with current git hash
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	cd $(APP_NAME) && $(MAKE) release-build \
 		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG)"
 
 release-publish: ## Publish release to $APP_NAME's build repository
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	./bin/publish-release.sh $(APP_NAME) $(IMAGE_NAME) $(IMAGE_TAG)
 
 release-run-database-migrations: ## Run $APP_NAME's database migrations in $ENVIRONMENT
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	./bin/run-database-migrations.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
 
 release-deploy: ## Deploy release to $APP_NAME's web service in $ENVIRONMENT
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
 	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
 
 release-image-name: ## Prints the image name of the release image
+	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@echo $(IMAGE_NAME)
 
 release-image-tag: ## Prints the image tag of the release image

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ release-publish: ## Publish release to $APP_NAME's build repository
 
 release-run-database-migrations: ## Run $APP_NAME's database migrations in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
+	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
 	./bin/run-database-migrations.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
 
 release-deploy: ## Deploy release to $APP_NAME's web service in $ENVIRONMENT


### PR DESCRIPTION
## Ticket

Resolves #391 

## Changes
- Remove default for `APP_NAME`
- Anywhere `APP_NAME` is required, do a check
- Add ENVIRONMENT check to release-run-database-migrations

## Context for reviewers
- `IMAGE-NAME` also requires `APP-NAME`

Hopefully I got them all! I didn't test every single command locally. This is overall better for apps that rename the `/app` directory or monorepo structures so that there is no confusion.
