### PR TITLE
Add support for custom domains and HTTPS

### DIFF
--- a/docs/infra/https-support.md
+++ b/docs/infra/https-support.md
@@ -1,0 +1,40 @@
+# HTTPS support
+
+Production systems will want to use HTTPS rather than HTTP to prevent man-in-the-middle attacks. This document describes how HTTPS is configured. This process will:
+
+1. Issue an SSL/TLS certificate using Amazon Certificate Manager (ACM) for each domain that we want to support HTTPS
+2. Associate the certificate with the application's load balancer so that the load balancer can serve HTTPS requests intended for that domain
+
+## Requirements
+
+In order to set up HTTPS support you'll also need to have [set up custom domains](/docs/infra/set-up-custom-domains.md). This is because SSL/TLS certificates must be properly configured for the specific domain to support establishing secure connections.
+
+## 1. Set desired certificates in domain configuration
+
+For each custom domain you want to set up in the network, define a certificate configuration object and set the `source` to `issued`. You'll probably want at least one custom domain for each application/service in the network. The custom domain must be either the same as the hosted zone or a subdomain of the hosted zone.
+
+## 2. Update the network layer to issue the certificates
+
+Run the following command to issue SSL/TLS certificates for each custom domain you configured
+
+```bash
+make infra-update-network NETWORK_NAME=<NETWORK_NAME>
+```
+
+Run the following command to check the status of a certificate (replace `<CERTIFICATE_ARN>` using the output from the previous command):
+
+```bash
+aws acm describe-certificate --certificate-arn <CERTIFICATE_ARN> --query Certificate.Status
+```
+
+## 4. Update `enable_https = true` in `app-config`
+
+Update `enable_https = true` in your application's `app-config` module. You should have already set `domain_name` as part of [setting up custom domain names](/docs/infra/set-up-custom-domains.md).
+
+## 5. Attach certificate to load balancer
+
+Run the following command to attach the SSL/TLS certificate to the load balancer
+
+```bash
+make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>
+```

--- a/docs/infra/set-up-custom-domains.md
+++ b/docs/infra/set-up-custom-domains.md
@@ -1,0 +1,73 @@
+# Custom domains
+
+Production systems will want to set up custom domains to route internet traffic to their application services rather than using AWS-generated hostnames for the load balancers or the CDN. This document describes how to configure custom domains. The custom domain setup process will:
+
+1. Create an [Amazon Route 53 hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html) to manage DNS records for a domain and subdomains
+2. Create a DNS A (address) records to route traffic from a custom domain to the application's load balancer
+
+## Requirements
+
+Before setting up custom domains you'll need to have [set up the AWS account](./set-up-aws-account.md)
+
+## 1. Set hosted zone in domain configuration
+
+Update the value for the `hosted_zone` in the domain configuration. The custom domain configuration is defined as a `domain_config` object in the [network section of the project config module](/infra/project-config/networks.tf). A [hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html) represents a domain and all of its subdomains. For example, a hosted zone of `platform-test.navateam.com` includes `platform-test.navateam.com`, `cdn.platform-test.navateam.com`, `notifications.platform-test.navateam.com`, `foo.bar.platform-test.navateam.com`, etc.
+
+## 2. Update the network layer to create the hosted zone
+
+Run the following command to create the hosted zone specified in the domain configuration.
+
+```bash
+make infra-update-network NETWORK_NAME=<NETWORK_NAME>
+```
+
+## 3. Delegate DNS requests to the newly created hosted zone
+
+You most likely registered your domain outside of this project. Using whichever service you used to register the domain name (e.g. Namecheap, GoDaddy, Google Domains, etc.), add a DNS NS (nameserver) record. Set the "name" equal to the `hosted_zone` and set the value equal to the list of hosted zone name servers that was created in the previous step. You can see the list of servers by running
+
+```bash
+terraform -chdir=infra/networks output -json hosted_zone_name_servers
+```
+
+Your NS record might look something like this:
+
+**Name**:
+
+```text
+platform-test.navateam.com
+```
+
+**Value**: (Note the periods after each of the server addresses)
+
+```text
+ns-1431.awsdns-50.org.
+ns-1643.awsdns-13.co.uk.
+ns-687.awsdns-21.net.
+ns-80.awsdns-10.com.
+```
+
+Run the following command to verify that DNS requests are being served by the hosted zone nameservers using `nslookup`.
+
+```bash
+nslookup -type=NS <HOSTED_ZONE>
+```
+
+## 4. Configure custom domain for your application
+
+Define the `domain_name` for each of the application environments in the `app-config` module. The `domain_name` must be either the same as the `hosted_zone` or a subdomain of the `hosted_zone`. For example, if your hosted zone is `platform-test.navateam.com`, then `platform-test.navateam.com` and `cdn.platform-test.navateam.com` are both valid values for `domain_name`.
+
+## 5. Create A (address) records to route traffice from the custom domain to your application's load balancer
+
+Run the following command to create the A record that routes traffic from the custom domain to the application's load balancer.
+
+```bash
+make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>
+```
+
+## 6. Repeat for each application
+
+If you have multiple applications in the same network, repeat steps 4 and 5 for each application.
+
+## Externally managed DNS
+
+If you plan to manage DNS records outside of the project, then set `network_configs[*].domain_config.manage_dns = false` in [the networks section of the project-config module](/infra/project-config/networks.tf).

