### PR TITLE
makefile: streamline variable checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ __check_defined = \
 		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
 			required by target '$@')))
 
+COMMON_ENV_VARS := APP_NAME ENVIRONMENT NETWORK_NAME
+
+APP_NAME_HELP := "the name of subdirectory of /infra that holds the application's infrastructure code"
+ENVIRONMENT_HELP := "the name of the application environment e.g. 'prod' or 'staging'"
+NETWORK_NAME_HELP := "the name of the network in /infra/networks"
+
+require-%:
+	@:$(call check_defined, $*, $($*_HELP))
 
 .PHONY : \
 	help \
@@ -58,16 +66,6 @@ __check_defined = \
 	release-image-tag \
 	release-publish \
 	release-run-database-migrations
-
-
-COMMON_ENV_VARS := APP_NAME ENVIRONMENT NETWORK_NAME
-
-APP_NAME_HELP := "the name of subdirectory of /infra that holds the application's infrastructure code"
-ENVIRONMENT_HELP := "the name of the application environment e.g. 'prod' or 'staging'"
-NETWORK_NAME_HELP := "the name of the network in /infra/networks"
-
-require-%:
-	@:$(call check_defined, $*, $($*_HELP))
 
 infra-set-up-account: ## Configure and create resources for current AWS profile and save tfbackend file to infra/accounts/$ACCOUNT_NAME.ACCOUNT_ID.s3.tfbackend
 	@:$(call check_defined, ACCOUNT_NAME, human readable name for account e.g. "prod" or the AWS account alias)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ __check_defined = \
 	release-publish \
 	release-run-database-migrations
 
+
+COMMON_ENV_VARS := APP_NAME ENVIRONMENT NETWORK_NAME
+
 APP_NAME_HELP := "the name of subdirectory of /infra that holds the application's infrastructure code"
 ENVIRONMENT_HELP := "the name of the application environment e.g. 'prod' or 'staging'"
 NETWORK_NAME_HELP := "the name of the network in /infra/networks"
@@ -226,3 +229,6 @@ help: ## Prints the help documentation and info about each command
 	@echo "SHELL=$(SHELL)"
 	@echo "MAKE_VERSION=$(MAKE_VERSION)"
 	@echo "MODULES=$(MODULES)"
+	@echo ""
+	@echo "Commonly needed environment variables help:"
+	@printf "%s\n" $(foreach env_var, $(COMMON_ENV_VARS), $(env_var)=$($(env_var)_HELP))


### PR DESCRIPTION
## Changes

Reduce boilerplate for commonly used environment variables. And generally rather than more imperatively checking variables, having a target to do the check and moving them to the prerequisite list feels "cleaner".

TODO:
- Don't love `require-` prefix, was thinking maybe just `var-%`? Or more verbose `check-defined-%`/`assert-set-%`
- Moving to a target instead of inline function call does lose the context in the "error" message of which target it's coming from (though generally should be obvious).

## Testing

Run some make commands.

TODO: screenshots
