### PR TITLE
Show CloudWatch logs in run-command.sh

### DIFF
--- a/bin/run-command.sh
+++ b/bin/run-command.sh
@@ -112,6 +112,13 @@ while true; do
 done
 echo
 echo
+
+# Tail logs until task stops using a loop that polls for new logs.
+# The reason why we don't use `aws logs tail` is because that command is meant
+# for interactive use. In particular, it will wait forever for new logs, even
+# after a task stops, until the user hits Ctrl+C. And the reason why we don't
+# wait until the task completes first before fetching logs is so that we can
+# show logs in near real-time, which can be useful for long running tasks.
 echo "::group::Tailing logs until task stops"
 echo "  LOG_GROUP=$LOG_GROUP"
 echo "  LOG_STREAM=$LOG_STREAM"

--- a/bin/run-command.sh
+++ b/bin/run-command.sh
@@ -34,6 +34,10 @@ echo
 CLUSTER_NAME=$(terraform -chdir=infra/$APP_NAME/service output -raw service_cluster_name)
 SERVICE_NAME=$(terraform -chdir=infra/$APP_NAME/service output -raw service_name)
 
+# Get the log group and log stream prefix so that we can print out the ECS task's logs after running the task
+LOG_GROUP=$(terraform -chdir=infra/$APP_NAME/service output -raw application_log_group)
+LOG_STREAM_PREFIX=$(terraform -chdir=infra/$APP_NAME/service output -raw application_log_stream_prefix)
+
 SERVICE_TASK_DEFINITION_ARN=$(aws ecs describe-services --no-cli-pager --cluster $CLUSTER_NAME --services $SERVICE_NAME --query "services[0].taskDefinition" --output text)
 # For subsequent commands, use the task definition family rather than the service's task definition ARN
 # because in the case of migrations, we'll deploy a new task definition revision before updating the
@@ -62,6 +66,9 @@ OVERRIDES=$(cat << EOF
 EOF
 )
 
+TASK_START_TIME=$(date +%s)
+TASK_START_TIME_MILLIS=$((TASK_START_TIME * 1000))
+
 AWS_ARGS=(
   ecs run-task
   --region=$CURRENT_REGION
@@ -73,15 +80,70 @@ AWS_ARGS=(
   --network-configuration "$NETWORK_CONFIG"
   --overrides "$OVERRIDES"
 )
-echo "Running AWS CLI command"
+echo "::group::Running AWS CLI command"
 printf " ... %s\n" "${AWS_ARGS[@]}"
-echo
 TASK_ARN=$(aws --no-cli-pager "${AWS_ARGS[@]}" --query "tasks[0].taskArn" --output text)
-
-echo "Waiting for task to stop"
-echo "  TASK_ARN=$TASK_ARN"
+echo "::endgroup::"
 echo
-aws ecs wait tasks-stopped --region $CURRENT_REGION --cluster $CLUSTER_NAME --tasks $TASK_ARN
+
+# Get the task id by extracting the substring after the last '/' since the task ARN is of
+# the form "arn:aws:ecs:<region>:<account id>:task/<cluster name>/<task id>"
+ECS_TASK_ID=$(basename $TASK_ARN)
+
+# The log stream has the format "prefix-name/container-name/ecs-task-id"
+# See https://docs.aws.amazon.com/AmazonECS/latest/userguide/using_awslogs.html
+LOG_STREAM="$LOG_STREAM_PREFIX/$CONTAINER_NAME/$ECS_TASK_ID"
+
+echo "Waiting for log stream to be created"
+echo "  LOG_STREAM=$LOG_STREAM"
+while true; do
+  IS_LOG_STREAM_CREATED=$(aws logs describe-log-streams --no-cli-pager --log-group-name $LOG_GROUP --query "length(logStreams[?logStreamName==\`$LOG_STREAM\`])")
+  if [ "$IS_LOG_STREAM_CREATED" == "1" ]; then
+    break
+  fi
+  sleep 1
+  echo -n "."
+done
+echo
+echo
+echo "::group::Tailing logs until task stops"
+echo "  LOG_GROUP=$LOG_GROUP"
+echo "  LOG_STREAM=$LOG_STREAM"
+echo "  TASK_START_TIME_MILLIS=$TASK_START_TIME_MILLIS"
+# Initialize the logs start time filter to the time we started the task
+LOGS_START_TIME_MILLIS=$TASK_START_TIME_MILLIS
+while true; do
+  # Print logs with human readable timestamps by fetching the log events as JSON
+  # then transforming them afterwards using jq
+  LOG_EVENTS=$(aws logs get-log-events \
+    --no-cli-pager \
+    --log-group-name $LOG_GROUP \
+    --log-stream-name $LOG_STREAM \
+    --start-time $LOGS_START_TIME_MILLIS \
+    --start-from-head \
+    --no-paginate \
+    --output json)
+  # Divide timestamp by 1000 since AWS timestamps are in milliseconds
+  echo $LOG_EVENTS | jq -r '.events[] | ((.timestamp / 1000 | strftime("%Y-%m-%d %H:%M:%S")) + "\t" + .message)'
+
+  # If the task stopped, then stop tailing logs
+  LAST_TASK_STATUS=$(aws ecs describe-tasks --cluster $CLUSTER_NAME --tasks $TASK_ARN --query "tasks[0].containers[?name=='$CONTAINER_NAME'].lastStatus" --output text)
+  if [ "$LAST_TASK_STATUS" = "STOPPED" ]; then
+    break
+  fi
+
+  # If there were new logs printed, then update the logs start time filter
+  # to be the last log's timestamp + 1
+  LAST_LOG_TIMESTAMP=$(echo $LOG_EVENTS | jq -r '.events[-1].timestamp' )
+  if [ "$LAST_LOG_TIMESTAMP" != "null" ]; then
+    LOGS_START_TIME_MILLIS=$((LAST_LOG_TIMESTAMP + 1))
+  fi
+
+  # Give the application a moment to generate more logs before fetching again
+  sleep 1
+done
+echo "::endgroup::"
+echo
 
 CONTAINER_EXIT_CODE=$(aws ecs describe-tasks --cluster $CLUSTER_NAME --tasks $TASK_ARN --query "tasks[0].containers[?name=='$CONTAINER_NAME'].exitCode" --output text)
 

--- a/bin/run-command.sh
+++ b/bin/run-command.sh
@@ -94,6 +94,12 @@ ECS_TASK_ID=$(basename $TASK_ARN)
 # See https://docs.aws.amazon.com/AmazonECS/latest/userguide/using_awslogs.html
 LOG_STREAM="$LOG_STREAM_PREFIX/$CONTAINER_NAME/$ECS_TASK_ID"
 
+# Wait for log stream to be created before fetching the logs.
+# The reason we don't use the `aws ecs wait tasks-running` command is because
+# that command can fail on short-lived tasks. In particular, the command polls
+# every 6 seconds with describe-tasks until tasks[].lastStatus is RUNNING. A
+# task that completes quickly can go from PENDING to STOPPED, causing the wait
+# command to error out.
 echo "Waiting for log stream to be created"
 echo "  LOG_STREAM=$LOG_STREAM"
 while true; do

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -47,7 +47,7 @@ TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_tas
 
 echo "::endgroup::"
 echo
-echo '::group::Step 2. Run "db-migrate" command'
+echo 'Step 2. Run "db-migrate" command'
 
 COMMAND='["db-migrate"]'
 
@@ -58,4 +58,3 @@ EOF
 )
 
 ./bin/run-command.sh $APP_NAME $ENVIRONMENT "$COMMAND" "$ENVIRONMENT_VARIABLES"
