### PR TITLE
Ignore linting localhost Markdown links

### DIFF
--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -2,6 +2,12 @@
     "ignorePatterns" : [
         {
             "pattern": "0005-example.md"
+        },
+        {
+            "pattern": "localhost"
+        },
+        {
+            "pattern": "127.0.0.1"
         }
     ],
     "replacementPatterns": [


### PR DESCRIPTION
## Context for reviewers

Some templates include links to localhost when communicating where something can be viewed when the application is running locally.

## Testing

![CleanShot 2023-12-13 at 16 13 31@2x](https://github.com/navapbc/template-infra/assets/371943/a184d8a2-273d-483d-9a4a-9bd8a6ebfe2a)

