### PR TITLE
Attach param group to rds

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -1,6 +1,11 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+data "aws_rds_engine_version" "db_version" {
+  engine       = "aurora-postgresql"
+  default_only = true
+}
+
 locals {
   master_username       = "postgres"
   primary_instance_name = "${var.name}-primary"
@@ -23,7 +28,7 @@ resource "aws_rds_cluster" "db" {
   # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.CreateInstance.html
   cluster_identifier = var.name
 
-  engine            = "aurora-postgresql"
+  engine            = data.aws_rds_engine_version.db_version.engine
   engine_mode       = "provisioned"
   database_name     = var.database_name
   port              = var.port
@@ -48,6 +53,8 @@ resource "aws_rds_cluster" "db" {
   vpc_security_group_ids = [aws_security_group.db.id]
 
   enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
 }
 
 resource "aws_rds_cluster_instance" "primary" {
@@ -83,7 +90,7 @@ resource "aws_kms_key" "db" {
 
 resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
   name        = var.name
-  family      = "aurora-postgresql13"
+  family      = data.aws_rds_engine_version.db_version.parameter_group_family
   description = "Default cluster parameter group"
 
   parameter {


### PR DESCRIPTION
## Ticket

Resolves #385 

## Changes

- Associate parameter group with db in db module
- Use data module to avoid circular dependency

## Testing

Testing performed under [platform-test PR](https://github.com/navapbc/platform-test/pull/59)
>Terraform creates expected changes without deletion of resources (excluding automatic replacement of lambda package)
><img width="1023" alt="Screenshot 2023-09-19 at 10 45 47 AM" src="https://github.com/navapbc/platform-test/assets/127765344/ac7990a0-be91-4fe0-947b-a34ea93e6a8d">
After application, expected parameter group is applied to cluster
><img width="542" alt="Screenshot 2023-09-19 at 10 45 35 AM" src="https://github.com/navapbc/platform-test/assets/127765344/5c1592e2-4ddf-452a-a253-e80b6a6abcc4">