--- a/docs/infra/set-up-network.md
+++ b/docs/infra/set-up-network.md
@@ -11,7 +11,9 @@ The network setup process will configure and deploy network resources needed by 
 Before setting up the network you'll need to have:
 
 1. [Set up the AWS account](./set-up-aws-account.md)
-2. Optionally adjust the configuration for the networks you want to have on your project in the [project-config module](/infra/project-config/main.tf). By default there are three networks defined, one for each application environment. If you have multiple apps and want your applications in separate networks, you may want to give the networks differentiating names (e.g. "foo-dev", "foo-prod", "bar-dev", "bar-prod", instead of just "dev", "prod").
+2. Optionally adjust the configuration for the networks you want to have on your project in the [project-config module](/infra/project-config/networks.tf). By default there are three networks defined, one for each application environment. If you have multiple apps and want your applications in separate networks, you may want to give the networks differentiating names (e.g. "foo-dev", "foo-prod", "bar-dev", "bar-prod", instead of just "dev", "prod").
+   1. Optionally, [configure custom domains](/docs/infra/set-up-custom-domains.md). You can also come back to setting up custom domains at a later time.
+   2. Optionally, [configure HTTPS support](/docs/infra/https-support.md). You can also come back to setting up HTTPS support at a later time.
 3. [Configure the app](/infra/app/app-config/main.tf).
    1. Update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with. This setting determines whether or not to create VPC endpoints needed by the database layer.
    2. Update `has_external_non_aws_service` to `true` or `false` depending on whether or not your application makes calls to an external non-AWS service. This setting determines whether or not to create NAT gateways, which allows the service in the private subnet to make requests to the internet.

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -5,8 +5,8 @@ module "dev_config" {
   default_region                  = module.project_config.default_region
   environment                     = "dev"
   network_name                    = "dev"
-  domain_name                     = "platform-test-dev.navateam.com"
-  enable_https                    = true
+  domain_name                     = null
+  enable_https                    = false
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -5,6 +5,8 @@ module "dev_config" {
   default_region                  = module.project_config.default_region
   environment                     = "dev"
   network_name                    = "dev"
+  domain_name                     = "platform-test-dev.navateam.com"
+  enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -17,6 +17,8 @@ output "network_name" {
 output "service_config" {
   value = {
     service_name           = "${local.prefix}${var.app_name}-${var.environment}"
+    domain_name            = var.domain_name
+    enable_https           = var.enable_https
     region                 = var.default_region
     cpu                    = var.service_cpu
     memory                 = var.service_memory

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -21,6 +21,24 @@ variable "default_region" {
   type        = string
 }
 
+variable "domain_name" {
+  type        = string
+  description = "The fully qualified domain name for the application"
+  default     = null
+}
+
+variable "enable_https" {
+  type        = bool
+  description = "Whether to enable HTTPS for the application"
+  default     = false
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "The ARN of the certificate to use for the application"
+  default     = null
+}
+
 variable "has_database" {
   type = bool
 }

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -5,6 +5,8 @@ module "prod_config" {
   default_region                  = module.project_config.default_region
   environment                     = "prod"
   network_name                    = "prod"
+  domain_name                     = "platform-test.navateam.com"
+  enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -5,8 +5,8 @@ module "prod_config" {
   default_region                  = module.project_config.default_region
   environment                     = "prod"
   network_name                    = "prod"
-  domain_name                     = "platform-test.navateam.com"
-  enable_https                    = true
+  domain_name                     = null
+  enable_https                    = false
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 

--- a/infra/app/app-config/staging.tf
+++ b/infra/app/app-config/staging.tf
@@ -5,6 +5,8 @@ module "staging_config" {
   default_region                  = module.project_config.default_region
   environment                     = "staging"
   network_name                    = "staging"
+  domain_name                     = "platform-test-staging.navateam.com"
+  enable_https                    = true
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/app-config/staging.tf
+++ b/infra/app/app-config/staging.tf
@@ -5,8 +5,8 @@ module "staging_config" {
   default_region                  = module.project_config.default_region
   environment                     = "staging"
   network_name                    = "staging"
-  domain_name                     = "platform-test-staging.navateam.com"
-  enable_https                    = true
+  domain_name                     = null
+  enable_https                    = false
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -126,7 +126,7 @@ module "service" {
 
   domain_name     = local.service_config.domain_name
   hosted_zone_id  = local.service_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
-  certificate_arn = local.service_config.enable_https != null ? data.aws_acm_certificate.certificate[0].arn : null
+  certificate_arn = local.service_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
 
   cpu                    = local.service_config.cpu
   memory                 = local.service_config.memory

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -35,6 +35,8 @@ locals {
   database_config                                = local.environment_config.database_config
   storage_config                                 = local.environment_config.storage_config
   incident_management_service_integration_config = local.environment_config.incident_management_service_integration
+
+  network_config = module.project_config.network_configs[local.environment_config.network_name]
 }
 
 terraform {
@@ -101,14 +103,30 @@ data "aws_security_groups" "aws_services" {
   }
 }
 
+data "aws_acm_certificate" "certificate" {
+  count  = local.service_config.enable_https ? 1 : 0
+  domain = local.service_config.domain_name
+}
+
+data "aws_route53_zone" "zone" {
+  count = local.service_config.domain_name != null ? 1 : 0
+  name  = local.network_config.domain_config.hosted_zone
+}
+
 module "service" {
-  source                = "../../modules/service"
-  service_name          = local.service_config.service_name
+  source       = "../../modules/service"
+  service_name = local.service_config.service_name
+
   image_repository_name = module.app_config.image_repository_name
   image_tag             = local.image_tag
-  vpc_id                = data.aws_vpc.network.id
-  public_subnet_ids     = data.aws_subnets.public.ids
-  private_subnet_ids    = data.aws_subnets.private.ids
+
+  vpc_id             = data.aws_vpc.network.id
+  public_subnet_ids  = data.aws_subnets.public.ids
+  private_subnet_ids = data.aws_subnets.private.ids
+
+  domain_name     = local.service_config.domain_name
+  hosted_zone_id  = local.service_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
+  certificate_arn = local.service_config.enable_https != null ? data.aws_acm_certificate.certificate[0].arn : null
 
   cpu                    = local.service_config.cpu
   memory                 = local.service_config.memory

--- a/infra/modules/domain/certificates.tf
+++ b/infra/modules/domain/certificates.tf
@@ -1,0 +1,59 @@
+locals {
+  # Filter configs for issued certificates.
+  # These certificates are managed by the project using AWS Certificate Manager.
+  issued_certificate_configs = {
+    for domain, config in var.certificate_configs : domain => config
+    if config.source == "issued"
+  }
+
+  # Filter configs for imported certificates.
+  # These certificates are created outside of the project and imported.
+  imported_certificate_configs = {
+    for domain, config in var.certificate_configs : domain => config
+    if config.source == "imported"
+  }
+
+  domain_validation_options = merge([
+    for domain, config in local.issued_certificate_configs :
+    {
+      for dvo in aws_acm_certificate.issued[domain].domain_validation_options :
+      dvo.domain_name => {
+        name   = dvo.resource_record_name
+        record = dvo.resource_record_value
+        type   = dvo.resource_record_type
+      }
+    }
+  ]...)
+}
+
+# ACM certificate that will be used by the load balancer.
+resource "aws_acm_certificate" "issued" {
+  for_each = local.issued_certificate_configs
+
+  domain_name       = each.key
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# DNS records for certificate validation.
+resource "aws_route53_record" "validation" {
+  for_each = local.domain_validation_options
+
+  allow_overwrite = true
+  zone_id         = aws_route53_zone.zone[0].zone_id
+  name            = each.value.name
+  type            = each.value.type
+  ttl             = 60
+  records         = [each.value.record]
+}
+
+# Representation of successful validation of the ACM certificate.
+resource "aws_acm_certificate_validation" "validation" {
+  for_each = local.imported_certificate_configs
+
+  certificate_arn         = aws_acm_certificate.issued[each.key].arn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+}

--- a/infra/modules/domain/main.tf
+++ b/infra/modules/domain/main.tf
@@ -1,0 +1,10 @@
+# Create a Route53 hosted zone for the domain.
+# Individual address records will be created in the service layer by the services that
+# need them (e.g. the load balancer or CDN).
+# If DNS is managed elsewhere then this resource will not be created.
+resource "aws_route53_zone" "zone" {
+  count = var.manage_dns ? 1 : 0
+  name  = var.name
+
+  # checkov:skip=CKV2_AWS_38:TODO(https://github.com/navapbc/template-infra/issues/560) enable DNSSEC
+}

--- a/infra/modules/domain/outputs.tf
+++ b/infra/modules/domain/outputs.tf
@@ -1,0 +1,9 @@
+output "hosted_zone_name_servers" {
+  value = length(aws_route53_zone.zone) > 0 ? aws_route53_zone.zone[0].name_servers : []
+}
+
+output "certificate_arns" {
+  value = {
+    for domain in keys(var.certificate_configs) : domain => aws_acm_certificate.issued[domain].arn
+  }
+}

--- a/infra/modules/domain/query-logs.tf
+++ b/infra/modules/domain/query-logs.tf
@@ -1,0 +1,43 @@
+# DNS query logging
+
+resource "aws_cloudwatch_log_group" "dns_query_logging" {
+  count = var.manage_dns ? 1 : 0
+
+  name              = "/dns/${var.name}"
+  retention_in_days = 30
+
+  # checkov:skip=CKV_AWS_158:No need to manage KMS key for DNS query logs or audit access to these logs
+}
+
+resource "aws_route53_query_log" "dns_query_logging" {
+  count = var.manage_dns ? 1 : 0
+
+  zone_id                  = aws_route53_zone.zone[0].zone_id
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.dns_query_logging[0].arn
+
+  depends_on = [aws_cloudwatch_log_resource_policy.dns_query_logging[0]]
+}
+
+# Allow Route53 to write logs to any log group under /dns/*
+data "aws_iam_policy_document" "dns_query_logging" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*:*:log-group:/dns/*"]
+
+    principals {
+      identifiers = ["route53.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "dns_query_logging" {
+  count = var.manage_dns ? 1 : 0
+
+  policy_document = data.aws_iam_policy_document.dns_query_logging.json
+  policy_name     = "dns-query-logging"
+}

--- a/infra/modules/domain/variables.tf
+++ b/infra/modules/domain/variables.tf
@@ -1,0 +1,51 @@
+variable "name" {
+  type        = string
+  description = "Fully qualified domain name"
+}
+
+variable "manage_dns" {
+  type        = bool
+  description = "Whether DNS is managed by the project (true) or managed externally (false)"
+}
+
+variable "certificate_configs" {
+  type = map(object({
+    source           = string
+    private_key      = optional(string)
+    certificate_body = optional(string)
+  }))
+  description = <<EOT
+    Map from domains to certificate configuration objects for that domain.
+
+    For each domain's certificate:
+    `source` indicates whether the certificate is managed by the project using AWS
+    Certificate Manager (issued) or imported from an external source (imported)
+    
+    `private_key` and `certificate_body` describe the certificate information for
+    imported certificates, which is required if `source` is 'imported'.
+    EOT
+
+  validation {
+    condition = alltrue([
+      for certificate_config in var.certificate_configs :
+      contains(["issued", "imported"], certificate_config.source)
+    ])
+    error_message = "certificate_config.source must be either 'issued' or 'imported'"
+  }
+
+  validation {
+    condition = alltrue([
+      for certificate_config in var.certificate_configs :
+      certificate_config.source != "imported" || certificate_config.private_key != null
+    ])
+    error_message = "certificate_config.private_key is required if certificate_config.source is 'imported'"
+  }
+
+  validation {
+    condition = alltrue([
+      for certificate_config in var.certificate_configs :
+      certificate_config.source != "imported" || certificate_config.certificate_body != null
+    ])
+    error_message = "certificate_config.certificate_body is required if certificate_config.source is 'imported'"
+  }
+}

--- a/infra/modules/service/dns.tf
+++ b/infra/modules/service/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "app" {
   # Don't create DNS record for temporary environments (e.g. ones spun up by CI/)
-  count = !var.is_temporary ? 1 : 0
+  count = !var.is_temporary && var.domain_name != null && var.hosted_zone_id != null ? 1 : 0
 
   name    = var.domain_name
   zone_id = var.hosted_zone_id

--- a/infra/modules/service/dns.tf
+++ b/infra/modules/service/dns.tf
@@ -1,0 +1,13 @@
+resource "aws_route53_record" "app" {
+  # Don't create DNS record for temporary environments (e.g. ones spun up by CI/)
+  count = !var.is_temporary ? 1 : 0
+
+  name    = var.domain_name
+  zone_id = var.hosted_zone_id
+  type    = "A"
+  alias {
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -70,6 +70,45 @@ resource "aws_lb_listener_rule" "app_http_forward" {
   }
 }
 
+resource "aws_lb_listener" "alb_listener_https" {
+  count = var.certificate_arn != null ? 1 : 0
+
+  load_balancer_arn = aws_lb.alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = var.certificate_arn
+
+  # Use security policy that supports TLS 1.3 but requires at least TLS 1.2
+  ssl_policy = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not Found"
+      status_code  = "404"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "app_https_forward" {
+  count = var.certificate_arn != null ? 1 : 0
+
+  listener_arn = aws_lb_listener.alb_listener_https[0].arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app_tg.arn
+  }
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
 resource "aws_lb_target_group" "app_tg" {
   # you must use a prefix, to facilitate successful tg changes
   name_prefix          = "app-"

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -29,6 +29,14 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "Allow HTTPS traffic from public internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     description = "Allow all outgoing traffic"
     from_port   = 0

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -6,6 +6,24 @@ variable "service_name" {
   }
 }
 
+variable "domain_name" {
+  type        = string
+  description = "The fully qualified domain name for the application"
+  default     = null
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "The ARN of the certificate to use for the application"
+  default     = null
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "The Route53 hosted zone id for the domain"
+  default     = null
+}
+
 variable "image_tag" {
   type        = string
   description = "The tag of the image to deploy"

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -6,6 +6,7 @@ locals {
   region = module.project_config.default_region
 
   network_config = module.project_config.network_configs[var.network_name]
+  domain_config  = local.network_config.domain_config
 
   # List of configuration for all applications, even ones that are not in the current network
   # If project has multiple applications, add other app configs to this list
@@ -66,4 +67,11 @@ module "network" {
   database_subnet_group_name              = local.network_config.database_subnet_group_name
   has_database                            = local.has_database
   has_external_non_aws_service            = local.has_external_non_aws_service
+}
+
+module "domain" {
+  source              = "../modules/domain"
+  name                = local.domain_config.hosted_zone
+  manage_dns          = local.domain_config.manage_dns
+  certificate_configs = local.domain_config.certificate_configs
 }

--- a/infra/networks/outputs.tf
+++ b/infra/networks/outputs.tf
@@ -1,0 +1,11 @@
+output "hosted_zone_name_servers" {
+  value = module.domain.hosted_zone_name_servers
+}
+
+output "certificate_domains" {
+  value = keys(local.domain_config.certificate_configs)
+}
+
+output "certificate_arns" {
+  value = module.domain.certificate_arns
+}

--- a/infra/project-config/main.tf
+++ b/infra/project-config/main.tf
@@ -17,10 +17,4 @@ locals {
   github_actions_role_name = "${local.project_name}-github-actions"
 
   aws_services_security_group_name_prefix = "aws-service-vpc-endpoints"
-
-  network_configs = {
-    dev     = { database_subnet_group_name = "dev" }
-    staging = { database_subnet_group_name = "staging" }
-    prod    = { database_subnet_group_name = "prod" }
-  }
 }

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -5,12 +5,21 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "platform-test-dev.navateam.com"
+        hosted_zone = "<HOSTED_ZONE_FOR_DEV_NETWORK>"
 
         certificate_configs = {
-          "platform-test-dev.navateam.com" = {
-            source = "issued"
-          }
+          # Example certificate configuration for a certificate that is managed by the project
+          # "sub.domain.com" = {
+          #   source = "issued"
+          # }
+
+          # Example certificate configuration for a certificate that is issued elsewhere and imported into the project
+          # (currently not supported, will be supported via https://github.com/navapbc/template-infra/issues/559)
+          # "platform-test-dev.navateam.com" = {
+          #   source = "imported"
+          #   private_key_ssm_name = "/certificates/sub.domain.com/private-key"
+          #   certificate_body_ssm_name = "/certificates/sub.domain.com/certificate-body"
+          # }
         }
       }
     }
@@ -20,13 +29,9 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "platform-test-dev.navateam.com"
+        hosted_zone = "<HOSTED_ZONE_FOR_STAGING_NETWORK>"
 
-        certificate_configs = {
-          "platform-test-dev.navateam.com" = {
-            source = "issued"
-          }
-        }
+        certificate_configs = {}
       }
     }
 
@@ -35,13 +40,9 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "platform-test.navateam.com"
+        hosted_zone = "<HOSTED_ZONE_FOR_PROD_NETWORK>"
 
-        certificate_configs = {
-          "platform-test.navateam.com" = {
-            source = "issued"
-          }
-        }
+        certificate_configs = {}
       }
     }
   }

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -4,8 +4,11 @@ locals {
       database_subnet_group_name = "dev"
 
       domain_config = {
-        manage_dns  = true
-        hosted_zone = "<HOSTED_ZONE_FOR_DEV_NETWORK>"
+        manage_dns = true
+        # Placeholder value for the hosted zone
+        # A hosted zone represents a domain and all of its subdomains. For example, a
+        # hosted zone of foo.domain.com includes foo.domain.com, bar.foo.domain.com, etc.
+        hosted_zone = "hosted.zone.for.dev.network.com"
 
         certificate_configs = {
           # Example certificate configuration for a certificate that is managed by the project
@@ -29,7 +32,7 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "<HOSTED_ZONE_FOR_STAGING_NETWORK>"
+        hosted_zone = "hosted.zone.for.staging.network.com"
 
         certificate_configs = {}
       }
@@ -40,7 +43,7 @@ locals {
 
       domain_config = {
         manage_dns  = true
-        hosted_zone = "<HOSTED_ZONE_FOR_PROD_NETWORK>"
+        hosted_zone = "hosted.zone.for.prod.network.com"
 
         certificate_configs = {}
       }

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -1,0 +1,48 @@
+locals {
+  network_configs = {
+    dev = {
+      database_subnet_group_name = "dev"
+
+      domain_config = {
+        manage_dns  = true
+        hosted_zone = "platform-test-dev.navateam.com"
+
+        certificate_configs = {
+          "platform-test-dev.navateam.com" = {
+            source = "issued"
+          }
+        }
+      }
+    }
+
+    staging = {
+      database_subnet_group_name = "staging"
+
+      domain_config = {
+        manage_dns  = true
+        hosted_zone = "platform-test-dev.navateam.com"
+
+        certificate_configs = {
+          "platform-test-dev.navateam.com" = {
+            source = "issued"
+          }
+        }
+      }
+    }
+
+    prod = {
+      database_subnet_group_name = "prod"
+
+      domain_config = {
+        manage_dns  = true
+        hosted_zone = "platform-test.navateam.com"
+
+        certificate_configs = {
+          "platform-test.navateam.com" = {
+            source = "issued"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/163

## Changes
* Add domain config options to the network config objects in project-config module
  * Domain config has `hosted_zone`, `manage_dns`, and `certificate_configs` options
  * Certificate config has `source` option
* Add domain module which creates Route53 hosted zone and ACM issued SSL certificates
* Add `domain_name` and `enable_https` to environment config objects in app-config module
* Update service module to create A record routing traffic from custom domain to load balancer
* Update service module to attach SSL certificate to load balancer
* Add instructions for setting up custom domains and HTTPS

## Context for reviewers

First review the instructions to see how a project would use this:

1. [Review changes to set up network instructions](https://github.com/navapbc/platform-test/pull/90/files?short_path=0634c64#diff-0634c648eab3a931b4ad7ed680f114efac86636ac4f9b05d89bc57f14b3bc707)
2. Review instructions for [setting up custom domains](https://github.com/navapbc/platform-test/blob/c054d350fb046250760bec38e632c1e8cf401490/docs/infra/set-up-custom-domains.md)
3. Review instructions for [setting up HTTPS support](https://github.com/navapbc/platform-test/blob/c054d350fb046250760bec38e632c1e8cf401490/docs/infra/https-support.md)


## Testing

Developed and tested in platform-test in https://github.com/navapbc/platform-test/pull/90