### PR TITLE
Create non-default VPC in network layer

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -21,6 +21,7 @@ on:
         type: choice
         options:
           - dev
+          - staging
           - prod
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,9 @@ infra-set-up-account: ## Configure and create resources for current AWS profile 
 	@:$(call check_defined, ACCOUNT_NAME, human readable name for account e.g. "prod" or the AWS account alias)
 	./bin/set-up-current-account.sh $(ACCOUNT_NAME)
 
-infra-configure-network: ## Configure default network
-	./bin/create-tfbackend.sh infra/networks default
+infra-configure-network: ## Configure network $NETWORK_NAME
+	@:$(call check_defined, NETWORK_NAME, the name of the network in /infra/networks)
+	./bin/create-tfbackend.sh infra/networks $(NETWORK_NAME)
 
 infra-configure-app-build-repository: ## Configure infra/$APP_NAME/build-repository tfbackend and tfvars files
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
@@ -90,8 +91,10 @@ infra-configure-app-service: ## Configure infra/$APP_NAME/service module's tfbac
 infra-update-current-account: ## Update infra resources for current AWS profile
 	./bin/terraform-init-and-apply.sh infra/accounts `./bin/current-account-config-name.sh`
 
-infra-update-network: ## Update default network
-	./bin/terraform-init-and-apply.sh infra/networks default
+infra-update-network: ## Update network
+	@:$(call check_defined, NETWORK_NAME, the name of the network in /infra/networks)
+	terraform -chdir="infra/networks" init -input=false -reconfigure -backend-config="$(NETWORK_NAME).s3.tfbackend"
+	terraform -chdir="infra/networks" apply -var="network_name=$(NETWORK_NAME)"
 
 infra-update-app-build-repository: ## Create or update $APP_NAME's build repository
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/docs/infra/set-up-app-env.md
+++ b/docs/infra/set-up-app-env.md
@@ -10,7 +10,7 @@ Before setting up the application's environments you'll need to have:
 
 1. [A compatible application in the app folder](https://github.com/navapbc/template-infra/blob/main/template-only-docs/application-requirements.md)
 2. [Configure the app](/infra/app/app-config/main.tf). Make sure you update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with.
-3. (If the application has a database) [Set up the network with VPC endpoints required for the database](./set-up-network.md)
+3. [Create a nondefault VPC to be used by the application](./set-up-network.md)
 4. (If the application has a database) [Set up the database for the application](./set-up-database.md)
 5. (If you have an incident management service) [Set up monitoring](./set-up-monitoring-alerts.md)
 6. [Set up the application build repository](./set-up-app-build-repository.md)

--- a/docs/infra/set-up-network.md
+++ b/docs/infra/set-up-network.md
@@ -1,21 +1,25 @@
 # Set up network
 
-The network setup process will:
+The network setup process will configure and deploy network resources needed by other modules. In particular, it will:
 
-1. Configure and deploy network resources needed by other modules. If your application has a database, it will create VPC endpoints for the AWS services needed by the database layer and a security group to contain those VPC endpoints.
+1. Create a nondefault VPC
+2. Create public subnets for publicly accessible resources such as the application load balancer, private subnets for the application service, and private subnets for the database.
+3. Create a NAT gateway for internet access from the private subnets
+4. Create VPC endpoints for the AWS services needed by ECS Fargate to fetch the container image and log to AWS CloudWatch. If your application has a database, it will also create VPC endpoints for the AWS services needed by the database layer and a security group to contain those VPC endpoints.
 
 ## Requirements
 
 Before setting up the database you'll need to have:
 
 1. [Set up the AWS account](./set-up-aws-account.md)
+2. Optionally configure the networks you want to have on your project in the [project-config module](/infra/project-config/main.tf). By default there is configuration for three networks, one for each application environment.
 
 ## 1. Configure backend
 
-To create the tfbackend file for the new application environment, run
+To create the tfbackend file for the new network, run
 
 ```bash
-make infra-configure-network
+make infra-configure-network NETWORK_NAME=<NETWORK_NAME>
 ```
 
 ## 2. Create network resources
@@ -23,5 +27,5 @@ make infra-configure-network
 Now run the following commands to create the resources. Review the terraform before confirming "yes" to apply the changes.
 
 ```bash
-make infra-update-network
+make infra-update-network NETWORK_NAME=<NETWORK_NAME>
 ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -62,10 +62,11 @@ To set up this project for the first time (aka it has never been deployed to the
 1. [Configure the project](/infra/project-config/main.tf) (These values will be used in subsequent infra setup steps to namespace resources and add infrastructure tags.)
 2. [Set up infrastructure developer tools](/docs/infra/set-up-infrastructure-tools.md)
 3. [Set up AWS account](/docs/infra/set-up-aws-account.md)
-4. [Set up the network](/docs/infra/set-up-network.md)
+4. [Set up the virtual network (VPC)](/docs/infra/set-up-network.md)
 5. For each application:
     1. [Set up application build repository](/docs/infra/set-up-app-build-repository.md)
-    2. [Set up application environment](/docs/infra/set-up-app-env.md)
+    2. [Set up application database](/docs/infra/set-up-database.md)
+    3. [Set up application environment](/docs/infra/set-up-app-env.md)
 
 ### 🆕 New developer
 

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -3,6 +3,7 @@ module "dev_config" {
   app_name                        = local.app_name
   default_region                  = module.project_config.default_region
   environment                     = "dev"
+  network_name                    = "dev"
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -11,6 +11,10 @@ output "database_config" {
   } : null
 }
 
+output "network_name" {
+  value = var.network_name
+}
+
 output "service_config" {
   value = {
     region = var.default_region

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -7,6 +7,11 @@ variable "environment" {
   type        = string
 }
 
+variable "network_name" {
+  description = "Human readable identifier of the network / VPC"
+  type        = string
+}
+
 variable "default_region" {
   description = "default region for the project"
   type        = string

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -50,7 +50,7 @@ locals {
   account_names_by_environment = {
     shared  = "dev"
     dev     = "dev"
-    staging = "staging"
+    staging = "dev"
     prod    = "prod"
   }
 }

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -3,6 +3,7 @@ module "prod_config" {
   app_name                        = local.app_name
   default_region                  = module.project_config.default_region
   environment                     = "prod"
+  network_name                    = "prod"
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/app-config/staging.tf
+++ b/infra/app/app-config/staging.tf
@@ -3,6 +3,7 @@ module "staging_config" {
   app_name                        = local.app_name
   default_region                  = module.project_config.default_region
   environment                     = "staging"
+  network_name                    = "staging"
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -1,16 +1,15 @@
-# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
-data "aws_vpc" "default" {
-  default = true
-}
-
-# TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
-data "aws_subnets" "default" {
-  filter {
-    name   = "default-for-az"
-    values = [true]
+data "aws_vpc" "network" {
+  tags = {
+    network_name = local.environment_config.network_name
   }
 }
 
+data "aws_subnets" "database" {
+  tags = {
+    network_name = local.environment_config.network_name
+    subnet_type  = "database"
+  }
+}
 
 locals {
   # The prefix key/value pair is used for Terraform Workspaces, which is useful for projects with multiple infrastructure developers.
@@ -26,6 +25,7 @@ locals {
 
   environment_config = module.app_config.environment_configs[var.environment_name]
   database_config    = local.environment_config.database_config
+  network_config     = module.project_config.network_configs[local.environment_config.network_name]
 }
 
 terraform {
@@ -66,7 +66,7 @@ data "aws_security_groups" "aws_services" {
 
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
 }
 
@@ -84,7 +84,8 @@ module "database" {
   migrator_username = local.database_config.migrator_username
   schema_name       = local.database_config.schema_name
 
-  vpc_id                         = data.aws_vpc.default.id
-  private_subnet_ids             = data.aws_subnets.default.ids
+  vpc_id                         = data.aws_vpc.network.id
+  database_subnet_group_name     = local.network_config.database_subnet_group_name
+  private_subnet_ids             = data.aws_subnets.database.ids
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 }

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -1,11 +1,13 @@
 data "aws_vpc" "network" {
   tags = {
+    project      = module.project_config.project_name
     network_name = local.environment_config.network_name
   }
 }
 
 data "aws_subnets" "database" {
   tags = {
+    project      = module.project_config.project_name
     network_name = local.environment_config.network_name
     subnet_type  = "database"
   }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -1,11 +1,13 @@
 data "aws_vpc" "network" {
   tags = {
+    project      = module.project_config.project_name
     network_name = local.environment_config.network_name
   }
 }
 
 data "aws_subnets" "public" {
   tags = {
+    project      = module.project_config.project_name
     network_name = local.environment_config.network_name
     subnet_type  = "public"
   }
@@ -13,6 +15,7 @@ data "aws_subnets" "public" {
 
 data "aws_subnets" "private" {
   tags = {
+    project      = module.project_config.project_name
     network_name = local.environment_config.network_name
     subnet_type  = "private"
   }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -1,16 +1,22 @@
-# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
-data "aws_vpc" "default" {
-  default = true
-}
-
-# TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
-data "aws_subnets" "default" {
-  filter {
-    name   = "default-for-az"
-    values = [true]
+data "aws_vpc" "network" {
+  tags = {
+    network_name = local.environment_config.network_name
   }
 }
 
+data "aws_subnets" "public" {
+  tags = {
+    network_name = local.environment_config.network_name
+    subnet_type  = "public"
+  }
+}
+
+data "aws_subnets" "private" {
+  tags = {
+    network_name = local.environment_config.network_name
+    subnet_type  = "private"
+  }
+}
 
 locals {
   # The prefix key/value pair is used for Terraform Workspaces, which is useful for projects with multiple infrastructure developers.
@@ -84,13 +90,28 @@ data "aws_ssm_parameter" "incident_management_service_integration_url" {
   name  = local.incident_management_service_integration_config.integration_url_param_name
 }
 
+data "aws_security_groups" "aws_services" {
+  filter {
+    name   = "group-name"
+    values = ["${module.project_config.aws_services_security_group_name_prefix}*"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.network.id]
+  }
+}
+
 module "service" {
   source                = "../../modules/service"
   service_name          = local.service_name
   image_repository_name = module.app_config.image_repository_name
   image_tag             = local.image_tag
-  vpc_id                = data.aws_vpc.default.id
-  subnet_ids            = data.aws_subnets.default.ids
+  vpc_id                = data.aws_vpc.network.id
+  public_subnet_ids     = data.aws_subnets.public.ids
+  private_subnet_ids    = data.aws_subnets.private.ids
+
+  aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -50,6 +50,7 @@ resource "aws_rds_cluster" "db" {
     min_capacity = 0.5
   }
 
+  db_subnet_group_name   = var.database_subnet_group_name
   vpc_security_group_ids = [aws_security_group.db.id]
 
   enabled_cloudwatch_logs_exports = ["postgresql"]

--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -63,7 +63,7 @@ resource "aws_lambda_function" "role_manager" {
 resource "terraform_data" "role_manager_python_vendor_packages" {
   triggers_replace = timestamp()
   provisioner "local-exec" {
-    command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor"
+    command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor --upgrade"
   }
 }
 

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -56,6 +56,11 @@ variable "vpc_id" {
   description = "Uniquely identifies the VPC."
 }
 
+variable "database_subnet_group_name" {
+  type        = string
+  description = "Name of database subnet group"
+}
+
 variable "private_subnet_ids" {
   type        = list(any)
   description = "list of private subnet IDs to put the role provisioner and role checker lambda functions in"

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,0 +1,30 @@
+data "aws_availability_zones" "available" {}
+
+locals {
+  vpc_cidr               = "10.0.0.0/20"
+  num_availability_zones = 3
+  availability_zones     = slice(data.aws_availability_zones.available.names, 0, local.num_availability_zones)
+}
+
+module "aws_vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = var.name
+  azs  = local.availability_zones
+  cidr = local.vpc_cidr
+
+  public_subnets             = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
+  private_subnets            = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
+  database_subnets           = ["10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24"]
+  public_subnet_tags         = { subnet_type = "public" }
+  private_subnet_tags        = { subnet_type = "private" }
+  database_subnet_tags       = { subnet_type = "database" }
+  database_subnet_group_name = var.database_subnet_group_name
+
+  enable_nat_gateway     = var.nat_gateway_config != "none" ? true : false
+  single_nat_gateway     = var.nat_gateway_config == "shared" ? true : false
+  one_nat_gateway_per_az = var.nat_gateway_config == "per_az" ? true : false
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -7,7 +7,8 @@ locals {
 }
 
 module "aws_vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.2.0"
 
   name = var.name
   azs  = local.availability_zones

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.aws_vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnets"
+  value       = module.aws_vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "Public subnets"
+  value       = module.aws_vpc.private_subnets
+}
+
+output "database_subnet_ids" {
+  description = "Database subnets"
+  value       = module.aws_vpc.database_subnets
+}

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  type        = string
+  description = "Name to give the VPC. Will be added to the VPC under the 'network_name' tag."
+}
+
+variable "database_subnet_group_name" {
+  type        = string
+  description = "Name of the database subnet group"
+}
+
+variable "nat_gateway_config" {
+  # nat gateways are pricey, unless outgoing traffic
+  # is part of your service, one should be enough
+  # (i.e. to allow your app to fetch some resources on startup)
+  type        = string
+  default     = "none"
+  description = "How many NAT gateways (which can be pricey) to create. None, a single one that is shared across all subnets, one per availability zone, or one per private subnet"
+  validation {
+    condition     = contains(["none", "shared", "per_az", "per_subnet"], var.nat_gateway_config)
+    error_message = "Allowed values for nat_gateway_config are 'none', 'shared', 'per_az', 'per_subnet'"
+  }
+}

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -9,7 +9,7 @@ resource "aws_lb" "alb" {
   idle_timeout    = "120"
   internal        = false
   security_groups = [aws_security_group.alb.id]
-  subnets         = var.subnet_ids
+  subnets         = var.public_subnet_ids
 
   # TODO(https://github.com/navapbc/template-infra/issues/163) Implement HTTPS
   # checkov:skip=CKV2_AWS_20:Redirect HTTP to HTTPS as part of implementing HTTPS support

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -49,8 +49,6 @@ resource "aws_ecs_service" "app" {
   }
 
   network_configuration {
-    # TODO(https://github.com/navapbc/template-infra/issues/152) set assign_public_ip = false after using private subnets
-    # checkov:skip=CKV_AWS_333:Switch to using private subnets
     assign_public_ip = false
     subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.app.id]

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -51,8 +51,8 @@ resource "aws_ecs_service" "app" {
   network_configuration {
     # TODO(https://github.com/navapbc/template-infra/issues/152) set assign_public_ip = false after using private subnets
     # checkov:skip=CKV_AWS_333:Switch to using private subnets
-    assign_public_ip = true
-    subnets          = var.subnet_ids
+    assign_public_ip = false
+    subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.app.id]
   }
 

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -49,20 +49,32 @@ resource "aws_security_group" "app" {
   lifecycle {
     create_before_destroy = true
   }
+}
 
-  ingress {
-    description     = "Allow HTTP traffic to application container port"
-    protocol        = "tcp"
-    from_port       = var.container_port
-    to_port         = var.container_port
-    security_groups = [aws_security_group.alb.id]
-  }
+resource "aws_vpc_security_group_egress_rule" "service_egress_to_all" {
+  security_group_id = aws_security_group.app.id
+  description       = "Allow all outgoing traffic from application"
 
-  egress {
-    description = "Allow all outgoing traffic from application"
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  ip_protocol = "-1"
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "service_ingress_from_load_balancer" {
+  security_group_id = aws_security_group.app.id
+  description       = "Allow HTTP traffic to application container port"
+
+  from_port                    = var.container_port
+  to_port                      = var.container_port
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_ingress_from_service" {
+  security_group_id = var.aws_services_security_group_id
+  description       = "Allow inbound requests to VPC endpoints from role manager"
+
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.app.id
 }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -46,9 +46,19 @@ variable "vpc_id" {
   description = "Uniquely identifies the VPC."
 }
 
-variable "subnet_ids" {
+variable "public_subnet_ids" {
   type        = list(any)
-  description = "Private subnet id from vpc module"
+  description = "Public subnet ids in VPC"
+}
+
+variable "private_subnet_ids" {
+  type        = list(any)
+  description = "Private subnet ids in VPC"
+}
+
+variable "aws_services_security_group_id" {
+  type        = string
+  description = "Security group ID for VPC endpoints that access AWS Services"
 }
 
 variable "extra_environment_variables" {

--- a/infra/networks/variables.tf
+++ b/infra/networks/variables.tf
@@ -1,0 +1,4 @@
+variable "network_name" {
+  type        = string
+  description = "Human readable identifier for the VPC"
+}

--- a/infra/project-config/main.tf
+++ b/infra/project-config/main.tf
@@ -17,4 +17,10 @@ locals {
   github_actions_role_name = "${local.project_name}-github-actions"
 
   aws_services_security_group_name_prefix = "aws-service-vpc-endpoints"
+
+  network_configs = {
+    dev     = { database_subnet_group_name = "dev" }
+    staging = { database_subnet_group_name = "staging" }
+    prod    = { database_subnet_group_name = "prod" }
+  }
 }

--- a/infra/project-config/outputs.tf
+++ b/infra/project-config/outputs.tf
@@ -38,3 +38,7 @@ output "github_actions_role_name" {
 output "aws_services_security_group_name_prefix" {
   value = local.aws_services_security_group_name_prefix
 }
+
+output "network_configs" {
+  value = local.network_configs
+}

--- a/template-only-bin/destroy-network.sh
+++ b/template-only-bin/destroy-network.sh
@@ -9,4 +9,4 @@ cd infra/networks
 
 terraform init -reconfigure -backend-config=$BACKEND_CONFIG_FILE
 
-terraform destroy -auto-approve
+terraform destroy -auto-approve -var="network_name=dev"

--- a/template-only-bin/destroy-network.sh
+++ b/template-only-bin/destroy-network.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 
 BACKEND_CONFIG_FILE="dev.s3.tfbackend"
 
-cd infra/app/build-repository
+cd infra/networks
 
 terraform init -reconfigure -backend-config=$BACKEND_CONFIG_FILE
 

--- a/template-only-bin/destroy-network.sh
+++ b/template-only-bin/destroy-network.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Do not use this script on your project. This script is only used for testing
+# the platform bootstrap process.
+set -euxo pipefail
+
+BACKEND_CONFIG_FILE="dev.s3.tfbackend"
+
+cd infra/app/build-repository
+
+terraform init -reconfigure -backend-config=$BACKEND_CONFIG_FILE
+
+terraform destroy -auto-approve

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -24,7 +24,7 @@ func TestSetUpAccount(t *testing.T) {
 	SetUpAccount(t)
 
 	t.Run("ValidateAccount", ValidateAccount)
-	t.Run("TestBuildRepository", SubtestBuildRepository)
+	t.Run("TestNetwork", SubtestNetwork)
 }
 
 func ValidateAccount(t *testing.T) {
@@ -33,6 +33,13 @@ func ValidateAccount(t *testing.T) {
 	region := "us-east-1"
 	ValidateAccountBackend(t, region, projectName)
 	ValidateGithubActionsAuth(t, accountId, projectName)
+}
+
+func SubtestNetwork(t *testing.T) {
+	defer TeardownNetwork(t)
+	SetUpNetwork(t)
+
+	t.Run("TestBuildRepository", SubtestBuildRepository)
 }
 
 func SubtestBuildRepository(t *testing.T) {
@@ -65,6 +72,21 @@ func SetUpAccount(t *testing.T) {
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"infra-set-up-account", "ACCOUNT_NAME=prod"},
+		WorkingDir: "../",
+	})
+	fmt.Println("::endgroup::")
+}
+
+func SetUpNetwork(t *testing.T) {
+	fmt.Println("::group::Setting up network")
+	shell.RunCommand(t, shell.Command{
+		Command:    "make",
+		Args:       []string{"infra-configure-network", "NETWORK_NAME=dev"},
+		WorkingDir: "../",
+	})
+	shell.RunCommand(t, shell.Command{
+		Command:    "make",
+		Args:       []string{"infra-update-network", "NETWORK_NAME=dev"},
 		WorkingDir: "../",
 	})
 	fmt.Println("::endgroup::")
@@ -182,6 +204,16 @@ func TeardownAccount(t *testing.T) {
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"-f", "template-only.mak", "destroy-account"},
+		WorkingDir: "../",
+	})
+	fmt.Println("::endgroup::")
+}
+
+func TeardownNetwork(t *testing.T) {
+	fmt.Println("::group::Destroying network resources")
+	shell.RunCommand(t, shell.Command{
+		Command:    "make",
+		Args:       []string{"-f", "template-only.mak", "destroy-network"},
 		WorkingDir: "../",
 	})
 	fmt.Println("::endgroup::")

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -78,7 +78,7 @@ func SetUpAccount(t *testing.T) {
 }
 
 func SetUpNetwork(t *testing.T) {
-	fmt.Println("::group::Setting up network")
+	fmt.Println("::group::Creating network resources")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"infra-configure-network", "NETWORK_NAME=dev"},

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -87,6 +87,7 @@ func SetUpNetwork(t *testing.T) {
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
 		Args:       []string{"infra-update-network", "NETWORK_NAME=dev"},
+		Env:        map[string]string{"TF_CLI_ARGS_apply": "-input=false -auto-approve"},
 		WorkingDir: "../",
 	})
 	fmt.Println("::endgroup::")

--- a/template-only.mak
+++ b/template-only.mak
@@ -39,5 +39,8 @@ destroy-app-service:
 destroy-app-build-repository:
 	./template-only-bin/destroy-app-build-repository.sh
 
+destroy-network:
+	./template-only-bin/destroy-network.sh
+
 destroy-account:
 	./template-only-bin/destroy-account.sh


### PR DESCRIPTION
## Ticket

Resolves #152 

## Changes

* Add network configuration object in `project-config` mapping network names to network-specific configs
  * Currently the only configurable thing is the name of the database subnet group. Everything else is hardcoded to use defaults
* Add `infra/modules/network` module that creates a nondefault VPC with a basic default configuration that contains:
  * 3 availability zones
  * 3 public subnets to be used by the load balancer
  * 3 private subnets to be used by the application layer
  * 3 database subnets to be used by the database layer
  * database subnet group containing the database subnets to be used by Amazon RDS Aurora
  * optional NAT gateway configurations
* Modify the network layer (`infra/networks/main.tf`):
  * Call `infra/modules/network` to create non-default VPC
  * Add VPC endpoints that are needed for ECS Fargate to be able to fetch ECR images and log to CloudWatch
* Add `network_name` property to the application environment config (env-config) to map environments to networks
* Modify database and service layers to reference the network given by `environment_config.network_name`. This is done using the `network_name` AWS tag. Also reference the appropriate subnets (public and private subnets for the service layer and database subnets for the database layer) by using the `network_name` and `network_type` tags.
* Modify infra/modules/service to accept two lists of subnets rather than one, a list of public subnets for the load balancer and a list of private subnets for the service
* Add egress rule from service to VPC endpoints

## Context for reviewers

It turns out we needed nondefault VPC sooner than realized so this is a bit of a rushed implementation of nondefault VPC that follows the [WIP VPC tech spec](https://github.com/navapbc/template-infra/pull/489/files?short_path=f638011#diff-f638011420c2795cf8240840b4d317aae7b784b871105fb50c43ce4610e180eb).

Notably, in the default implementation we added a single NAT Gateway which is needed by ECS Fargate to start up the ECS task. It might be possible to achieve this without a NAT Gateway but that will take additional investigation.

## Testing

Developed and tested on platform-test in https://github.com/navapbc/platform-test/pull/72