### PR TITLE
Tweak cd workflow name

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -1,7 +1,7 @@
-name: Continuous Deployment - App
+name: Deploy App
 # Need to set a default value for when the workflow is triggered from a git push
 # which bypasses the default configuration for inputs
-run-name: Deploy ${{ github.ref_name }} to ${{ inputs.environment || 'dev' }}
+run-name: Deploy ${{ github.ref_name }} to App ${{ inputs.environment || 'dev' }}
 
 on:
   # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Tweak workflow names to be more consistent with each other. I think the deploy workflows should be next to each other

<img width="297" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/a14718f9-667e-488b-88eb-740f9a42930e">


## Testing
didn't test, the change seems simple enough