### PR TITLE
ELB deletion protection

### DIFF
--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -11,12 +11,10 @@ resource "aws_lb" "alb" {
   security_groups = [aws_security_group.alb.id]
   subnets         = var.public_subnet_ids
 
+  enable_deletion_protection = terraform.workspace == "default"
+
   # TODO(https://github.com/navapbc/template-infra/issues/163) Implement HTTPS
   # checkov:skip=CKV2_AWS_20:Redirect HTTP to HTTPS as part of implementing HTTPS support
-
-  # TODO(https://github.com/navapbc/template-infra/issues/161) Prevent deletion protection
-  # checkov:skip=CKV_AWS_150:Allow deletion until we can automate deletion for automated tests
-  # enable_deletion_protection = true
 
   # TODO(https://github.com/navapbc/template-infra/issues/165) Protect ALB with WAF
   # checkov:skip=CKV2_AWS_28:Implement WAF in issue #165

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -11,7 +11,7 @@ resource "aws_lb" "alb" {
   security_groups = [aws_security_group.alb.id]
   subnets         = var.public_subnet_ids
 
-  enable_deletion_protection = terraform.workspace == "default"
+  enable_deletion_protection = !startswith(terraform.workspace, "t-")
 
   # TODO(https://github.com/navapbc/template-infra/issues/163) Implement HTTPS
   # checkov:skip=CKV2_AWS_20:Redirect HTTP to HTTPS as part of implementing HTTPS support


### PR DESCRIPTION
## Prevent ALB Deletion for security compliance

Resolves #161 

## Changes
Use the `terraform.workspace` name to determine if this is a test environment and therefore the alb should not get deletion protection, otherwise, enable deletion protection. Terratest prefixes workspaces it createst with "t-<unique_id>" therefore we should enable deletion protection for elbs in all workspaces that do not start with `t-`

Addresses:
ELB.6 check: NIST-800 53
