### PR TITLE
Create resource policy for feature flags log group

### DIFF
--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -7,11 +7,13 @@ on:
   #     - main
   #   paths:
   #     - infra/*/service/**
+  #     - infra/modules/**
   #     - infra/test/**
   #     - .github/workflows/ci-infra-service.yml
   # pull_request:
   #   paths:
   #     - infra/*/service/**
+  #     - infra/modules/**
   #     - infra/test/**
   #     - .github/workflows/ci-infra-service.yml
   workflow_dispatch:

--- a/infra/modules/feature-flags/logs.tf
+++ b/infra/modules/feature-flags/logs.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 resource "aws_cloudwatch_log_group" "logs" {
   name = "feature-flags/${local.evidently_project_name}"
 
@@ -6,4 +9,39 @@ resource "aws_cloudwatch_log_group" "logs" {
   # Conservatively retain logs for 5 years.
   # Looser requirements may allow shorter retention periods
   retention_in_days = 1827
+}
+
+# Manually create policy allowing AWS services to deliver logs to this log group
+# so that the automatically created one by AWS doesn't exceed the character limit
+# see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-vended-logs-permissions
+# see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length
+resource "aws_cloudwatch_log_resource_policy" "logs" {
+  policy_name     = "/log-delivery/feature-flags/${local.evidently_project_name}-logs"
+  policy_document = data.aws_iam_policy_document.logs.json
+}
+
+data "aws_iam_policy_document" "logs" {
+  statement {
+    sid    = "AWSLogDeliveryWrite"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.logs.arn}:log-stream:*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
 }

--- a/infra/modules/feature-flags/main.tf
+++ b/infra/modules/feature-flags/main.tf
@@ -10,6 +10,9 @@ resource "aws_evidently_project" "feature_flags" {
       log_group = aws_cloudwatch_log_group.logs.name
     }
   }
+  # Make sure the resource policy is created first so that AWS doesn't try to
+  # automatically create one
+  depends_on = [aws_cloudwatch_log_resource_policy.logs]
 }
 
 resource "aws_evidently_feature" "feature_flag" {


### PR DESCRIPTION
## Ticket

Resolves #529 

## Changes

see title

## Context for reviewers

The default resource policy for log group delivery was getting way too big causing CI to fail

## Testing

Developed and tested on platform-test in https://github.com/navapbc/platform-test/pull/82