### PR TITLE
Configure app env vars and secrets

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -69,6 +69,12 @@ def document_upload():
     return f'<form method="post" action="{upload_url}" enctype="multipart/form-data">{additional_fields}<input type="file" name="file"><input type="submit"></form>'
 
 
+@app.route("/secrets")
+def secrets():
+    secret_sauce = os.environ["SECRET_SAUCE"]
+    return f'The secret sauce is "{secret_sauce}"'
+
+
 @app.cli.command("etl", help="Run ETL job")
 @click.argument("input")
 def etl(input):

--- a/docs/infra/environment-variables-and-secrets.md
+++ b/docs/infra/environment-variables-and-secrets.md
@@ -1,0 +1,13 @@
+# Environment variables and secrets
+
+Many applications require custom environment variables for application configuration and for access to secrets. This document describes how to configure application-specific environment variables and secrets. It also describes how to override those environment variables for a specific environment.
+
+## Application-specific extra environment variables
+
+Application-specific environment variables are defined in the [environment-variables.tf](/infra/app/app-config/env-config/environment-variables.tf) file in the app-config module in a variable called `default_extra_environment_variables`. This is a map from environment variable names to the default values for those environment variables across environments.
+
+If you want to override the default values for a particular environment, you pass a `service_override_extra_environment_variables` variable to the [env-config module](/infra/app/app-config/env-config/variables.tf) in your `app-config/[environment].tf` file.
+
+## Secrets
+
+Secrets are defined in in the [environment-variables.tf](/infra/app/app-config/env-config/environment-variables.tf) file in the app-config module in a variable called `secrets`. Each secret configuration defines the environment variable name and the SSM parameter name for the secret. The SSM parameter name can include the environment, which is a way you can have different secrets for different environments.

--- a/docs/infra/environment-variables-and-secrets.md
+++ b/docs/infra/environment-variables-and-secrets.md
@@ -1,13 +1,58 @@
 # Environment variables and secrets
 
