### PR TITLE
Move network layer out of app in arch diagram

### DIFF
--- a/docs/infra/module-architecture.md
+++ b/docs/infra/module-architecture.md
@@ -26,10 +26,10 @@ flowchart TB
 
   subgraph infra
     account:::root-module
+    app/network[network]:::root-module
 
     subgraph app
       app/build-repository[build-repository]:::root-module
-      app/network[network]:::root-module
       app/database[database]:::root-module
       app/service[service]:::root-module
     end
@@ -45,8 +45,8 @@ flowchart TB
 
     account --> terraform-backend-s3
     account --> auth-github-actions
-    app/build-repository --> container-image-repository
     app/network --> network
+    app/build-repository --> container-image-repository
     app/database --> database
     app/service --> web-app
 


### PR DESCRIPTION
Fixing an inaccuracy in the diagram. Network layer shouldn't be specific to the app.

## Testing

Old
<img width="560" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/752080f2-a820-45ce-97ee-9806c3b34c15">

New
<img width="552" alt="image" src="https://github.com/navapbc/template-infra/assets/447859/fe6d2a7d-0983-4c1e-a8c3-0c8ba2d666d0">


