### PR TITLE
Update some documentation around APP_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,6 @@ infra-update-app-database-roles: ## Create or update database roles and schemas 
 	./bin/create-or-update-database-roles.sh $(APP_NAME) $(ENVIRONMENT)
 
 infra-update-app-service: ## Create or update $APP_NAME's web service module
-	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	terraform -chdir="infra/$(APP_NAME)/service" init -input=false -reconfigure -backend-config="$(ENVIRONMENT).s3.tfbackend"

--- a/docs/infra/set-up-app-env.md
+++ b/docs/infra/set-up-app-env.md
@@ -30,7 +30,7 @@ Depending on the value of `has_database` in the [app-config module](/infra/app/a
 
 ## 2. Build and publish the application to the application build repository
 
-Before creating the application resources, you'll need to first build and publish at least one image to the application build repository. 
+Before creating the application resources, you'll need to first build and publish at least one image to the application build repository.
 
 There are two ways to do this:
 
@@ -38,8 +38,8 @@ There are two ways to do this:
 1. Alternatively, run the following from the root directory. This option can take much longer than the GitHub workflow, depending on your machine's architecture.
 
     ```bash
-    make release-build
-    make release-publish
+    make release-build APP_NAME=app
+    make release-publish APP_NAME=app
     ```
 
 Copy the image tag name that was published. You'll need this in the next step.
@@ -54,6 +54,6 @@ TF_CLI_ARGS_apply="-var=image_tag=<IMAGE_TAG>" make infra-update-app-service APP
 
 ## 4. Configure monitoring alerts
 
-Configure email alerts, external incident management service integration and additional Cloudwatch Alerts. 
+Configure email alerts, external incident management service integration and additional Cloudwatch Alerts.
 [Configure monitoring module](./set-up-monitoring-alerts.md)
 


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.

- Removed a Makefile comment
- Updated documentation

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

The Makefile no longer defines `APP_NAME`, so the comment is no longer correct. Running `make infra-update-app-service` also prints out the incorrect comment:

```
$ TF_CLI_ARGS_apply="-var=image_tag=58d85d736f36d503035e5c526e1df5cbf512dc44" make infra-update-app-service APP_NAME=app ENVIRONMENT=dev
# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
terraform -chdir="infra/app/service" init -input=false -reconfigure -backend-config="dev.s3.tfbackend"

Initializing the backend...

<etc>
```

Updated the `set-up-app-env.md` documentation to reflect that you need to define `APP_NAME`

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

N/A