### PR TITLE
Use https not ssh for git clone in update-template.sh

### DIFF
--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 TARGET_VERSION=${1:-"main"}
 
 echo "Clone template-infra"
-git clone https://github.com/navapbc/template-infra.git
+git clone git@github.com:navapbc/template-infra.git
 
 # Switch to target version
 cd template-infra

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 TARGET_VERSION=${1:-"main"}
 
 echo "Clone template-infra"
-git clone git@github.com:navapbc/template-infra.git
+git clone https://github.com/navapbc/template-infra.git
 
 # Switch to target version
 cd template-infra


### PR DESCRIPTION
## Ticket

n/a, this is a quick fix from bug introduced in #402 

## Changes

see title

## Context for reviewers

Turns out git clone using SSH within a github action is more complicated and breaks. See broken run:
https://github.com/navapbc/template-infra/actions/runs/5978963936

## Testing

Ran template deploy from this branch: https://github.com/navapbc/template-infra/actions/runs/5979055015 it now succeeds
