### PR TITLE
Fix hadolint typo in vulnerability-management.md

### DIFF
--- a/docs/infra/vulnerability-management.md
+++ b/docs/infra/vulnerability-management.md
@@ -26,7 +26,7 @@ The workflow will run whenever there is a push to a PR or when merged to main if
 
 ## Notes about Scanners
 ### Hadolint
-The trivy scanner allows you to ignore or safelist certain findings, which can be specified in the [.hadolint.yaml](../../.hadolint.yaml) file. There is a template file here that you can use in your repo. 
+The hadolint scanner allows you to ignore or safelist certain findings, which can be specified in the [.hadolint.yaml](../../.hadolint.yaml) file. There is a template file here that you can use in your repo.
 ### Trivy
 The trivy scanner allows you to ignore or safelist certain findings, which can be specified in the [.trivyignore](../../.trivyignore) file. There is a template file here that you can use in your repo.
 ### Anchore


### PR DESCRIPTION
## Ticket

N/A

## Changes

- Fix typo: `trivy scanner` should be `hadolint scanner` in the Hadolint section

## Context for reviewers

Refer to `hadolint-scan` job: https://github.com/navapbc/template-infra/blob/yoom/fix-hadolint-typo/.github/workflows/ci-vulnerability-scans.yml#L27

## Testing

N/A
