### PR TITLE
Remove cd.yml and ci-infra.yml from update-template exclude list

### DIFF
--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -39,9 +39,7 @@ cd -
 
 echo "Applying patch"
 # Note: Keep this list in sync with the removed files in install-template.sh
-EXCLUDE_OPT="--exclude=.github/workflows/template-only-* \
-  --exclude=.github/workflows/cd.yml \
-  --exclude=.github/workflows/ci-infra.yml"
+EXCLUDE_OPT="--exclude=.github/workflows/template-only-*"
 git apply $EXCLUDE_OPT --allow-empty template-infra/patch
 
 echo "Saving new template version to .template-infra"


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

I needed to exclude cd.yml and ci-infra.yml for testing purposes when doing #403, but it is no longer necessary to exclude that from the list of files we patch

> Note that I had to temporarily exclude cd.yml and ci-infra.yml for testing, since those files included big changes that don't apply well. In the future, only changes to the commented out sections of those files would have issues with patching.

## Testing

Did a basic sanity test check by running on platform-test's main branch the version of update-template.sh on this branch via
```
platform-test$ curl https://raw.githubusercontent.com/navapbc/template-infra/lorenyu/updateexclude/template-only-bin/update-template.sh | bash -s
```
note the branch name in the command

<img width="925" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/67c507cf-3f3e-47fe-acba-a37e7dc1d6ea">

(there were no changes of course since platform-test is already up to date with main)
