### PR TITLE
Rename migrator policy to be consistent

### DIFF
--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -6,7 +6,7 @@ output "database_config" {
     migrator_username           = "migrator"
     schema_name                 = var.app_name
     app_access_policy_name      = "${var.app_name}-${var.environment}-app-access"
-    migrator_access_policy_name = "${var.app_name}-${var.environment}-migrate-access"
+    migrator_access_policy_name = "${var.app_name}-${var.environment}-migrator-access"
   } : null
 }
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

everywhere else in infra code we reference the noun migrator not the verb migrate.
it'll be much easier to rename this now before it's being used by the service in https://github.com/navapbc/template-infra/pull/411/files

## Testing

i didn't actually test this

## Rollout

will need to run `make infra-update-app-database APP_NAME=app ENVIRONMENT=dev` on all the platform test repos