### PR TITLE
Reduce polling frequency for describe-log-streams

### DIFF
--- a/bin/run-command.sh
+++ b/bin/run-command.sh
@@ -107,7 +107,7 @@ while true; do
   if [ "$IS_LOG_STREAM_CREATED" == "1" ]; then
     break
   fi
-  sleep 1
+  sleep 5
   echo -n "."
 done
 echo


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

I saw that we hit the rate limit for describe-log-streams in this run in the platform-test-flask account https://github.com/navapbc/platform-test-flask/actions/runs/6099419118/job/16551627018

This PR reduces the polling frequency to hopefully reduce the chance that this rate limit will be hit

## Testing

Didn't test since this is just a config change of a single number