### PR TITLE
Remove conflicting empty managed policy block

### DIFF
--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -17,10 +17,6 @@ resource "aws_iam_role" "migrator_task" {
 
   name               = "${var.service_name}-migrator"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role_policy.json
-
-  managed_policy_arns = [
-
-  ]
 }
 
 data "aws_iam_policy_document" "ecs_tasks_assume_role_policy" {


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

There was resource cycling on main branch due to the conflict between [the inline managed_policy_arns block](https://github.com/navapbc/template-infra/blob/057c763b1a24f076f2c57775cb73eaa02d052be5/infra/modules/service/access-control.tf#L21-L23) and the [policy attachment](https://github.com/navapbc/template-infra/blob/057c763b1a24f076f2c57775cb73eaa02d052be5/infra/modules/service/database-access.tf#L24-L29). This PR removes the inline block which was conflicting.

## Testing

dev and testing on platform test in https://github.com/navapbc/platform-test/pull/48