### PR TITLE
Switch scripts shebangs to /usr/bin/env

### DIFF
--- a/bin/account-ids-by-name.sh
+++ b/bin/account-ids-by-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Prints a JSON dictionary that maps account names to account ids for the list
 # of accounts given by the terraform backend files of the form
 # <ACCOUNT_NAME>.<ACCOUNT_ID>.s3.tfbackend in the infra/accounts directory.

--- a/bin/check-database-roles.sh
+++ b/bin/check-database-roles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Script that invokes the database role-manager AWS Lambda function to check
 # that the Postgres users were configured properly.

--- a/bin/check-github-actions-auth.sh
+++ b/bin/check-github-actions-auth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GITHUB_ACTIONS_ROLE=$1

--- a/bin/configure-monitoring-secret.sh
+++ b/bin/configure-monitoring-secret.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # This script creates SSM parameter for storing integration URL for incident management
 # services. Script creates new SSM attribute or updates existing. 

--- a/bin/create-or-update-database-roles.sh
+++ b/bin/create-or-update-database-roles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Script that invokes the database role-manager AWS Lambda function to create
 # or update the Postgres user roles for a particular environment.

--- a/bin/create-tfbackend.sh
+++ b/bin/create-tfbackend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # This script creates a terraform backend config file for a terraform module.
 # It is not meant to be used directly. Instead, it is called by other scripts

--- a/bin/current-account-alias.sh
+++ b/bin/current-account-alias.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Print the current AWS account alias
 set -euo pipefail
 echo -n "$(aws iam list-account-aliases --query "AccountAliases" --max-items 1 --output text)"

--- a/bin/current-account-config-name.sh
+++ b/bin/current-account-config-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Print the config name for the current AWS account
 # Do this by getting the current account and searching for a file in
 # infra/accounts that matches "<account name>.<account id>.s3.tfbackend".

--- a/bin/current-account-id.sh
+++ b/bin/current-account-id.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Print the current AWS account id
 set -euo pipefail
 echo -n "$(aws sts get-caller-identity --query "Account" --output text)"

--- a/bin/current-region.sh
+++ b/bin/current-region.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Print the current AWS region
 set -euo pipefail
 echo -n "$(aws configure list | grep region | awk '{print $2}')"

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 APP_NAME=$1

--- a/bin/lint-markdown.sh
+++ b/bin/lint-markdown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # To make things simpler, ensure we're in the repo's root directory (one directory up) before
 # running, regardless where the user is when invoking this script.

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/bin/run-command.sh
+++ b/bin/run-command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Run an application command using the application image
 # 

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Run database migrations
 # 1. Update the application's task definition with the latest build, but

--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # This script sets up the terraform backend for the AWS account that you are
 # currently authenticated into and creates the terraform backend config file.

--- a/bin/terraform-apply.sh
+++ b/bin/terraform-apply.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Convenience script for running terraform apply for the specified module and configuration name.
 # The configuration name is used to determine which .tfvars file to use for the -var-file

--- a/bin/terraform-init-and-apply.sh
+++ b/bin/terraform-init-and-apply.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Convenience script for running terraform init followed by terraform apply
 # See ./bin/terraform-init.sh and ./bin/terraform-apply.sh for more details.

--- a/bin/terraform-init.sh
+++ b/bin/terraform-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # Convenience script for running terraform init for the specified module and configuration name.
 # The configuration name is used to determine which .tfbackend file to use for the -backend-config

--- a/template-only-bin/destroy-account.sh
+++ b/template-only-bin/destroy-account.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Do not use this script on your project. This script is only used for testing
 # the platform bootstrap process.
 set -euxo pipefail

--- a/template-only-bin/destroy-app-build-repository.sh
+++ b/template-only-bin/destroy-app-build-repository.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Do not use this script on your project. This script is only used for testing
 # the platform bootstrap process.
 set -euxo pipefail

--- a/template-only-bin/destroy-app-service.sh
+++ b/template-only-bin/destroy-app-service.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Do not use this script on your project. This script is only used for testing
 # the platform bootstrap process.
 set -euxo pipefail

--- a/template-only-bin/destroy-network.sh
+++ b/template-only-bin/destroy-network.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Do not use this script on your project. This script is only used for testing
 # the platform bootstrap process.
 set -euxo pipefail

--- a/template-only-bin/download-and-install-template.sh
+++ b/template-only-bin/download-and-install-template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "Fetch latest version of template-infra"

--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script installs the template-infra to your project. Run
 # This script from your project's root directory.

--- a/template-only-bin/set-up-project.sh
+++ b/template-only-bin/set-up-project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 PROJECT_NAME=$1

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # This script updates template-infra in your project. Run
 # This script from your project's root directory.


### PR DESCRIPTION
They all have ultimate portability issues, but generally think the level of indirection is better.