### PR TITLE
Restructure template test output

### DIFF
--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -21,8 +21,7 @@ var projectName = fmt.Sprintf("plt-tst-act-%s", uniqueId)
 func TestSetUpAccount(t *testing.T) {
 	defer TeardownAccount(t)
 	SetUpProject(t, projectName)
-	SetUpAccount(t)
-
+	t.Run("SetUpAccount", SetUpAccount)
 	t.Run("ValidateAccount", ValidateAccount)
 	t.Run("TestNetwork", SubtestNetwork)
 }
@@ -37,24 +36,21 @@ func ValidateAccount(t *testing.T) {
 
 func SubtestNetwork(t *testing.T) {
 	defer TeardownNetwork(t)
-	SetUpNetwork(t)
-
+	t.Run("SetUpNetwork", SetUpNetwork)
 	t.Run("TestBuildRepository", SubtestBuildRepository)
 }
 
 func SubtestBuildRepository(t *testing.T) {
-	projectName := projectName
 	defer TeardownBuildRepository(t)
-	SetUpBuildRepository(t, projectName)
-	ValidateBuildRepository(t, projectName)
-
+	t.Run("SetUpBuildRepository", SetUpBuildRepository)
+	t.Run("ValidateBuildRepository", ValidateBuildRepository)
 	t.Run("TestDevEnvironment", SubtestDevEnvironment)
 }
 
 func SubtestDevEnvironment(t *testing.T) {
 	defer TeardownDevEnvironment(t)
-	SetUpDevEnvironment(t)
-	ValidateDevEnvironment(t)
+	t.Run("SetUpDevEnvironment", SetUpDevEnvironment)
+	t.Run("ValidateDevEnvironment", ValidateDevEnvironment)
 }
 
 func SetUpProject(t *testing.T, projectName string) {
@@ -93,7 +89,7 @@ func SetUpNetwork(t *testing.T) {
 	fmt.Println("::endgroup::")
 }
 
-func SetUpBuildRepository(t *testing.T, projectName string) {
+func SetUpBuildRepository(t *testing.T) {
 	fmt.Println("::group::Creating build repository resources")
 	shell.RunCommand(t, shell.Command{
 		Command:    "make",
@@ -156,7 +152,7 @@ func ValidateGithubActionsAuth(t *testing.T, accountId string, projectName strin
 	fmt.Println("::endgroup::")
 }
 
-func ValidateBuildRepository(t *testing.T, projectName string) {
+func ValidateBuildRepository(t *testing.T) {
 	fmt.Println("::group::Validating ability to publish build artifacts to build repository")
 
 	err := shell.RunCommandE(t, shell.Command{

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -18,12 +18,12 @@ import (
 var uniqueId = strings.ToLower(random.UniqueId())
 var projectName = fmt.Sprintf("plt-tst-act-%s", uniqueId)
 
-func TestSetUpAccount(t *testing.T) {
+func TestEndToEnd(t *testing.T) {
 	defer TeardownAccount(t)
 	SetUpProject(t, projectName)
 	t.Run("SetUpAccount", SetUpAccount)
 	t.Run("ValidateAccount", ValidateAccount)
-	t.Run("TestNetwork", SubtestNetwork)
+	t.Run("Network", SubtestNetwork)
 }
 
 func ValidateAccount(t *testing.T) {
@@ -37,14 +37,14 @@ func ValidateAccount(t *testing.T) {
 func SubtestNetwork(t *testing.T) {
 	defer TeardownNetwork(t)
 	t.Run("SetUpNetwork", SetUpNetwork)
-	t.Run("TestBuildRepository", SubtestBuildRepository)
+	t.Run("BuildRepository", SubtestBuildRepository)
 }
 
 func SubtestBuildRepository(t *testing.T) {
 	defer TeardownBuildRepository(t)
 	t.Run("SetUpBuildRepository", SetUpBuildRepository)
 	t.Run("ValidateBuildRepository", ValidateBuildRepository)
-	t.Run("TestDevEnvironment", SubtestDevEnvironment)
+	t.Run("Service", SubtestDevEnvironment)
 }
 
 func SubtestDevEnvironment(t *testing.T) {


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context & Testing

Developer experience improvement to have the summary of the template infra tests show more detail about which things passed and which failed, to make it easier to know which set of logs to dive into.

Before:
<img width="731" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/cd9f8cdd-9b1d-48bd-b112-b0b966d7681d">

After:
<img width="747" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/8690d5c6-dd77-4b82-89c8-c6ac657a10a1">
