### PR TITLE
Add object tagging permissions

### DIFF
--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -43,9 +43,12 @@ data "aws_iam_policy_document" "storage_access" {
   statement {
     actions = [
       "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
       "s3:GetObject",
       "s3:GetObjectAttributes",
+      "s3:GetObjectTagging",
       "s3:PutObject",
+      "s3:PutObjectTagging",
     ]
     effect    = "Allow"
     resources = ["arn:aws:s3:::${var.name}/*"]


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/552

## Changes

see title

## Context for reviewers

The ecs task could put files to S3 but couldn't add tags to those files. This change adds the permissions to add tags. This was discovered while working on another project.

## Testing

Developed and tested in platform-test in https://github.com/navapbc/platform-test/pull/88