### PR TITLE
makefile: Avoid mismatched quotes in `check_defined`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ check_defined = \
 __check_defined = \
 	$(if $(value $1),, \
 		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
-			required by target `$@')))
+			required by target '$@')))
 
 
 .PHONY : \


### PR DESCRIPTION
Can break some syntax highlighting.