### PR TITLE
Remove NAT gateway

### DIFF
--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -63,7 +63,12 @@ module "network" {
   source                     = "../modules/network"
   name                       = var.network_name
   database_subnet_group_name = local.network_config.database_subnet_group_name
-  nat_gateway_config         = "shared"
+  nat_gateway_config         = "none"
+}
+
+data "aws_route_table" "private" {
+  count     = length(module.network.private_subnet_ids)
+  subnet_id = module.network.private_subnet_ids[count.index]
 }
 
 # VPC Endpoints for accessing AWS Services
@@ -95,4 +100,5 @@ resource "aws_vpc_endpoint" "aws_service" {
   security_group_ids  = each.key == "s3" ? null : [aws_security_group.aws_services[0].id]
   subnet_ids          = each.key == "s3" ? null : module.network.private_subnet_ids
   private_dns_enabled = each.key == "s3" ? null : true
+  route_table_ids     = each.key == "s3" ? data.aws_route_table.private[*].id : null
 }


### PR DESCRIPTION
## Ticket

N/A

## Changes

* Add route table associations for S3 Gateway VPC endpoint
* Remove NAT gateway

## Context

When implementing non-default VPC in #72, we were running into issues where the ECS cluster would timeout when fetching the container image from ECR. Due to time pressure, we added a NAT gateway as a workaround, which bypasses the networking issues.

The issue was that the S3 Gateway VPC endpoint did not have the route table associations it needed in the route tables for the private subnets. This change adds the required route table associations and removes the NAT gateway that was there as a workaround.

## Testing

Developed and tested in platform-test on https://github.com/navapbc/platform-test/pull/73