### PR TITLE
 Replace refresh with apply refresh

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -23,14 +23,14 @@ runs:
         echo "::group::AWS account authentication details"
 
         terraform -chdir=infra/project-config init > /dev/null
-        terraform -chdir=infra/project-configapply -refresh-only -auto-approve> /dev/null
+        terraform -chdir=infra/project-config apply -refresh-only -auto-approve> /dev/null
         AWS_REGION=$(terraform -chdir=infra/project-config output -raw default_region)
         echo "AWS_REGION=$AWS_REGION"
         GITHUB_ACTIONS_ROLE_NAME=$(terraform -chdir=infra/project-config output -raw github_actions_role_name)
         echo "GITHUB_ACTIONS_ROLE_NAME=$GITHUB_ACTIONS_ROLE_NAME"
 
         terraform -chdir=infra/${{ inputs.app_name }}/app-config init > /dev/null
-        terraform -chdir=infra/${{ inputs.app_name }}/app-configapply -refresh-only -auto-approve> /dev/null 
+        terraform -chdir=infra/${{ inputs.app_name }}/app-config apply -refresh-only -auto-approve> /dev/null 
         ACCOUNT_NAME=$(terraform -chdir=infra/${{ inputs.app_name }}/app-config output -json account_names_by_environment | jq -r .${{ inputs.environment }})
         echo "ACCOUNT_NAME=$ACCOUNT_NAME"
 

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -23,14 +23,14 @@ runs:
         echo "::group::AWS account authentication details"
 
         terraform -chdir=infra/project-config init > /dev/null
-        terraform -chdir=infra/project-config refresh > /dev/null
+        terraform -chdir=infra/project-configapply -refresh-only -auto-approve> /dev/null
         AWS_REGION=$(terraform -chdir=infra/project-config output -raw default_region)
         echo "AWS_REGION=$AWS_REGION"
         GITHUB_ACTIONS_ROLE_NAME=$(terraform -chdir=infra/project-config output -raw github_actions_role_name)
         echo "GITHUB_ACTIONS_ROLE_NAME=$GITHUB_ACTIONS_ROLE_NAME"
 
         terraform -chdir=infra/${{ inputs.app_name }}/app-config init > /dev/null
-        terraform -chdir=infra/${{ inputs.app_name }}/app-config refresh > /dev/null 
+        terraform -chdir=infra/${{ inputs.app_name }}/app-configapply -refresh-only -auto-approve> /dev/null 
         ACCOUNT_NAME=$(terraform -chdir=infra/${{ inputs.app_name }}/app-config output -json account_names_by_environment | jq -r .${{ inputs.environment }})
         echo "ACCOUNT_NAME=$ACCOUNT_NAME"
 

--- a/bin/configure-monitoring-secret.sh
+++ b/bin/configure-monitoring-secret.sh
@@ -17,7 +17,7 @@ ENVIRONMENT=$2
 INTEGRATION_ENDPOINT_URL=$3
 
 terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
-terraform -chdir="infra/$APP_NAME/app-config" refresh > /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -refresh-only -auto-approve> /dev/null
 
 HAS_INCIDENT_MANAGEMENT_SERVICE=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw has_incident_management_service)
 if [ "$HAS_INCIDENT_MANAGEMENT_SERVICE" = "false" ]; then

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -16,7 +16,7 @@ echo "  IMAGE_TAG=$IMAGE_TAG"
 
 # Need to init module when running in CD since GitHub actions does a fresh checkout of repo
 terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
-terraform -chdir="infra/$APP_NAME/app-config" refresh > /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -refresh-only -auto-approve> /dev/null
 IMAGE_REPOSITORY_NAME=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw image_repository_name)
 
 REGION=$(./bin/current-region.sh)

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -30,7 +30,7 @@ echo
 echo "Step 0. Check if app has a database"
 
 terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
-terraform -chdir="infra/$APP_NAME/app-config" refresh > /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -refresh-only -auto-approve> /dev/null
 HAS_DATABASE=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw has_database)
 if [ "$HAS_DATABASE" = "false" ]; then
   echo "Application does not have a database, no migrations to run"

--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -28,7 +28,7 @@ ACCOUNT_ID=$(./bin/current-account-id.sh)
 REGION=$(./bin/current-region.sh)
 
 # Get project name
-terraform -chdir=infra/project-config refresh > /dev/null
+terraform -chdir="infra/project-config" apply -refresh-only -auto-approve> /dev/null
 PROJECT_NAME=$(terraform -chdir=infra/project-config output -raw project_name)
 
 TF_STATE_BUCKET_NAME="$PROJECT_NAME-$ACCOUNT_ID-$REGION-tf"


### PR DESCRIPTION
## Ticket

Resolves #412 
## Changes

Replaced deprecated `terraform refresh` with `terraform apply -refresh-only`

## Context for reviewers

Based on this [platform-test PR](https://github.com/navapbc/platform-test/pull/56)
Terraform refresh is deprecated and is known to have stability issues.

## Testing

All changed files have been tested in platform test