### PR TITLE
Remove link to live running app.

### DIFF
--- a/template-only-docs/application-requirements.md
+++ b/template-only-docs/application-requirements.md
@@ -22,7 +22,7 @@ If your application needs a database, it must also:
 
 ## Example Application
 
-The infra template includes an example "hello, world" application that works with the template. This application is fully deployed and can be viewed at the endpoint <http://app-dev-459811935.us-east-1.elb.amazonaws.com/>. The source code for this test application is at <https://github.com/navapbc/platform-test>.
+The infra template includes an example "hello, world" application that works with the template. The source code for this test application is at <https://github.com/navapbc/platform-test>. This application is fully deployed. Please check the source repo for the current URL.
 
 ## Template Applications
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

* Remove link to live running test app. This link is prone to breaking and the updated one can be found in the repo where the source code lives.

## Context for reviewers

[Slack thread with some discussion](https://nava.slack.com/archives/C03G1SWD9H7/p1702049486379949).

## Testing

Trivial doc change. I believe existing linters are adequate testing.
