### PR TITLE
Add storage module for uploading documents

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY db-migrate /usr/bin/
 COPY migrations.sql /app/
-COPY app.py /app/
+COPY *.py /app/
 
 # Set the host to 0.0.0.0 to make the server available external
 # to the Docker container that it's running in.

--- a/app/app.py
+++ b/app/app.py
@@ -1,16 +1,19 @@
 import logging
 import os
+from datetime import datetime
 
-import boto3
 from flask import Flask
-import psycopg
-import psycopg.conninfo
+
+from db import get_db_connection
+from feature_flags import is_feature_enabled
+from storage import create_upload_url
 
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 app = Flask(__name__)
+
 
 def main():
     host = os.environ.get("HOST")
@@ -30,6 +33,7 @@ def health():
     conn.execute("SELECT 1")
     return "OK"
 
+
 @app.route("/migrations")
 def migrations():
     conn = get_db_connection()
@@ -41,32 +45,6 @@ def migrations():
         last_migration_date = cur.fetchone()[0]
         return f"Last migration on {last_migration_date}"
 
-def get_db_token(host, port, user):
-    # gets the credentials from .aws/credentials
-    logger.info("Getting RDS client")
-    client = boto3.client("rds")
-
-    logger.info("Generating auth token for user %s", user)
-    token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=user)
-    return token
-
-
-def get_db_connection():
-    host = os.environ.get("DB_HOST")
-    port = os.environ.get("DB_PORT")
-    user = os.environ.get("DB_USER")
-
-    # Tokens last for 15 minutes, so normally you wouldn't need to generate
-    # an auth token every time you create a new connection, but we do that
-    # here to keep the example app simple.
-    password = get_db_token(host, port, user)
-    dbname = os.environ.get("DB_NAME")
-
-    conninfo = psycopg.conninfo.make_conninfo(host=host, port=port, user=user, password=password, dbname=dbname)
-
-    conn = psycopg.connect(conninfo)
-    return conn
-
 
 @app.route("/feature-flags")
 def feature_flags():
@@ -76,18 +54,18 @@ def feature_flags():
     return f"<p>Feature foo is {foo_status}</p><p>Feature bar is {bar_status}</p>"
 
 
-def is_feature_enabled(feature_name: str) -> bool:
-    feature_flags_project_name = os.environ.get("FEATURE_FLAGS_PROJECT")
-
-    logger.info("Getting Evidently client")
-    client = boto3.client("evidently")
-
-    response = client.evaluate_feature(
-        entityId="anonymous",
-        feature=feature_name,
-        project=feature_flags_project_name,
+@app.route("/document-upload")
+def document_upload():
+    path = f"uploads/{datetime.now().date()}/${{filename}}"
+    upload_url, fields = create_upload_url(path)
+    additional_fields = "".join(
+        [
+            f'<input type="hidden" name="{name}" value="{value}">'
+            for name, value in fields.items()
+        ]
     )
-    return response["value"]["boolValue"]
+    # Note: Additional fields should come first before the file and submit button
+    return f'<form method="post" action="{upload_url}" enctype="multipart/form-data">{additional_fields}<input type="file" name="file"><input type="submit"></form>'
 
 
 if __name__ == "__main__":

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,37 @@
+import logging
+import os
+
+import boto3
+import psycopg
+import psycopg.conninfo
+
+logger = logging.getLogger()
+
+
+def get_db_connection():
+    host = os.environ.get("DB_HOST")
+    port = os.environ.get("DB_PORT")
+    user = os.environ.get("DB_USER")
+
+    # Tokens last for 15 minutes, so normally you wouldn't need to generate
+    # an auth token every time you create a new connection, but we do that
+    # here to keep the example app simple.
+    password = get_db_token(host, port, user)
+    dbname = os.environ.get("DB_NAME")
+
+    conninfo = psycopg.conninfo.make_conninfo(
+        host=host, port=port, user=user, password=password, dbname=dbname
+    )
+
+    conn = psycopg.connect(conninfo)
+    return conn
+
+
+def get_db_token(host, port, user):
+    # gets the credentials from .aws/credentials
+    logger.info("Getting RDS client")
+    client = boto3.client("rds")
+
+    logger.info("Generating auth token for user %s", user)
+    token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=user)
+    return token

--- a/app/feature_flags.py
+++ b/app/feature_flags.py
@@ -1,0 +1,20 @@
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger()
+
+
+def is_feature_enabled(feature_name: str) -> bool:
+    feature_flags_project_name = os.environ.get("FEATURE_FLAGS_PROJECT")
+
+    logger.info("Getting Evidently client")
+    client = boto3.client("evidently")
+
+    response = client.evaluate_feature(
+        entityId="anonymous",
+        feature=feature_name,
+        project=feature_flags_project_name,
+    )
+    return response["value"]["boolValue"]

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,15 @@
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger()
+
+
+def create_upload_url(path):
+    bucket_name = os.environ.get("BUCKET_NAME")
+
+    s3_client = boto3.client("s3")
+    logger.info("Generating presigned POST URL")
+    response = s3_client.generate_presigned_post(bucket_name, path)
+    return response["url"], response["fields"]