-Many applications require custom environment variables for application configuration and for access to secrets. This document describes how to configure application-specific environment variables and secrets. It also describes how to override those environment variables for a specific environment.
+Applications follow [12-factor app](https://12factor.net/) principles to [store configuration as environment variables](https://12factor.net/config). The infrastructure provides some of these environment variables automatically, such as environment variables to authenticate as the ECS task role, environment variables for database access, and environment variables for accessing document storage. However, many applications require extra custom environment variables for application configuration and for access to secrets. This document describes how to configure application-specific environment variables and secrets. It also describes how to override those environment variables for a specific environment.
 
 ## Application-specific extra environment variables
 
-Application-specific environment variables are defined in the [environment-variables.tf](/infra/app/app-config/env-config/environment-variables.tf) file in the app-config module in a variable called `default_extra_environment_variables`. This is a map from environment variable names to the default values for those environment variables across environments.
+Applications may need application specific configuration as environment variables. Examples may includes things like `WORKER_THREADS_COUNT`, `LOG_LEVEL`, `DB_CONNECTION_POOL_SIZE`, or `SERVER_TIMEOUT`. This section describes how to define extra environment variables for your application that are then made accessible to the ECS task by defining the environment variables in the task definition (see AWS docs on [using task definition parameters to pass environment variables to a container](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html)).
 
-If you want to override the default values for a particular environment, you pass a `service_override_extra_environment_variables` variable to the [env-config module](/infra/app/app-config/env-config/variables.tf) in your `app-config/[environment].tf` file.
+> ⚠️ Note: Do not put sensitive information such as credentials as regular environment variables. The method described in this section will embed the environment variables and their values in the ECS task definition's container definitions, so anyone with access to view the task definition will be able to see the values of the environment variables. For configuring secrets, see the section below on [Secrets](#secrets)
+
+Environment variables are defined in the `app-config` module in the [environment-variables.tf file](/infra/app/app-config/env-config/environment-variables.tf). Modify the `default_extra_environment_variables` map to define extra environment variables specific to the application. Map keys define the environment variable name, and values define the default value for the variable across application environments. For example:
+
+```terraform
+# environment-variables.tf
+
+locals {
+  default_extra_environment_variables = {
+    WORKER_THREADS_COUNT = 4
+    LOG_LEVEL            = "info"
+  }
+}
+```
+
+To override the default values for a particular environment, modify the `app-config/[environment].tf file` for the environment, and pass overrides to the `env-config` module using the `service_override_extra_environment_variables` variable. For example:
+
+```terraform
+# dev.tf
+
+module "dev_config" {
+  source                                       = "./env-config"
+  service_override_extra_environment_variables = {
+    WORKER_THREADS_COUNT = 1
+    LOG_LEVEL            = "debug"
+  }
+  ...
+}
+```
 
 ## Secrets
 
-Secrets are defined in in the [environment-variables.tf](/infra/app/app-config/env-config/environment-variables.tf) file in the app-config module in a variable called `secrets`. Each secret configuration defines the environment variable name and the SSM parameter name for the secret. The SSM parameter name can include the environment, which is a way you can have different secrets for different environments.
+Secrets are a specific category of environment variables that need to be handled sensitively. Examples of secrets are authentication credentials such as API keys for external services. Secrets first need to be stored in AWS SSM Parameter Store as a `SecureString`. This section then describes how to make those secrets accessible to the ECS task as environment variables through the `secrets` configuration in the container definition (see AWS documentation on [retrieving Secrets Manager secrets through environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html)).
+
+Secrets are defined in the same file that non-sensitive environment variables are defined, in the `app-config` module in the [environment-variables.tf file](/infra/app/app-config/env-config/environment-variables.tf). Modify the `secrets` list to define the secrets that the application will have access to. For each secret, `name` defines the environment variable name, and `ssm_param_name` defines the SSM parameter name that stores the secret value. For example:
+
+```terraform
+# environment-variables.tf
+
+locals {
+  secrets = [
+    {
+      name           = "SOME_API_KEY"
+      ssm_param_name = "/${var.app_name}-${var.environment}/secret-sauce"
+    }
+  ]
+}
+```
+
+> ⚠️ Make sure you store the secret in SSM Parameter Store before you try to add secrets to your application service, or else the service won't be able to start since the ECS Task Executor won't be able to fetch the configured secret.

--- a/infra/README.md
+++ b/infra/README.md
@@ -67,7 +67,8 @@ To set up this project for the first time (aka it has never been deployed to the
     1. [Set up application build repository](/docs/infra/set-up-app-build-repository.md)
     2. [Set up application database](/docs/infra/set-up-database.md)
     3. [Set up application environment](/docs/infra/set-up-app-env.md)
-    4. [Set up background jobs](/docs/infra/background-jobs.md)
+    4. [Configure environment variables and secrets](/docs/infra/environment-variables-and-secrets.md)
+    5. [Set up background jobs](/docs/infra/background-jobs.md)
 
 ### 🆕 New developer
 

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -14,7 +14,7 @@ locals {
     # Example secret
     # {
     #   name           = "SECRET_SAUCE"
-    #   ssm_param_name = "/app-dev/secret-sauce"
-    # }
+    #   ssm_param_name = "/${var.app_name}-${var.environment}/secret-sauce"
+    # ]
   ]
 }

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -1,0 +1,17 @@
+locals {
+  # Map from environment variable name to environment variable value
+  # This is a map rather than a list so that variables can be easily
+  # overridden per environment using terraform's `merge` function
+  default_extra_environment_variables = {
+
+  }
+
+  # Configuration for secrets
+  # List of configurations for defining environment variables that pull from SSM parameter
+  # store. Configurations are of the format
+  # { name = "ENV_VAR_NAME", ssm_param_name = "/ssm/param/name" }
+  secrets = [{
+    name           = "SECRET_SAUCE"
+    ssm_param_name = "/app-dev/secret-sauce"
+  }]
+}

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -15,6 +15,6 @@ locals {
     # {
     #   name           = "SECRET_SAUCE"
     #   ssm_param_name = "/${var.app_name}-${var.environment}/secret-sauce"
-    # ]
+    # }
   ]
 }

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -3,7 +3,10 @@ locals {
   # This is a map rather than a list so that variables can be easily
   # overridden per environment using terraform's `merge` function
   default_extra_environment_variables = {
-
+    # Example environment variables
+    # WORKER_THREADS_COUNT    = 4
+    # LOG_LEVEL               = "info"
+    # DB_CONNECTION_POOL_SIZE = 5
   }
 
   # Configuration for secrets

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -10,8 +10,11 @@ locals {
   # List of configurations for defining environment variables that pull from SSM parameter
   # store. Configurations are of the format
   # { name = "ENV_VAR_NAME", ssm_param_name = "/ssm/param/name" }
-  secrets = [{
-    name           = "SECRET_SAUCE"
-    ssm_param_name = "/app-dev/secret-sauce"
-  }]
+  secrets = [
+    # Example secret
+    # {
+    #   name           = "SECRET_SAUCE"
+    #   ssm_param_name = "/app-dev/secret-sauce"
+    # }
+  ]
 }

--- a/infra/app/app-config/env-config/file_upload_jobs.tf
+++ b/infra/app/app-config/env-config/file_upload_jobs.tf
@@ -5,7 +5,7 @@ locals {
   # One difference is that `source_bucket` is optional here. If `source_bucket` is not
   # specified, then the source bucket will be set to the storage bucket's name
   file_upload_jobs = {
-    # Example job that triggers on a file upload to the `etl/input` prefix in the storage bucket
+    # Example job configuration
     # etl = {
     #   path_prefix  = "etl/input",
     #   task_command = ["python", "-m", "flask", "--app", "app.py", "etl", "<object_key>"]

--- a/infra/app/app-config/env-config/file_upload_jobs.tf
+++ b/infra/app/app-config/env-config/file_upload_jobs.tf
@@ -5,10 +5,9 @@ locals {
   # One difference is that `source_bucket` is optional here. If `source_bucket` is not
   # specified, then the source bucket will be set to the storage bucket's name
   file_upload_jobs = {
-    # Example job configuration
-    # etl = {
-    #   path_prefix  = "etl/input",
-    #   task_command = ["python", "-m", "flask", "--app", "app.py", "etl", "<object_key>"]
-    # }
+    etl = {
+      path_prefix  = "etl/input",
+      task_command = ["python", "-m", "flask", "--app", "app.py", "etl", "<object_key>"]
+    }
   }
 }

--- a/infra/app/app-config/env-config/file_upload_jobs.tf
+++ b/infra/app/app-config/env-config/file_upload_jobs.tf
@@ -5,9 +5,10 @@ locals {
   # One difference is that `source_bucket` is optional here. If `source_bucket` is not
   # specified, then the source bucket will be set to the storage bucket's name
   file_upload_jobs = {
-    etl = {
-      path_prefix  = "etl/input",
-      task_command = ["python", "-m", "flask", "--app", "app.py", "etl", "<object_key>"]
-    }
+    # Example job that triggers on a file upload to the `etl/input` prefix in the storage bucket
+    # etl = {
+    #   path_prefix  = "etl/input",
+    #   task_command = ["python", "-m", "flask", "--app", "app.py", "etl", "<object_key>"]
+    # }
   }
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -22,6 +22,13 @@ output "service_config" {
     memory                 = var.service_memory
     desired_instance_count = var.service_desired_instance_count
 
+    extra_environment_variables = merge(
+      local.default_extra_environment_variables,
+      var.service_override_extra_environment_variables
+    )
+
+    secrets = toset(local.secrets)
+
     file_upload_jobs = {
       for job_name, job_config in local.file_upload_jobs :
       # For job configs that don't define a source_bucket, add the source_bucket config property

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -43,3 +43,12 @@ variable "service_desired_instance_count" {
   type    = number
   default = 1
 }
+
+variable "service_override_extra_environment_variables" {
+  type        = map(string)
+  description = <<EOT
+    Map that overrides the default extra environment variables defined in environment-variables.tf.
+    Map from environment variable name to environment variable value
+    EOT
+  default     = {}
+}

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -131,10 +131,13 @@ module "service" {
     }
   } : null
 
-  extra_environment_variables = [
-    { name : "FEATURE_FLAGS_PROJECT", value : module.feature_flags.evidently_project_name },
-    { name : "BUCKET_NAME", value : local.storage_config.bucket_name }
-  ]
+  extra_environment_variables = merge({
+    FEATURE_FLAGS_PROJECT = module.feature_flags.evidently_project_name
+    BUCKET_NAME           = local.storage_config.bucket_name
+  }, local.service_config.extra_environment_variables)
+
+  secrets = local.service_config.secrets
+
   extra_policies = {
     feature_flags_access = module.feature_flags.access_policy_arn,
     storage_access       = module.storage.access_policy_arn

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -62,6 +62,12 @@ data "aws_iam_policy_document" "task_executor" {
     ]
     resources = [data.aws_ecr_repository.app.arn]
   }
+
+  statement {
+    sid       = "SecretsAccess"
+    actions   = ["ssm:GetParameters"]
+    resources = local.secrets[*].valueFrom
+  }
 }
 
 resource "aws_iam_role_policy" "task_executor" {

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -63,10 +63,13 @@ data "aws_iam_policy_document" "task_executor" {
     resources = [data.aws_ecr_repository.app.arn]
   }
 
-  statement {
-    sid       = "SecretsAccess"
-    actions   = ["ssm:GetParameters"]
-    resources = local.secrets[*].valueFrom
+  dynamic "statement" {
+    for_each = length(local.secrets) > 0 ? [1] : []
+    content {
+      sid       = "SecretsAccess"
+      actions   = ["ssm:GetParameters"]
+      resources = local.secrets[*].valueFrom
+    }
   }
 }
 

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -28,7 +28,10 @@ locals {
   environment_variables = concat(
     local.base_environment_variables,
     local.db_environment_variables,
-    var.extra_environment_variables,
+    [
+      for name, value in var.extra_environment_variables :
+      { name : name, value : value }
+    ],
   )
 }
 
@@ -89,6 +92,7 @@ resource "aws_ecs_task_definition" "app" {
         ]
       },
       environment = local.environment_variables,
+      secrets     = local.secrets,
       portMappings = [
         {
           containerPort = var.container_port,

--- a/infra/modules/service/secrets.tf
+++ b/infra/modules/service/secrets.tf
@@ -1,0 +1,14 @@
+data "aws_ssm_parameter" "secret" {
+  for_each = { for secret in var.secrets : secret.name => secret }
+  name     = each.value.ssm_param_name
+}
+
+locals {
+  secrets = [
+    for secret in var.secrets :
+    {
+      name      = secret.name,
+      valueFrom = data.aws_ssm_parameter.secret[secret.name].arn
+    }
+  ]
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -62,8 +62,17 @@ variable "aws_services_security_group_id" {
 }
 
 variable "extra_environment_variables" {
-  type        = list(object({ name = string, value = string }))
-  description = "Additional environment variables to pass to the service container"
+  type        = map(string)
+  description = "Additional environment variables to pass to the service container. Map from environment variable name to the value."
+  default     = {}
+}
+
+variable "secrets" {
+  type = set(object({
+    name           = string
+    ssm_param_name = string
+  }))
+  description = "List of configurations for defining environment variables that pull from SSM parameter store"
   default     = []
 }
 


### PR DESCRIPTION
## Ticket

Work for https://github.com/navapbc/template-infra/issues/535 and https://github.com/navapbc/template-infra/issues/310

## Changes

Add functionality for applications to:
* Define application specific environment variables
* Override values for these environment variables per application environment
* Access secrets in SSM parameter store that get injected to the container as environment variables

## Context for reviewers

This adds the ability for applications to define custom env vars and secrets

## Deploying

platform-test-flask needs some manual changes since currently there are custom changes to infra/app/service/main.tf to define the API key

## Testing

Developed and tested in platform-test in this PR https://github.com/navapbc/platform-test/pull/85