### PR TITLE
Add app and ref to build workflow run name

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,4 +1,5 @@
-name: Build and Publish
+name: Build and publish
+run-name: Build and publish ${{ inputs.app_name }}:${{ inputs.ref }}
 
 on:
   workflow_call:


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

When there are multiple apps, the build and publish workflow run name doesn't differentiate between them. This change adds the name and ref (branch or git hash) to the run name to improve developer experience.

## Testing

Developed and tested in https://github.com/navapbc/platform-test/pull/92