### PR TITLE
Exclude .venv subfolder for lint-markdown.sh

### DIFF
--- a/bin/lint-markdown.sh
+++ b/bin/lint-markdown.sh
@@ -13,6 +13,6 @@ cd "${SCRIPT_DIR}/.." >/dev/null || exit 1
 
 LINK_CHECK_CONFIG=".github/workflows/markdownlint-config.json"
 
-# Recursively find all markdown files (*.md) in the current directory, excluding node_modules subfolders.
+# Recursively find all markdown files (*.md) in the current directory, excluding node_modules and .venv subfolders.
 # Pass them in as args to the lint command using the handy `xargs` command.
-find . -name \*.md -not -path "*/node_modules/*" -print0 | xargs -0 -n1 npx markdown-link-check --config $LINK_CHECK_CONFIG
+find . -name \*.md -not -path "*/node_modules/*" -not -path "*/.venv/*" -print0 | xargs -0 -n1 npx markdown-link-check --config $LINK_CHECK_CONFIG


### PR DESCRIPTION
## Ticket

Resolves [lint-markdown.sh](https://github.com/navapbc/template-infra/blob/main/bin/lint-markdown.sh) unnecessarily analyzes `md` files under `.venv/`.

## Changes

Exclude files under `*/.venv/`  from being analyzed by adding the arguments `-not -path "*/.venv/*"`.

## Context for reviewers

Similar to #543 

## Testing

- Instantiate the `infra` and `flask` templates into a single repo.
- Set up the flask application so that a `.venv` subfolder is populated
- Run `bin/lint-markdown.sh` and ensure the `md` files under the `.venv` subfolder are not analyzed
