### PR TITLE
makefile: Clearer script calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,8 @@ PROJECT_ROOT ?= $(notdir $(PWD))
 
 # Use `=` instead of `:=` so that we only execute `./bin/current-account-alias.sh` when needed
 # See https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors
-CURRENT_ACCOUNT_ALIAS = `./bin/current-account-alias.sh`
-
-CURRENT_ACCOUNT_ID = $(./bin/current-account-id.sh)
+CURRENT_ACCOUNT_ALIAS = $(shell ./bin/current-account-alias.sh)
+CURRENT_ACCOUNT_ID = $(shell ./bin/current-account-id.sh)
 
 # Get the list of reusable terraform modules by getting out all the modules
 # in infra/modules and then stripping out the "infra/modules/" prefix
@@ -90,7 +89,7 @@ infra-configure-app-service: ## Configure infra/$APP_NAME/service module's tfbac
 	./bin/create-tfbackend.sh "infra/$(APP_NAME)/service" "$(ENVIRONMENT)"
 
 infra-update-current-account: ## Update infra resources for current AWS profile
-	./bin/terraform-init-and-apply.sh infra/accounts `./bin/current-account-config-name.sh`
+	./bin/terraform-init-and-apply.sh infra/accounts $$(./bin/current-account-config-name.sh)
 
 infra-update-network: ## Update network
 	@:$(call check_defined, NETWORK_NAME, the name of the network in /infra/networks)


### PR DESCRIPTION
Recommend avoiding backticks to indicate command substitution in general and to
standardize on `$()`. This can be a little confusing in a makefile which also
uses `$()` to indicate its own calls, but the consistency is better in my
opinion. So swap those where used. 

Also, Make isn't Bash, so use explicit `shell` function to highlight what is
intended to be executed by Make.

Though `CURRENT_ACCOUNT_ALIAS` and `CURRENT_ACCOUNT_ID` also don't appear to be
used currently, so could also be dropped.