### PR TITLE
makefile: Improve help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,4 +213,17 @@ release-image-tag: ## Prints the image tag of the release image
 ########################
 
 help: ## Prints the help documentation and info about each command
-	@grep -E '^[/a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -Eh '^[[:print:]]+:.*?##' $(MAKEFILE_LIST) | \
+	sort -d | \
+	awk -F':.*?## ' '{printf "\033[36m%s\033[0m\t%s\n", $$1, $$2}' | \
+	column -t -s "$$(printf '\t')"
+	@echo ""
+	@echo "APP_NAME=$(APP_NAME)"
+	@echo "ENVIRONMENT=$(ENVIRONMENT)"
+	@echo "IMAGE_NAME=$(IMAGE_NAME)"
+	@echo "IMAGE_TAG=$(IMAGE_TAG)"
+	@echo "INFO_TAG=$(INFO_TAG)"
+	@echo "GIT_REPO_AVAILABLE=$(GIT_REPO_AVAILABLE)"
+	@echo "SHELL=$(SHELL)"
+	@echo "MAKE_VERSION=$(MAKE_VERSION)"
+	@echo "MODULES=$(MODULES)"


### PR DESCRIPTION
A few different tweaks to improve generality and usefulness:
- Break up the core command across a few lines to be more readable
- Add `-h` to the grep to ensure filenames are never printed (say if you
  import/include another makefile)
- Add `column` into the mix to ensure things line up given arbitrarily long
  target names
- Print some of the variables used in the file's targets as a part of the help
  message, to aid debugging and for context

## Testing

### Before
![image](https://github.com/navapbc/template-infra/assets/5341292/50395914-6421-460d-9ac7-6854a0061551)

### After
![image](https://github.com/navapbc/template-infra/assets/5341292/e8473589-58a3-4905-9b5e-753c3455c9d7)
