### PR TITLE
Use migrator role when running migrations

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -41,6 +41,9 @@ fi
 
 DB_MIGRATOR_USER=$(terraform -chdir="infra/$APP_NAME/app-config" output -json environment_configs | jq -r ".$ENVIRONMENT.database_config.migrator_username")
 
+./bin/terraform-init.sh "infra/$APP_NAME/service" "$ENVIRONMENT"
+MIGRATOR_ROLE_ARN=$(terraform -chdir="infra/$APP_NAME/service" output -raw migrator_role_arn)
+
 echo
 echo "::group::Step 1. Update task definition without updating service"
 
@@ -58,4 +61,4 @@ ENVIRONMENT_VARIABLES=$(cat << EOF
 EOF
 )
 
-./bin/run-command.sh --environment-variables "$ENVIRONMENT_VARIABLES" "$APP_NAME" "$ENVIRONMENT" "$COMMAND"
+./bin/run-command.sh --task-role-arn "$MIGRATOR_ROLE_ARN" --environment-variables "$ENVIRONMENT_VARIABLES" "$APP_NAME" "$ENVIRONMENT" "$COMMAND"

--- a/infra/app/service/outputs.tf
+++ b/infra/app/service/outputs.tf
@@ -18,3 +18,7 @@ output "application_log_group" {
 output "application_log_stream_prefix" {
   value = module.service.application_log_stream_prefix
 }
+
+output "migrator_role_arn" {
+  value = module.service.migrator_role_arn
+}


### PR DESCRIPTION
## Ticket

Work for https://github.com/navapbc/template-infra/issues/354

## Changes

* Add migrator_role_arn to service layer outputs
* Use migrator role when running migrations

## Context for reviewers

Part 3 or 4 of task to separate db roles. Use the migrator role when running migrations.

## Testing

Developed and tested in platform-test in https://github.com/navapbc/platform-test/pull/54