### PR TITLE
makefile: breakout some common functionality into includable file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include make-lib/base.mk
+
 PROJECT_ROOT ?= $(notdir $(PWD))
 
 # Use `=` instead of `:=` so that we only execute `./bin/current-account-alias.sh` when needed
@@ -9,22 +11,6 @@ CURRENT_ACCOUNT_ID = $(./bin/current-account-id.sh)
 # Get the list of reusable terraform modules by getting out all the modules
 # in infra/modules and then stripping out the "infra/modules/" prefix
 MODULES := $(notdir $(wildcard infra/modules/*))
-
-# Check that given variables are set and all have non-empty values,
-# die with an error otherwise.
-#
-# Params:
-#   1. Variable name(s) to test.
-#   2. (optional) Error message to print.
-# Based off of https://stackoverflow.com/questions/10858261/how-to-abort-makefile-if-variable-not-set
-check_defined = \
-	$(strip $(foreach 1,$1, \
-        $(call __check_defined,$1,$(strip $(value 2)))))
-__check_defined = \
-	$(if $(value $1),, \
-		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
-			required by target '$@')))
-
 
 .PHONY : \
 	help \
@@ -215,18 +201,14 @@ release-image-tag: ## Prints the image tag of the release image
 ## Scripts and Helper ##
 ########################
 
+HELP_VARS := \
+  APP_NAME \
+  ENVIRONMENT \
+  IMAGE_NAME \
+  IMAGE_TAG \
+  INFO_TAG \
+  GIT_REPO_AVAILABLE \
+  MODULES
+
 help: ## Prints the help documentation and info about each command
-	@grep -Eh '^[[:print:]]+:.*?##' $(MAKEFILE_LIST) | \
-	sort -d | \
-	awk -F':.*?## ' '{printf "\033[36m%s\033[0m\t%s\n", $$1, $$2}' | \
-	column -t -s "$$(printf '\t')"
-	@echo ""
-	@echo "APP_NAME=$(APP_NAME)"
-	@echo "ENVIRONMENT=$(ENVIRONMENT)"
-	@echo "IMAGE_NAME=$(IMAGE_NAME)"
-	@echo "IMAGE_TAG=$(IMAGE_TAG)"
-	@echo "INFO_TAG=$(INFO_TAG)"
-	@echo "GIT_REPO_AVAILABLE=$(GIT_REPO_AVAILABLE)"
-	@echo "SHELL=$(SHELL)"
-	@echo "MAKE_VERSION=$(MAKE_VERSION)"
-	@echo "MODULES=$(MODULES)"
+help: help/standard

--- a/make-lib/base.mk
+++ b/make-lib/base.mk
@@ -1,0 +1,49 @@
+# Makefiles using this library should include a target called `help` or override
+# `.DEFAULT_GOAL` if another default behavior is needed.
+.DEFAULT_GOAL := help
+
+# Check that given variables are set and all have non-empty values,
+# die with an error otherwise.
+#
+# Params:
+#   1. Variable name(s) to test.
+#   2. (optional) Error message to print.
+# Based off of https://stackoverflow.com/questions/10858261/how-to-abort-makefile-if-variable-not-set
+check_defined = \
+	$(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+	$(if $(value $1),, \
+		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
+			required by target '$@')))
+
+# Prints the make targets and their docstring (the content after '##'). Pull it
+# into your own `help` target as a prerequisite.
+help/targets:
+	@grep -Eh '^[^#[:space:]]+[[:print:]]+:.*?##' $(MAKEFILE_LIST) | \
+	sort -d | \
+	awk -F':.*?## ' '{printf "\033[36m%s\033[0m\t%s\n", $$1, $$2}' | \
+	column -t -s "$$(printf '\t')"
+
+# Prints various make/env vars name and current value, some common ones and any
+# specified by the HELP_VARS variable
+# @printf "%s\n" $(foreach env_var, $(HELP_VARS), $(var)=$($(var)_HELP))
+help/vars:
+	@printf "%s\n" $(foreach var_name, $(HELP_VARS), "$(var_name)=$($(var_name))")
+	@echo ""
+	@echo "SHELL=$(SHELL)"
+	@echo "MAKE_VERSION=$(MAKE_VERSION)"
+
+
+help/empty-line:
+	@echo ""
+
+# A common configuration that should cover the basics.
+#
+# Most projects should be able to just define:
+#
+#    help: ## Prints the help documentation and info about each command
+#    help: help-standard
+#
+# And set HELP_VARS for any project-specific variables to include.
+help/standard: help/targets help/empty-line help/vars


### PR DESCRIPTION
## Changes

Example for consolidating some shared functionality between a bunch of template makefiles.

Could be built on with a file for common docker stuff, desired common targets (e.g., `lint`, `test`) etc. to further streamline application makefiles.

TODO:
- Not sure how realistically different projects would need to do something radically different for the `help` target, so could have that defined by default? Or maybe include a standard `help` alias for `help-standard` in a different lib file?

## Testing

Run some make commands.