### PR TITLE
Fix run-database-migrations

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -58,4 +58,4 @@ ENVIRONMENT_VARIABLES=$(cat << EOF
 EOF
 )
 
-./bin/run-command.sh "$APP_NAME" "$ENVIRONMENT" "$COMMAND" "$ENVIRONMENT_VARIABLES"
+./bin/run-command.sh --environment-variables "$ENVIRONMENT_VARIABLES" "$APP_NAME" "$ENVIRONMENT" "$COMMAND"


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/pull/440

## Changes

see title

## Context for reviewers

In https://github.com/navapbc/template-infra/pull/440 we added an option to override task role but also changed the way the run-command script accepts environment variables, which broke migrations. This change fixes that.

## Testing

developed and tested in platform-test in https://github.com/navapbc/platform-test/pull/53