### PR TITLE
Add concurrency limit to build and publish

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,6 +26,7 @@ jobs:
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
+    concurrency: ${{ github.action }}-${{ inputs.ref }}
 
     permissions:
       contents: read

--- a/docs/code-reviews.md
+++ b/docs/code-reviews.md
@@ -48,7 +48,7 @@ After you make requested changes in response to code review feedback, please re-
 - find shared code
 - share knowledge
 
-#### Challenges
+## Challenges of code reviews
 - it can take long
 - who to ask
 - how do you know when is "enough" review

--- a/docs/code-reviews.md
+++ b/docs/code-reviews.md
@@ -41,15 +41,15 @@ and state what you are looking for in the description.
 
 After you make requested changes in response to code review feedback, please re-request reviews from the reviewers to notify them that the work is ready to be reviewed again.
 
-Advantages of code review
+#### Advantages of code review
 
-catch and prevent bugs
-consistent code
-find shared code
-share knowledge
+- catch and prevent bugs
+- consistent code
+- find shared code
+- share knowledge
 
-Challenges
-it can take long
-who to ask
-how do you know when is "enough" review
-what should i be reviewing
+#### Challenges
+- it can take long
+- who to ask
+- how do you know when is "enough" review
+- what should i be reviewing

--- a/docs/code-reviews.md
+++ b/docs/code-reviews.md
@@ -41,7 +41,7 @@ and state what you are looking for in the description.
 
 After you make requested changes in response to code review feedback, please re-request reviews from the reviewers to notify them that the work is ready to be reviewed again.
 
-#### Advantages of code review
+## Advantages of code review
 
 - catch and prevent bugs
 - consistent code


### PR DESCRIPTION
## Ticket

Resolves #427 

## Changes

- Add `concurrency` key to stop race condition for multiple runs on same branch
- Uses github action and commit hash
  + Action because only concurrent runs of same action is an issue
  + commit hash because that's the image tag and causes conflict

## Context for reviewers

Prevents race condition in which second job fails due to naming conflict

## Testing

Tested in [platform-test](https://github.com/navapbc/platform-test/pull/57)