### PR TITLE
Customize service module

### DIFF
--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -81,13 +81,13 @@ resource "aws_lb_target_group" "app_tg" {
   deregistration_delay = "30"
 
   health_check {
-    path                = "/health"
+    path                = "/${local.healthcheck_path}"
     port                = var.container_port
     healthy_threshold   = 2
     unhealthy_threshold = 10
     interval            = 30
     timeout             = 29
-    matcher             = "200-299"
+    matcher             = var.healthcheck_matcher
   }
 
   lifecycle {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -1,7 +1,8 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 data "aws_ecr_repository" "app" {
-  name = var.image_repository_name
+  count = var.external_image_url == "" ? 1 : 0
+  name  = var.image_repository_name
 }
 
 locals {
@@ -10,12 +11,15 @@ locals {
   log_group_name          = "service/${var.service_name}"
   log_stream_prefix       = var.service_name
   task_executor_role_name = "${var.service_name}-task-executor"
-  image_url               = "${data.aws_ecr_repository.app.repository_url}:${var.image_tag}"
+  image_url               = var.external_image_url != "" ? "${var.external_image_url}:${var.image_tag}" : "${data.aws_ecr_repository.app[0].repository_url}:${var.image_tag}"
+  healthcheck_path        = trimprefix(var.healthcheck_path, "/")
+  read_only               = var.container_read_only
 
   base_environment_variables = [
     { name : "PORT", value : tostring(var.container_port) },
     { name : "AWS_REGION", value : data.aws_region.current.name },
   ]
+
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },
     { name : "DB_PORT", value : var.db_vars.connection_info.port },
@@ -23,7 +27,9 @@ locals {
     { name : "DB_NAME", value : var.db_vars.connection_info.db_name },
     { name : "DB_SCHEMA", value : var.db_vars.connection_info.schema_name },
   ]
-  environment_variables = concat(local.base_environment_variables, local.db_environment_variables)
+
+  environment_variables = concat(local.base_environment_variables, local.db_environment_variables, var.container_env_vars)
+  container_secrets     = var.container_secrets
 }
 
 #-------------------
@@ -71,20 +77,23 @@ resource "aws_ecs_task_definition" "app" {
       cpu                    = var.cpu,
       networkMode            = "awsvpc",
       essential              = true,
-      readonlyRootFilesystem = true,
+      readonlyRootFilesystem = local.read_only,
 
       # Need to define all parameters in the healthCheck block even if we want
       # to use AWS's defaults, otherwise the terraform plan will show a diff
       # that will force a replacement of the task definition
-      healthCheck = {
-        interval = 30,
-        retries  = 3,
-        timeout  = 5,
-        command = ["CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:${var.container_port}/health || exit 1"
-        ]
-      },
+      healthCheck = var.enable_container_healthcheck ? {
+        interval    = 30,
+        retries     = 3,
+        timeout     = 5,
+        startPeriod = var.healthcheck_start_period,
+        command = [
+          "CMD-SHELL",
+          var.healthcheck_type == "curl" ? "curl --fail http://localhost:${var.container_port}/${local.healthcheck_path} || exit 1" : "wget --no-verbose --tries=1 --spider http://localhost:${var.container_port}/${local.healthcheck_path} || exit 1",
+        ],
+      } : null,
       environment = local.environment_variables,
+      secrets     = local.container_secrets,
       portMappings = [
         {
           containerPort = var.container_port,
@@ -124,3 +133,4 @@ resource "aws_ecs_cluster" "cluster" {
     value = "enabled"
   }
 }
+

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -66,3 +66,13 @@ resource "aws_security_group" "app" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_ingress_from_app" {
+  security_group_id = var.aws_services_security_group_id
+  description       = "Allow inbound requests to VPC endpoints from application ${var.service_name}"
+
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.app.id
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -16,6 +16,12 @@ variable "image_repository_name" {
   description = "The name of the container image repository"
 }
 
+variable "external_image_url" {
+  type        = string
+  description = "A non-AWS container image repository. If this is not empty, this takes precedence over image_repository_name"
+  default     = ""
+}
+
 variable "desired_instance_count" {
   type        = number
   description = "Number of instances of the task definition to place and keep running."
@@ -66,4 +72,60 @@ variable "db_vars" {
     })
   })
   default = null
+}
+
+variable "container_env_vars" {
+  type        = list(map(string))
+  description = "Additional environment variables to pass to the container definition"
+  default     = []
+}
+
+variable "container_secrets" {
+  type        = list(map(string))
+  description = "AWS secrets to pass to the container definition"
+  default     = []
+}
+
+variable "container_read_only" {
+  type        = bool
+  description = "Whether the container root filesystem should be read-only"
+  default     = true
+}
+
+#-------------------
+# Healthcheck
+#-------------------
+
+variable "healthcheck_path" {
+  type        = string
+  description = "The path to the application healthcheck"
+  default     = "/health"
+}
+
+variable "healthcheck_type" {
+  type        = string
+  description = "Whether to configure a curl or wget healthcheck. curl is more common. use wget for alpine-based images"
+  default     = "wget"
+  validation {
+    condition     = contains(["curl", "wget"], var.healthcheck_type)
+    error_message = "choose either: curl or wget"
+  }
+}
+
+variable "healthcheck_matcher" {
+  type        = string
+  description = "The response codes that indicate healthy to the ALB"
+  default     = "200-299"
+}
+
+variable "healthcheck_start_period" {
+  type        = number
+  description = "The optional grace period to provide containers time to bootstrap in before failed health checks count towards the maximum number of retries"
+  default     = 0
+}
+
+variable "enable_container_healthcheck" {
+  type        = bool
+  description = "The ALB healthcheck is mandatory, but the container healthcheck can be disabled if desired"
+  default     = true
 }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -86,6 +86,12 @@ variable "container_secrets" {
   default     = []
 }
 
+variable "aws_services_security_group_id" {
+  type        = string
+  description = "Security group ID for VPC endpoints that access AWS Services"
+}
+
+
 variable "container_read_only" {
   type        = bool
   description = "Whether the container root filesystem should be read-only"


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.
- Add ability to pass in container environment variables to the service module
- Add ability to pass in container secrets from Parameter Store to the service module
- Add ability VPC security group ingress rule allow inbound requests to VPC endpoints from the app (needed for access to Parameter Store)
- Add ability to run non-custom docker images
- Add ability to customize healthcheck
- Add ability to disable read-only containers

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

On a number of my recent projects, I've needed the ability to run non-custom docker images (e.g. [flowable](https://github.com/flowable/flowable-engine/tree/main/docker). This means I've needed the `service` module to be a little bit more flexible.

Specifically, I've needed to be able to:

- Pass in a different docker image (such as from docker hub)
- Pass in environment variables I can use to configure the container
- Pass in secrets that are stored in AWS Parameter Store to the container
- Modify the healthcheck settings (for instance `/health` doesn't exist, but `/healthcheck` does or `/homepage` does)
- Modify the container to not be read-only (some containers will fail if run in read-only mode)

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

I've created a matching test PR in the platform-test repo that demonstrates how to test these changes: https://github.com/navapbc/platform-test/pull/65