### PR TITLE
Shorten database IAM role name prefixes due to character limits

### DIFF
--- a/infra/modules/database/backups.tf
+++ b/infra/modules/database/backups.tf
@@ -41,7 +41,7 @@ resource "aws_backup_selection" "db_backup" {
 
 # Role that AWS Backup uses to authenticate when backing up the target resource
 resource "aws_iam_role" "db_backup_role" {
-  name_prefix        = "${local.name}-db-backup-role-"
+  name_prefix        = "${local.name}-db-backup-"
   assume_role_policy = data.aws_iam_policy_document.db_backup_policy.json
 }
 

--- a/infra/modules/database/backups.tf
+++ b/infra/modules/database/backups.tf
@@ -30,7 +30,7 @@ data "aws_kms_key" "backup_vault_key" {
 # See https://docs.aws.amazon.com/aws-backup/latest/devguide/assigning-resources.html
 # and https://docs.aws.amazon.com/aws-backup/latest/devguide/API_BackupSelection.html
 resource "aws_backup_selection" "db_backup" {
-  name         = "${local.name}-db-backup"
+  name         = "${var.name}-db-backup"
   plan_id      = aws_backup_plan.backup_plan.id
   iam_role_arn = aws_iam_role.db_backup_role.arn
 
@@ -41,7 +41,7 @@ resource "aws_backup_selection" "db_backup" {
 
 # Role that AWS Backup uses to authenticate when backing up the target resource
 resource "aws_iam_role" "db_backup_role" {
-  name_prefix        = "${local.name}-db-backup-"
+  name_prefix        = "${var.name}-db-backup-"
   assume_role_policy = data.aws_iam_policy_document.db_backup_policy.json
 }
 

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -6,7 +6,6 @@ locals {
   primary_instance_name = "${var.name}-primary"
   role_manager_name     = "${var.name}-role-manager"
   role_manager_package  = "${path.root}/role_manager.zip"
-  name                  = substr(var.name, 0, 12)
   # The ARN that represents the users accessing the database are of the format: "arn:aws:rds-db:<region>:<account-id>:dbuser:<resource-id>/<database-user-name>""
   # See https://aws.amazon.com/blogs/database/using-iam-authentication-to-connect-with-pgadmin-amazon-aurora-postgresql-or-amazon-rds-for-postgresql/
   db_user_arn_prefix = "arn:aws:rds-db:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_rds_cluster.db.cluster_resource_id}"

--- a/infra/modules/database/monitoring.tf
+++ b/infra/modules/database/monitoring.tf
@@ -3,7 +3,7 @@
 #----------------------------------#
 
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  name_prefix        = "${local.name}-enhanced-monitoring-"
+  name_prefix        = "${local.name}-db-monitor-"
   assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
 }
 

--- a/infra/modules/database/monitoring.tf
+++ b/infra/modules/database/monitoring.tf
@@ -3,7 +3,7 @@
 #----------------------------------#
 
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  name_prefix        = "${local.name}-db-monitor-"
+  name_prefix        = "${var.name}-db-monitor-"
   assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
 }
 


### PR DESCRIPTION
## Ticket

Resolves #455 

## Changes

> What was added, updated, or removed in this PR.
- Rename the database backup IAM role prefix
- Rename the database enhanced monitoring IAM role prefix

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

I've gotten this kind of error multiple times:

```
│ Error: expected length of name_prefix to be in the range (1 - 38), got rocket-experiment-dev-enhanced-monitoring-
│
│   with module.database.aws_iam_role.rds_enhanced_monitoring,
│   on ../../modules/database/monitoring.tf line 6, in resource "aws_iam_role" "rds_enhanced_monitoring":
│    6:   name_prefix        = "${var.name}-enhanced-monitoring-"
│
```

It originates here:

https://github.com/navapbc/template-infra/blob/7bcfb4a2867ac9f830fc840aa6aaac2a3e5dd079/infra/modules/database/monitoring.tf#L6 

This line often causes issues with workspaces. The maximum character length for `name_prefix` is 1–38 characters. We set `var.name` to be `<WORKSPACE>-<APP_NAME>-<ENVIRONMENT>-enhanced-monitoring-`. That means we always have at least 22 characters preset, leaving 16 characters. If the environment is `staging`, then we've already used up 29 characters, leaving 9 characters for app name and workspace.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
