### PR TITLE
Exclude node_modules subfolder for lint-markdown.sh

### DIFF
--- a/bin/lint-markdown.sh
+++ b/bin/lint-markdown.sh
@@ -13,6 +13,6 @@ cd "${SCRIPT_DIR}/.." >/dev/null || exit 1
 
 LINK_CHECK_CONFIG=".github/workflows/markdownlint-config.json"
 
-# Recursively find all markdown files (*.md) in this directory. Pass them in as args to the lint
-# command using the handy `xargs` command.
-find . -name \*.md -print0 | xargs -0 -n1 npx markdown-link-check --config $LINK_CHECK_CONFIG
+# Recursively find all markdown files (*.md) in the current directory, excluding node_modules subfolders.
+# Pass them in as args to the lint command using the handy `xargs` command.
+find . -name \*.md -not -path "*/node_modules/*" -print0 | xargs -0 -n1 npx markdown-link-check --config $LINK_CHECK_CONFIG


### PR DESCRIPTION
## Ticket

Resolves 
[lint-markdown.sh](https://github.com/navapbc/template-infra/blob/main/bin/lint-markdown.sh) unnecessarily analyzes `md` files under `node_modules/`.

## Changes

Exclude files under `*/node_modules/`  from being analyzed by adding the arguments `-not -path "*/node_modules/*"`.

## Context for reviewers

The `gaurav-nelson/github-action-markdown-link-check` action [ignores node_modules files](https://github.com/navapbc/bid-fed-va-spruce-challenge-practice3/actions/runs/7576561682/job/20635654502?pr=4#step:4:109).

## Testing

- Instantiate the `infra` and `nextjs` templates into a single repo.
- Run `npm install` for the nextjs application so that a `node_modules` subfolder is populated
- Run `bin/lint-markdown.sh` and ensure the `md` files under the `node_modules` subfolder are not analyzed
