### PR TITLE
Install role manager dependencies on every apply

### DIFF
--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -49,10 +49,11 @@ resource "aws_lambda_function" "role_manager" {
 }
 
 # Installs python packages needed by the role manager lambda function before
-# creating the zip archive. Reinstalls whenever requirements.txt changes
+# creating the zip archive. 
+# Runs pip install on every apply.
+# Timestamp is used to always trigger replacement.
 resource "terraform_data" "role_manager_python_vendor_packages" {
-  triggers_replace = file("${path.module}/role_manager/requirements.txt")
-
+  triggers_replace = timestamp()
   provisioner "local-exec" {
     command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor"
   }

--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -50,7 +50,10 @@ resource "aws_lambda_function" "role_manager" {
 
 # Installs python packages needed by the role manager lambda function before
 # creating the zip archive. 
-# Runs pip install on every apply.
+# Runs pip install on every apply so that the role manager archive file that
+# is generated locally is guaranteed to have the required dependencies even
+# when terraform is run by a developer that did not originally create the
+# environment.
 # Timestamp is used to always trigger replacement.
 resource "terraform_data" "role_manager_python_vendor_packages" {
   triggers_replace = timestamp()


### PR DESCRIPTION
## Ticket

Resolves #446

## Changes

- Causes pip install to occur on every apply
- Done using `timestamp()` for `trigger_replace` value

## Context for reviewers

Done to prevent case where second engineer in repo can make deployment without lambda dependencies

## Testing

Tested in [platform-test PR](https://github.com/navapbc/platform-test/pull/58)