### PR TITLE
Migrate VPC endpoints to separate networks module (step 2/2)

### DIFF
--- a/docs/infra/set-up-app-env.md
+++ b/docs/infra/set-up-app-env.md
@@ -10,9 +10,10 @@ Before setting up the application's environments you'll need to have:
 
 1. [A compatible application in the app folder](./application-requirements.md)
 2. [Configure the app](/infra/app/app-config/main.tf). Make sure you update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with.
-3. (If the application has a database) [Set up the database for the application](./set-up-database.md)
-4. (If you have an incident management service) [Set up monitoring](./set-up-monitoring-alerts.md)
-5. [Set up the application build repository](./set-up-app-build-repository.md)
+3. (If the application has a database) [Set up the network with VPC endpoints required for the database](./set-up-network.md)
+4. (If the application has a database) [Set up the database for the application](./set-up-database.md)
+5. (If you have an incident management service) [Set up monitoring](./set-up-monitoring-alerts.md)
+6. [Set up the application build repository](./set-up-app-build-repository.md)
 
 ## 1. Configure backend
 

--- a/docs/infra/set-up-network.md
+++ b/docs/infra/set-up-network.md
@@ -1,0 +1,27 @@
+# Set up network
+
+The network setup process will:
+
+1. Configure and deploy network resources needed by other modules. If your application has a database, it will create VPC endpoints for the AWS services needed by the database layer and a security group to contain those VPC endpoints.
+
+## Requirements
+
+Before setting up the database you'll need to have:
+
+1. [Set up the AWS account](./set-up-aws-account.md)
+
+## 1. Configure backend
+
+To create the tfbackend file for the new application environment, run
+
+```bash
+make infra-configure-network
+```
+
+## 2. Create network resources
+
+Now run the following commands to create the resources. Review the terraform before confirming "yes" to apply the changes.
+
+```bash
+make infra-update-network
+```

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -58,15 +58,31 @@ module "app_config" {
   source = "../app-config"
 }
 
