### PR TITLE
Update terraform version

### DIFF
--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.4.6
+          terraform_version: 1.7.2
           terraform_wrapper: false
 
       - uses: actions/setup-go@v3

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -151,7 +151,7 @@ module "monitoring" {
   # Module takes service and ALB names to link all alerts with corresponding targets
   service_name                                = local.service_config.service_name
   load_balancer_arn_suffix                    = module.service.load_balancer_arn_suffix
-  incident_management_service_integration_url = module.app_config.has_incident_management_service ? data.aws_ssm_parameter.incident_management_service_integration_url[0].value : null
+  incident_management_service_integration_url = module.app_config.has_incident_management_service && !local.is_temporary ? data.aws_ssm_parameter.incident_management_service_integration_url[0].value : null
 }
 
 module "feature_flags" {


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Was seeing the following error in the ci-infra-service.yml workflow
```
Error refreshing state: unsupported checkable object kind "var"
```
From terraform docs (https://developer.hashicorp.com/terraform/language/upgrade-guides) it looks like upgrading to terraform 1.7.2 resolves this issue.

<img width="1438" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/8643001f-7ee1-4590-8b6b-5890633eab36">

## Testing

Developed and tested on platform-test in https://github.com/navapbc/platform-test/pull/86