### PR TITLE
Fix accounts setup for other regions

### DIFF
--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -47,23 +47,39 @@ echo
 echo "------------------------------------------------------------------------------"
 echo "Bootstrapping the account by creating an S3 backend with minimal configuration"
 echo "------------------------------------------------------------------------------"
-echo 
+echo
 echo "Creating bucket: $TF_STATE_BUCKET_NAME"
 # For creating buckets outside of us-east-1, a LocationConstraint needs to be set
 # For creating buckets in us-east-1, LocationConstraint cannot be set
 # See https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html
-CREATE_BUCKET_CONFIGURATION=""
+CREATE_BUCKET_CONFIGURATION=("")
 if [ "$REGION" != "us-east-1" ]; then
-  CREATE_BUCKET_CONFIGURATION="--create-bucket-configuration LocationConstraint=$REGION"
+  CREATE_BUCKET_CONFIGURATION=("--create-bucket-configuration" "LocationConstraint=$REGION")
 fi
-aws s3api create-bucket --bucket "$TF_STATE_BUCKET_NAME" --region "$REGION" "$CREATE_BUCKET_CONFIGURATION" > /dev/null
+
+aws s3api create-bucket --bucket "$TF_STATE_BUCKET_NAME" --region "$REGION" "${CREATE_BUCKET_CONFIGURATION[@]}" > /dev/null
 echo
 echo "----------------------------------"
 echo "Creating rest of account resources"
 echo "----------------------------------"
-echo 
+echo
 
 cd infra/accounts
+
+# Create the OpenID Connect provider for GitHub Actions to allow GitHub Actions
+# to authenticate with AWS and manage AWS resources. We create the OIDC provider
+# via AWS CLI rather than via Terraform because we need to first check if there
+# is already an existing OpenID Connect provider for GitHub Actions. This check
+# is needed since there can only be one OpenID Connect provider per URL per AWS
+# account.
+github_arn=$(aws iam list-open-id-connect-providers | jq -r ".[] | .[] | .Arn" | grep github || echo "")
+
+if [[ -z ${github_arn} ]]; then
+  aws iam create-open-id-connect-provider \
+    --url "https://token.actions.githubusercontent.com" \
+    --client-id-list "sts.amazonaws.com" \
+    --thumbprint-list "0000000000000000000000000000000000000000"
+fi
 
 # Create the infrastructure for the terraform backend such as the S3 bucket
 # for storing tfstate files and the DynamoDB table for tfstate locks.

--- a/infra/modules/auth-github-actions/main.tf
+++ b/infra/modules/auth-github-actions/main.tf
@@ -1,15 +1,6 @@
 # Set up GitHub's OpenID Connect provider in AWS account
-resource "aws_iam_openid_connect_provider" "github" {
-  url            = "https://token.actions.githubusercontent.com"
-  client_id_list = ["sts.amazonaws.com"]
-
-  # AWS already trusts the GitHub OIDC identity provider's library of root certificate authorities
-  # so no thumbprints from intermediate certificates are needed
-  # At the time of writing (July 12, 2023), the thumbprint_list parameter
-  # is required to be a non-empty array, so we are passing an array with a dummy string that passes validation
-  # TODO(https://github.com/navapbc/template-infra/issues/350) Remove this parameter thumbprint_list is no
-  # longer required (see https://github.com/hashicorp/terraform-provider-aws/issues/32480)
-  thumbprint_list = ["0000000000000000000000000000000000000000"]
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
 }
 
 # Create IAM role for GitHub Actions
@@ -40,7 +31,7 @@ data "aws_iam_policy_document" "github_assume_role" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github.arn]
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
     }
 
     condition {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/526

## Changes

see title

## Context for reviewers

@daphnegold discovered a regression where set-up-account failed when region was not us-east-1

## Testing

Developed and tested on platform-test in https://github.com/navapbc/platform-test/pull/83