### PR TITLE
Refactor env configs into separate blocks

### DIFF
--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -1,0 +1,8 @@
+module "dev_config" {
+  source                          = "./env-config"
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "dev"
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+}

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -6,7 +6,11 @@ locals {
   has_database                    = false
   has_incident_management_service = false
 
-  environment_configs = { for environment in local.environments : environment => module.env_config[environment] }
+  environment_configs = {
+    dev     = module.dev_config
+    staging = module.staging_config
+    prod    = module.prod_config
+  }
 
   build_repository_config = {
     region = module.project_config.default_region
@@ -51,15 +55,4 @@ locals {
 
 module "project_config" {
   source = "../../project-config"
-}
-
-module "env_config" {
-  for_each = toset(local.environments)
-
-  source                          = "./env-config"
-  app_name                        = local.app_name
-  default_region                  = module.project_config.default_region
-  environment                     = each.key
-  has_database                    = local.has_database
-  has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -1,0 +1,8 @@
+module "prod_config" {
+  source                          = "./env-config"
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "prod"
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+}

--- a/infra/app/app-config/staging.tf
+++ b/infra/app/app-config/staging.tf
@@ -1,0 +1,8 @@
+module "staging_config" {
+  source                          = "./env-config"
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "staging"
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+}


### PR DESCRIPTION
## Ticket

Resolves #425 

## Changes

see title

## Context

The current app-config doesn't make it obvious how to have separate config values for each environment. This change refactors app-config to have separate config blocks for each environment which will probably be the more common scenario rather than the scenario where every environment is identically configured.

## Testing

Developed and tested on platform-test in this PR: https://github.com/navapbc/platform-test/pull/51