### PR TITLE
Update markdown linter name and execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ __check_defined = \
 	infra-configure-network \
 	infra-format \
 	infra-lint \
-	infra-lint-markdown \
 	infra-lint-scripts \
 	infra-lint-terraform \
 	infra-lint-workflows \
@@ -52,6 +51,7 @@ __check_defined = \
 	infra-update-current-account \
 	infra-update-network \
 	infra-validate-modules \
+	lint-markdown \
 	release-build \
 	release-deploy \
 	release-image-name \
@@ -140,9 +140,9 @@ infra-check-compliance-checkov: ## Run checkov compliance checks
 infra-check-compliance-tfsec: ## Run tfsec compliance checks
 	tfsec infra
 
-infra-lint: infra-lint-markdown infra-lint-scripts infra-lint-terraform infra-lint-workflows ## Lint infra code
+infra-lint: lint-markdown infra-lint-scripts infra-lint-terraform infra-lint-workflows ## Lint infra code
 
-infra-lint-markdown: ## Lint Markdown docs for broken links
+lint-markdown: ## Lint Markdown docs for broken links
 	./bin/lint-markdown.sh
 
 infra-lint-scripts: ## Lint shell scripts

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,6 @@ infra-check-compliance-tfsec: ## Run tfsec compliance checks
 
 infra-lint: lint-markdown infra-lint-scripts infra-lint-terraform infra-lint-workflows ## Lint infra code
 
-lint-markdown: ## Lint Markdown docs for broken links
-	./bin/lint-markdown.sh
-
 infra-lint-scripts: ## Lint shell scripts
 	shellcheck bin/**
 
@@ -159,6 +156,9 @@ infra-format: ## Format infra code
 
 infra-test-service: ## Run service layer infra test suite
 	cd infra/test && go test -run TestService -v -timeout 30m
+
+lint-markdown: ## Lint Markdown docs for broken links
+	./bin/lint-markdown.sh
 
 ########################
 ## Release Management ##

--- a/bin/lint-markdown.sh
+++ b/bin/lint-markdown.sh
@@ -15,4 +15,4 @@ LINK_CHECK_CONFIG=".github/workflows/markdownlint-config.json"
 
 # Recursively find all markdown files (*.md) in this directory. Pass them in as args to the lint
 # command using the handy `xargs` command.
-find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check --config $LINK_CHECK_CONFIG
+find . -name \*.md -print0 | xargs -0 -n1 npx markdown-link-check --config $LINK_CHECK_CONFIG

--- a/docs/infra/set-up-infrastructure-tools.md
+++ b/docs/infra/set-up-infrastructure-tools.md
@@ -51,10 +51,9 @@ We have several optional utilities for running infrastructure linters locally. T
 * [markdown-link-check](https://github.com/tcort/markdown-link-check)
 
 ```bash
-
 brew install shellcheck
 brew install actionlint
-npm install -g markdown-link-check
+make infra-lint
 ```
 
 ## AWS Authentication


### PR DESCRIPTION
## Changes

- Renamed the Make target from `infra-lint-markdown` to `lint-markdown`, since when a project copies templates into a repo, this linter runs across the entire repo and not just the `infra` directory
- Use `npx` to execute `markdown-link-check` which will automatically offer to install the package if it's missing. `npx` is bundled alongside `npm`

## Testing

![CleanShot 2023-12-13 at 15 57 23@2x](https://github.com/navapbc/template-infra/assets/371943/b2b27382-2b0f-49d9-8529-9367a6534088)
