### PR TITLE
Group logs in infra CI service tests

### DIFF
--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -7,12 +7,12 @@ on:
   #     - main
   #   paths:
   #     - infra/*/service/**
-  #     - test/**
+  #     - infra/test/**
   #     - .github/workflows/ci-infra-service.yml
   # pull_request:
   #   paths:
   #     - infra/*/service/**
-  #     - test/**
+  #     - infra/test/**
   #     - .github/workflows/ci-infra-service.yml
   workflow_dispatch:
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

About half of the logs were grouped for infra CI service tests, and the other half weren't grouped, making the logs still hard to read. This change groups the rest of the logs.

## Testing

developed and tested on platform test in https://github.com/navapbc/platform-test/pull/44