### PR TITLE
Use targeted apply when enabling force_destroy

### DIFF
--- a/template-only-bin/destroy-app-service.sh
+++ b/template-only-bin/destroy-app-service.sh
@@ -11,6 +11,6 @@ cd infra/app/service
 
 terraform init -reconfigure -backend-config=$BACKEND_CONFIG_FILE
 
-terraform apply -auto-approve -var="environment_name=dev"
+terraform apply -auto-approve -target="module.service.aws_s3_bucket.access_logs" -var="environment_name=dev"
 
 terraform destroy -auto-approve -var="environment_name=dev"


### PR DESCRIPTION
## Ticket

Resolves #470 

## Changes

see title

## Context for reviewers

@shawnvanderjagt pointed out that when there's an error in the service layer's apply, then the subsequent apply to enable force_destroy will also fail, causing the service layer to not properly cleanup. This change does something slightly different than what Shawn suggested in his ticket but should be a similar level of improvement. Rather than move the force_destroy enabling to before the service layer apply, instead use a targeted apply to enable force_destroy, which should work in most cases.

## Testing

CI should cover this change.