--- a/app/storage.py
+++ b/app/storage.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import boto3
+from botocore.client import Config
 
 logger = logging.getLogger()
 
@@ -9,7 +10,9 @@ logger = logging.getLogger()
 def create_upload_url(path):
     bucket_name = os.environ.get("BUCKET_NAME")
 
-    s3_client = boto3.client("s3")
+    # Manually specify signature version 4 which is required since the bucket is encrypted with KMS.
+    # By default presigned URLs use signature version 2 to be backwards compatible
+    s3_client = boto3.client("s3", config=Config(signature_version="s3v4"))
     logger.info("Generating presigned POST URL")
     response = s3_client.generate_presigned_post(bucket_name, path)
     return response["url"], response["fields"]

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -35,7 +35,8 @@ locals {
 
   service_name = "${local.prefix}${module.app_config.app_name}-${var.environment_name}"
 
-  bucket_name = "${local.prefix}${module.project_config.project_name}-${local.service_name}-storage"
+  # Include project name in bucket name since buckets need to be globally unique across AWS
+  bucket_name = "${local.prefix}${module.project_config.project_name}-${module.app_config.app_name}-${var.environment_name}"
 
   environment_config                             = module.app_config.environment_configs[var.environment_name]
   service_config                                 = local.environment_config.service_config

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -35,6 +35,8 @@ locals {
 
   service_name = "${local.prefix}${module.app_config.app_name}-${var.environment_name}"
 
+  bucket_name = "${local.prefix}${module.project_config.project_name}-${local.service_name}-storage"
+
   environment_config                             = module.app_config.environment_configs[var.environment_name]
   service_config                                 = local.environment_config.service_config
   database_config                                = local.environment_config.database_config
@@ -130,10 +132,12 @@ module "service" {
   } : null
 
   extra_environment_variables = [
-    { name : "FEATURE_FLAGS_PROJECT", value : module.feature_flags.evidently_project_name }
+    { name : "FEATURE_FLAGS_PROJECT", value : module.feature_flags.evidently_project_name },
+    { name : "BUCKET_NAME", value : local.bucket_name }
   ]
   extra_policies = {
-    "feature_flags_access" = module.feature_flags.access_policy_arn
+    feature_flags_access = module.feature_flags.access_policy_arn,
+    storage_access       = module.storage.access_policy_arn
   }
 }
 
@@ -152,4 +156,9 @@ module "feature_flags" {
   source        = "../../modules/feature-flags"
   service_name  = local.service_name
   feature_flags = module.app_config.feature_flags
+}
+
+module "storage" {
+  source = "../../modules/storage"
+  name   = local.bucket_name
 }

--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -35,25 +35,24 @@ data "aws_iam_policy_document" "storage" {
 # Create policy for read/write access
 # Attach this policy to roles that need access to the bucket
 resource "aws_iam_policy" "storage_access" {
-  name = "${var.name}-access"
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Action = [
-          "s3:DeleteObject",
-          "s3:GetObject",
-          "s3:HeadObject",
-          "s3:PutObject",
-        ],
-        Effect   = "Allow",
-        Resource = ["arn:aws:s3:::${var.name}/*"]
-      },
-      {
-        Action   = "kms:GenerateDataKey"
-        Effect   = "Allow"
-        Resource = aws_kms_key.storage.arn
-      }
+  name   = "${var.name}-access"
+  policy = data.aws_iam_policy_document.storage_access.json
+}
+
+data "aws_iam_policy_document" "storage_access" {
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:GetObjectAttributes",
+      "s3:PutObject",
     ]
-  })
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::${var.name}/*"]
+  }
+  statement {
+    actions   = ["kms:GenerateDataKey"]
+    effect    = "Allow"
+    resources = [aws_kms_key.storage.arn]
+  }
 }

--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -1,0 +1,29 @@
+# Block public access
+resource "aws_s3_bucket_public_access_block" "storage" {
+  bucket = aws_s3_bucket.storage.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Create policy for read/write access
+# Attach this policy to roles that need access to the bucket
+resource "aws_iam_policy" "storage_access" {
+  name = "${var.name}-access"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
+        ],
+        Effect   = "Allow",
+        Resource = ["arn:aws:s3:::${var.name}/*"]
+      }
+    ]
+  })
+}

--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -19,6 +19,7 @@ resource "aws_iam_policy" "storage_access" {
         Action = [
           "s3:DeleteObject",
           "s3:GetObject",
+          "s3:HeadObject",
           "s3:PutObject",
         ],
         Effect   = "Allow",

--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -8,6 +8,30 @@ resource "aws_s3_bucket_public_access_block" "storage" {
   restrict_public_buckets = true
 }
 
+# Bucket policy that requires HTTPS
+resource "aws_s3_bucket_policy" "storage" {
+  bucket = aws_s3_bucket.storage.id
+  policy = data.aws_iam_policy_document.storage.json
+}
+
+data "aws_iam_policy_document" "storage" {
+  statement {
+    sid       = "RestrictToTLSRequestsOnly"
+    effect    = "Deny"
+    actions   = ["s3:*"]
+    resources = [aws_s3_bucket.storage.arn]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
 # Create policy for read/write access
 # Attach this policy to roles that need access to the bucket
 resource "aws_iam_policy" "storage_access" {

--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -23,6 +23,11 @@ resource "aws_iam_policy" "storage_access" {
         ],
         Effect   = "Allow",
         Resource = ["arn:aws:s3:::${var.name}/*"]
+      },
+      {
+        Action   = "kms:GenerateDataKey"
+        Effect   = "Allow"
+        Resource = aws_kms_key.storage.arn
       }
     ]
   })

--- a/infra/modules/storage/encryption.tf
+++ b/infra/modules/storage/encryption.tf
@@ -1,0 +1,18 @@
+resource "aws_kms_key" "storage" {
+  description = "KMS key for bucket ${var.name}"
+  # The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key.
+  deletion_window_in_days = "10"
+  # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
+  enable_key_rotation = "true"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "storage" {
+  bucket = aws_s3_bucket.storage.id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.storage.arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}

--- a/infra/modules/storage/events.tf
+++ b/infra/modules/storage/events.tf
@@ -1,0 +1,7 @@
+# Tell S3 to publish events to EventBridge. Subscribers can then subscribe
+# to these events to in an event-based architecture.
+# See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-mapping-troubleshooting.html
+resource "aws_s3_bucket_notification" "storage" {
+  bucket      = aws_s3_bucket.storage.id
+  eventbridge = true
+}

--- a/infra/modules/storage/events.tf
+++ b/infra/modules/storage/events.tf
@@ -1,5 +1,5 @@
 # Tell S3 to publish events to EventBridge. Subscribers can then subscribe
-# to these events to in an event-based architecture.
+# to these events in an event-based architecture.
 # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-mapping-troubleshooting.html
 resource "aws_s3_bucket_notification" "storage" {
   bucket      = aws_s3_bucket.storage.id

--- a/infra/modules/storage/lifecycle.tf
+++ b/infra/modules/storage/lifecycle.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket_lifecycle_configuration" "storage" {
+  bucket = aws_s3_bucket.storage.id
+
+  rule {
+    id     = "AbortIncompleteUpload"
+    status = "Enabled"
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "storage" {
+  bucket        = var.name
+  force_destroy = false
+}

--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -1,4 +1,10 @@
 resource "aws_s3_bucket" "storage" {
   bucket        = var.name
   force_destroy = false
+
+  # checkov:skip=CKV_AWS_18:TODO(https://github.com/navapbc/template-infra/issues/507) Implement access logging
+
+  # checkov:skip=CKV_AWS_144:Cross region replication not required by default
+  # checkov:skip=CKV2_AWS_62:S3 bucket does not need notifications enabled
+  # checkov:skip=CKV_AWS_21:Bucket versioning is not needed
 }

--- a/infra/modules/storage/outputs.tf
+++ b/infra/modules/storage/outputs.tf
@@ -1,0 +1,3 @@
+output "access_policy_arn" {
+  value = aws_iam_policy.storage_access.arn
+}

--- a/infra/modules/storage/variables.tf
+++ b/infra/modules/storage/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  type        = string
+  description = "Name of the AWS S3 bucket. Needs to be globally unique across all regions."
+}

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -122,6 +122,15 @@ func EnableDestroyService(t *testing.T, terraformOptions *terraform.Options) {
 		},
 		WorkingDir: "../../",
 	})
+	shell.RunCommand(t, shell.Command{
+		Command: "sed",
+		Args: []string{
+			"-i.bak",
+			"s/force_destroy = false/force_destroy = true/g",
+			"infra/modules/storage/main.tf",
+		},
+		WorkingDir: "../../",
+	})
 	terraform.Apply(t, terraformOptions)
 	fmt.Println("::endgroup::")
 }

--- a/template-only-bin/destroy-app-service.sh
+++ b/template-only-bin/destroy-app-service.sh
@@ -6,6 +6,7 @@ set -euxo pipefail
 BACKEND_CONFIG_FILE="dev.s3.tfbackend"
 
 sed -i.bak 's/force_destroy = false/force_destroy = true/g' infra/modules/service/access-logs.tf
+sed -i.bak 's/force_destroy = false/force_destroy = true/g' infra/modules/storage/main.tf
 
 cd infra/app/service
 


### PR DESCRIPTION
## Ticket

Resolves #508 

## Changes

* Add new module infra/modules/storage that creates a bucket for uploading documents
* Add document_upload endpoint to example app that allows a user to upload a document to the bucket
* Split example app into separate files
* Update CI infra to delete the bucket properly

## Context for reviewers

It is common for applications to need a place to store documents. The documents can be user uploaded documents to be processed by the system, or documents from other systems that are used for ETL pipelines. This change adds the bucket and an example app endpoint that leverages the bucket to upload a document.

Also, the app.py file for the example app was getting long so I split it up into separate files.

## Testing

Developed and tested on platform-test in https://github.com/navapbc/platform-test/pull/76