-echo "::endgroup::"

--- a/infra/app/service/outputs.tf
+++ b/infra/app/service/outputs.tf
@@ -10,3 +10,11 @@ output "service_cluster_name" {
 output "service_name" {
   value = local.service_name
 }
+
+output "application_log_group" {
+  value = module.service.application_log_group
+}
+
+output "application_log_stream_prefix" {
+  value = module.service.application_log_stream_prefix
+}

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -8,6 +8,7 @@ locals {
   alb_name                = var.service_name
   cluster_name            = var.service_name
   log_group_name          = "service/${var.service_name}"
+  log_stream_prefix       = var.service_name
   task_executor_role_name = "${var.service_name}-task-executor"
   image_url               = "${data.aws_ecr_repository.app.repository_url}:${var.image_tag}"
 
@@ -103,7 +104,7 @@ resource "aws_ecs_task_definition" "app" {
         options = {
           "awslogs-group"         = aws_cloudwatch_log_group.service_logs.name,
           "awslogs-region"        = data.aws_region.current.name,
-          "awslogs-stream-prefix" = var.service_name
+          "awslogs-stream-prefix" = local.log_stream_prefix
         }
       }
     }

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -12,6 +12,14 @@ output "load_balancer_arn_suffix" {
   value       = aws_lb.alb.arn_suffix
 }
 
+output "application_log_group" {
+  value = local.log_group_name
+}
+
+output "application_log_stream_prefix" {
+  value = local.log_stream_prefix
+}
+
 output "migrator_role_arn" {
   description = "ARN for role to use for migration"
   value       = aws_iam_role.migrator_service.arn


### PR DESCRIPTION
## Ticket

Resolves #320 

## Changes

* Add application_log_group and application_log_stream_prefix to service layer outputs
* Update run-command to print task logs every second while the task is running until it completes

## Context for reviewers

When running database migrations, the logs from the migration are currently in CloudWatch. It would be more convenient for developers to see the logs directly in the GitHub actions workflow. This change makes that possible.

## Testing

Development and testing on platform-test repo https://github.com/navapbc/platform-test/pull/29