### PR TITLE
Bugfix: Add missing prefix needed for using workspaces

### DIFF
--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -64,17 +64,17 @@ module "app_config" {
 
 data "aws_rds_cluster" "db_cluster" {
   count              = module.app_config.has_database ? 1 : 0
-  cluster_identifier = local.database_config.cluster_name
+  cluster_identifier = "${local.prefix}${local.database_config.cluster_name}"
 }
 
 data "aws_iam_policy" "app_db_access_policy" {
   count = module.app_config.has_database ? 1 : 0
-  name  = local.database_config.app_access_policy_name
+  name  = "${local.prefix}${local.database_config.app_access_policy_name}"
 }
 
 data "aws_iam_policy" "migrator_db_access_policy" {
   count = module.app_config.has_database ? 1 : 0
-  name  = local.database_config.migrator_access_policy_name
+  name  = "${local.prefix}${local.database_config.migrator_access_policy_name}"
 }
 
 # Retrieve url for external incident management tool (e.g. Pagerduty, Splunk-On-Call)


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.
- Add terraform prefix to service module

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

While working on the BDS project, I ran into an issue where I wasn't able to use multiple workspaces to deploy apps with services. I realized it was because we were missing the necessary prefix.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Test by deploying multiple apps, each in different workspaces.
