### PR TITLE
Store template version in a file on project

### DIFF
--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -21,10 +21,6 @@ jobs:
           - navapbc/platform-test-flask
           - navapbc/platform-test-nextjs
     steps:
-      - name: Checkout template-infra repo
-        uses: actions/checkout@v3
-        with:
-          path: template-infra
       - name: Checkout project repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -21,6 +21,10 @@ jobs:
           - navapbc/platform-test-flask
           - navapbc/platform-test-nextjs
     steps:
+      - name: Checkout template-infra repo
+        uses: actions/checkout@v3
+        with:
+          path: template-infra
       - name: Checkout project repo
         uses: actions/checkout@v3
         with:

--- a/template-only-bin/download-and-install-template.sh
+++ b/template-only-bin/download-and-install-template.sh
@@ -7,5 +7,10 @@ git clone --single-branch --branch main --depth 1 git@github.com:navapbc/templat
 echo "Install template"
 ./template-infra/template-only-bin/install-template.sh
 
+# Store template version in a file
+cd template-infra
+git rev-parse HEAD > ../.template-version
+cd -
+
 echo "Clean up template-infra folder"
 rm -fr template-infra

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
-#
+# -----------------------------------------------------------------------------
 # This script updates template-infra in your project. Run
 # This script from your project's root directory.
+#
+# Positional parameters:
+#   TARGET_VERSION (optional) – the version of template-infra to upgrade to.
+#     Defaults to main.
+# -----------------------------------------------------------------------------
 set -euo pipefail
 
-echo "Fetch latest version of template-infra"
+TARGET_VERSION=${1:-"main"}
+
+echo "Clone template-infra"
 git clone git@github.com:navapbc/template-infra.git
+
+# Switch to target version
+cd template-infra
+git checkout $TARGET_VERSION
+cd -
 
 echo "Install template"
 ./template-infra/template-only-bin/install-template.sh

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -4,10 +4,11 @@
 # This script from your project's root directory.
 set -euo pipefail
 
-SCRIPT_DIR=$(dirname $0)
+echo "Fetch latest version of template-infra"
+git clone git@github.com:navapbc/template-infra.git
 
 echo "Install template"
-$SCRIPT_DIR/install-template.sh
+./template-infra/template-only-bin/install-template.sh
 
 # Restore project files with project-specific configuration that was defined as part of project setup.
 # This includes the terraform backend configuration blocks and the project-config module
@@ -24,3 +25,11 @@ git checkout HEAD -- \
   .trivyignore \
   infra/project-config/main.tf \
   infra/app/app-config/main.tf
+
+# Store template version in a file
+cd template-infra
+git rev-parse HEAD > ../.template-version
+cd -
+
+echo "Clean up template-infra folder"
+rm -fr template-infra


### PR DESCRIPTION
## Ticket

Work for #352 

## Changes

* After running install-template.sh or update-template.sh on a project, store the template version in a .template-version file
* Add TARGET_VERSION parameter to update-template.sh
* Switch update-template.sh script to clone template-infra repo
* Remove redundant checkout of template-infra repo from template-only-cd

## Context for reviewers

This is the first PR for #352 that will create the .template-version files in platform test repos.
A subsequent PR will refactor update-template.sh to creating and apply git patches rather than simply copying and restoring files.

## Testing

Ran this branch's version of update-template.sh from platform-test repo via the command

```
curl https://raw.githubusercontent.com/navapbc/template-infra/lorenyu/update/template-only-bin/update-template.sh | bash -s
```

and saw that it created a .template-version file
<img width="919" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/a8745bfb-10f5-4352-b421-2a0bdc0fc13b">


the version in the .template-version file matches the current commit on template-infra@main : https://github.com/navapbc/template-infra/commit/f78b4641191d29cbfbad6531f9a0c7664efd02d7