### PR TITLE
Use v3 of aws-actions/configure-aws-credentials

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -52,7 +52,7 @@ runs:
         echo "AWS_REGION=$AWS_REGION" >> "$GITHUB_ENV"
       shell: bash
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v3
       with:
         role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/check-infra-auth.yml
+++ b/.github/workflows/check-infra-auth.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           go-version: ">=1.19.0"
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: us-east-1
 


### PR DESCRIPTION
## Ticket

Resolves #243 

## Changes

see title

## Context for reviewers

There was a maintenance ticket to switch to v2 of aws-actions/configure-aws-credentials, but turns out they released v3 already. This change switches to using that.

## Testing

CI should cover at least the changes in check-infra-auth.yml and template-only-ci-infra.yml, and the change in actions/configure-aws-credentials/action.yml is similar enough to the other two and also low risk enough that I don't think it's worth explicitly testing that one. If https://github.com/navapbc/template-infra/pull/415 gets merged first, then CI will also automatically cover all three changes.