### PR TITLE
Add healthcheck variables to support deploying non-custom docker containers

### DIFF
--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -80,14 +80,17 @@ resource "aws_lb_target_group" "app_tg" {
   target_type          = "ip"
   deregistration_delay = "30"
 
-  health_check {
-    path                = "/health"
-    port                = var.container_port
-    healthy_threshold   = 2
-    unhealthy_threshold = 10
-    interval            = 30
-    timeout             = 29
-    matcher             = "200-299"
+  dynamic "health_check" {
+    for_each = var.enable_healthcheck ? [0] : []
+    content {
+      path                = "/${local.healthcheck_path}"
+      port                = var.container_port
+      healthy_threshold   = 2
+      unhealthy_threshold = 10
+      interval            = 30
+      timeout             = 29
+      matcher             = "200-299"
+    }
   }
 
   lifecycle {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -11,7 +11,7 @@ locals {
   log_stream_prefix       = var.service_name
   task_executor_role_name = "${var.service_name}-task-executor"
   image_url               = "${data.aws_ecr_repository.app.repository_url}:${var.image_tag}"
-  healthcheck_path            = trimprefix(var.healthcheck_path, "/")
+  healthcheck_path        = trimprefix(var.healthcheck_path, "/")
 
   base_environment_variables = [
     { name : "PORT", value : tostring(var.container_port) },

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -67,3 +67,35 @@ variable "db_vars" {
   })
   default = null
 }
+
+#-------------------
+# Healthcheck
+#-------------------
+
+variable "enable_healthcheck" {
+  type        = bool
+  description = "Enable container healthcheck"
+  default     = true
+}
+
+variable "healthcheck_path" {
+  type        = string
+  description = "The path to the application healthcheck"
+  default     = "/health"
+}
+
+variable "healthcheck_type" {
+  type        = string
+  description = "Whether to configure a curl or wget healthcheck. use wget for alpine-based images"
+  default     = "wget"
+  validation {
+    condition     = contains(["curl", "wget"], var.healthcheck_type)
+    error_message = "choose either: curl or wget"
+  }
+}
+
+variable "healthcheck_start_period" {
+  type        = number
+  description = "The optional grace period to provide containers time to bootstrap in before failed health checks count towards the maximum number of retries"
+  default     = 0
+}


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.
- Add a variables to `service` child module: 
  - `enable_healthcheck`
  - `healthcheck_path`
  - `healthcheck_type`
  - `healthcheck_start_period`

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

I've used the `service` module a few times now to deploy open source solutions that we don't custom create. These docker images often need a little bit of massaging, but generally benefit from many of the same resources we use when deploying custom docker images. One thing that often needs to be altered are the ECS and ALB healthchecks. This PR adds the following terraform variables to the `service` child module to provide additional flexibility while allowing for our existing defaults.

- `enable_healthcheck`: defaults to `true`. Setting to `false` will disable healthchecks for the container in both ECS and ALB
- `healthcheck_path`: defaults to `/health`. Allows root modules to set the healthcheck to another path depending on what the docker container provides
- `healthcheck_type`: defaults to `wget`. Allows for non-custom docker containers that come with `curl` built-in but not `wget`
- `healthcheck_start_period`: defaults to `0`. Allows for setting a much longer grace period for non-custom docker containers that might take a long time to boot up.

I've found this really useful, but I would like to hear whether this is helpful to include in the template. 

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

I could use some assistance on how we want to write tests for this, if any.