+data "aws_security_groups" "aws_services" {
+  filter {
+    name   = "group-name"
+    values = ["${module.project_config.aws_services_security_group_name_prefix}*"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
 module "database" {
   source = "../../modules/database"
 
   name               = "${local.prefix}${local.database_config.cluster_name}"
   access_policy_name = "${local.prefix}${local.database_config.access_policy_name}"
-  app_username       = "${local.prefix}${local.database_config.app_username}"
-  migrator_username  = "${local.prefix}${local.database_config.migrator_username}"
-  schema_name        = "${local.prefix}${local.database_config.schema_name}"
 
-  vpc_id             = data.aws_vpc.default.id
-  private_subnet_ids = data.aws_subnets.default.ids
+  # The following are not AWS infra resources and therefore do not need to be
+  # isolated via the terraform workspace prefix
+  app_username      = local.database_config.app_username
+  migrator_username = local.database_config.migrator_username
+  schema_name       = local.database_config.schema_name
+
+  vpc_id                         = data.aws_vpc.default.id
+  private_subnet_ids             = data.aws_subnets.default.ids
+  aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 }

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -35,7 +35,7 @@ resource "aws_rds_cluster" "db" {
   # checkov:skip=CKV_AWS_128:Auth decision needs to be ironed out
   # checkov:skip=CKV_AWS_162:Auth decision needs to be ironed out
   iam_database_authentication_enabled = true
-  deletion_protection                 = false
+  deletion_protection                 = true
   copy_tags_to_snapshot               = true
   # final_snapshot_identifier = "${var.name}-final"
   skip_final_snapshot = true

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -35,7 +35,7 @@ resource "aws_rds_cluster" "db" {
   # checkov:skip=CKV_AWS_128:Auth decision needs to be ironed out
   # checkov:skip=CKV_AWS_162:Auth decision needs to be ironed out
   iam_database_authentication_enabled = true
-  deletion_protection                 = true
+  deletion_protection                 = false
   copy_tags_to_snapshot               = true
   # final_snapshot_identifier = "${var.name}-final"
   skip_final_snapshot = true

--- a/infra/modules/database/networking.tf
+++ b/infra/modules/database/networking.tf
@@ -33,42 +33,6 @@ resource "aws_vpc_security_group_ingress_rule" "db_ingress_from_role_manager" {
   referenced_security_group_id = aws_security_group.role_manager.id
 }
 
-# VPC Endpoints for accessing AWS Services
-# ----------------------------------------
-#
-# Since the role manager Lambda function is in the VPC (which is needed to be
-# able to access the database) we need to allow the Lambda function to access
-# AWS Systems Manager Parameter Store (to fetch the database password) and
-# KMS (to decrypt SecureString parameters from Parameter Store). We can do
-# this by either allowing internet access to the Lambda, or by using a VPC
-# endpoint. The latter is more secure.
-# See https://repost.aws/knowledge-center/lambda-vpc-parameter-store
-# See https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#create-interface-endpoint
-
-resource "aws_vpc_endpoint" "ssm" {
-  vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssm"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  subnet_ids          = var.private_subnet_ids
-  private_dns_enabled = true
-}
-
-resource "aws_vpc_endpoint" "kms" {
-  vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.kms"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  subnet_ids          = var.private_subnet_ids
-  private_dns_enabled = true
-}
-
-resource "aws_security_group" "vpc_endpoints" {
-  name_prefix = "${var.name}-vpc-endpoints"
-  description = "VPC endpoints to access SSM and KMS"
-  vpc_id      = var.vpc_id
-}
-
 resource "aws_vpc_security_group_egress_rule" "role_manager_egress_to_vpc_endpoints" {
   security_group_id = aws_security_group.role_manager.id
   description       = "Allow outbound requests from role manager to VPC endpoints"
@@ -76,11 +40,11 @@ resource "aws_vpc_security_group_egress_rule" "role_manager_egress_to_vpc_endpoi
   from_port                    = 443
   to_port                      = 443
   ip_protocol                  = "tcp"
-  referenced_security_group_id = aws_security_group.vpc_endpoints.id
+  referenced_security_group_id = var.aws_services_security_group_id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_ingress_from_role_manager" {
-  security_group_id = aws_security_group.vpc_endpoints.id
+  security_group_id = var.aws_services_security_group_id
   description       = "Allow inbound requests to VPC endpoints from role manager"
 
   from_port                    = 443

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -50,3 +50,8 @@ variable "private_subnet_ids" {
   type        = list(any)
   description = "list of private subnet IDs to put the role provisioner and role checker lambda functions in"
 }
+
+variable "aws_services_security_group_id" {
+  type        = string
+  description = "Security group ID for VPC endpoints that access AWS Services"
+}

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -76,6 +76,8 @@ data "aws_subnets" "default" {
 # See https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#create-interface-endpoint
 
 resource "aws_security_group" "aws_services" {
+  count = length(local.aws_service_integrations) > 0 ? 1 : 0
+
   name_prefix = module.project_config.aws_services_security_group_name_prefix
   description = "VPC endpoints to access AWS services from the VPCs private subnets"
   vpc_id      = data.aws_vpc.default.id


### PR DESCRIPTION
## Ticket

Work for #277 

## Changes

* Replace VPC endpoints in database module with data sources referencing VPC endpoints created in network module

## Context for reviewers

This is the second part of migrating VPC endpoints to the network module from the database module

## Rollout

As part of rolling out https://github.com/navapbc/template-infra/pull/405 we imported VPC endpoints to a separate networks module, so as part of rolling out this module, we need to [terraform rm](https://developer.hashicorp.com/terraform/cli/commands/state/rm) the VPC endpoints from the database module before applying on platform-test and platform-test-flask:

```bash
terraform -chdir=infra/app/database state rm module.database.aws_vpc_endpoint.kms
terraform -chdir=infra/app/database state rm module.database.aws_vpc_endpoint.ssm
make infra-update-app-database APP_NAME=app ENVIRONMENT=dev
```

## Testing

I developed and tested in platform-test in this PR https://github.com/navapbc/platform-test/pull/36