### PR TITLE
Fix broken link; improve template application usage instructions

### DIFF
--- a/docs/infra/set-up-app-env.md
+++ b/docs/infra/set-up-app-env.md
@@ -8,7 +8,7 @@ The application environment setup process will:
 
 Before setting up the application's environments you'll need to have:
 
-1. [A compatible application in the app folder](./application-requirements.md)
+1. [A compatible application in the app folder](https://github.com/navapbc/template-infra/blob/main/template-only-docs/application-requirements.md)
 2. [Configure the app](/infra/app/app-config/main.tf). Make sure you update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with.
 3. (If the application has a database) [Set up the database for the application](./set-up-database.md)
 4. [Set up the application build repository](./set-up-app-build-repository.md)

--- a/template-only-docs/application-requirements.md
+++ b/template-only-docs/application-requirements.md
@@ -26,7 +26,7 @@ The infra template includes an example "hello, world" application that works wit
 
 ## Template Applications
 
-You can the following template applications with the template infrastructure
+You can use the following template applications with the template infrastructure. Each of these includes a script to generate a repository based on the template, which should be run from [the `/app` directory](/app).
 
 * [template-application-nextjs](https://github.com/navapbc/template-application-nextjs)
 * [template-application-flask](https://github.com/navapbc/template-application-flask)

--- a/template-only-docs/application-requirements.md
+++ b/template-only-docs/application-requirements.md
@@ -26,7 +26,7 @@ The infra template includes an example "hello, world" application that works wit
 
 ## Template Applications
 
-You can use the following template applications with the template infrastructure. Each of these includes a script to generate a repository based on the template, which should be run from [the `/app` directory](/app).
+You can use the following template applications with the template infrastructure. Each of these includes a script to generate a working application that works with this infra template.
 
 * [template-application-nextjs](https://github.com/navapbc/template-application-nextjs)
 * [template-application-flask](https://github.com/navapbc/template-application-flask)


### PR DESCRIPTION
## Ticket

Not applicable.

## Changes

- Fix broken link to application requirements (will not work after installing template)
- Mention installation scripts for current template applications

## Context for reviewers

The broken link increased the difficulty of deploying code for a bid. This will reduce the likelihood that we will run into the same issue if we need to setup another version of the same repository for the bid.

This also mentions the relevant details (the application setup scripts) directly in this repo's documentation to improve visibility.

## Testing

Not applicable.
