### PR TITLE
Remove terraform -refresh-only commands

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -23,14 +23,14 @@ runs:
         echo "::group::AWS account authentication details"
 
         terraform -chdir=infra/project-config init > /dev/null
-        terraform -chdir=infra/project-config apply -refresh-only -auto-approve> /dev/null
+        terraform -chdir=infra/project-config apply -auto-approve > /dev/null
         AWS_REGION=$(terraform -chdir=infra/project-config output -raw default_region)
         echo "AWS_REGION=$AWS_REGION"
         GITHUB_ACTIONS_ROLE_NAME=$(terraform -chdir=infra/project-config output -raw github_actions_role_name)
         echo "GITHUB_ACTIONS_ROLE_NAME=$GITHUB_ACTIONS_ROLE_NAME"
 
         terraform -chdir=infra/${{ inputs.app_name }}/app-config init > /dev/null
-        terraform -chdir=infra/${{ inputs.app_name }}/app-config apply -refresh-only -auto-approve> /dev/null 
+        terraform -chdir=infra/${{ inputs.app_name }}/app-config apply -auto-approve > /dev/null
         ACCOUNT_NAME=$(terraform -chdir=infra/${{ inputs.app_name }}/app-config output -json account_names_by_environment | jq -r .${{ inputs.environment }})
         echo "ACCOUNT_NAME=$ACCOUNT_NAME"
 

--- a/bin/configure-monitoring-secret.sh
+++ b/bin/configure-monitoring-secret.sh
@@ -17,7 +17,7 @@ ENVIRONMENT=$2
 INTEGRATION_ENDPOINT_URL=$3
 
 terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
-terraform -chdir="infra/$APP_NAME/app-config" apply -refresh-only -auto-approve> /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
 
 HAS_INCIDENT_MANAGEMENT_SERVICE=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw has_incident_management_service)
 if [ "$HAS_INCIDENT_MANAGEMENT_SERVICE" = "false" ]; then

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -16,7 +16,7 @@ echo "  IMAGE_TAG=$IMAGE_TAG"
 
 # Need to init module when running in CD since GitHub actions does a fresh checkout of repo
 terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
-terraform -chdir="infra/$APP_NAME/app-config" apply -refresh-only -auto-approve> /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
 IMAGE_REPOSITORY_NAME=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw image_repository_name)
 
 REGION=$(./bin/current-region.sh)

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -30,7 +30,7 @@ echo
 echo "Step 0. Check if app has a database"
 
 terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
-terraform -chdir="infra/$APP_NAME/app-config" apply -refresh-only -auto-approve> /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
 HAS_DATABASE=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw has_database)
 if [ "$HAS_DATABASE" = "false" ]; then
   echo "Application does not have a database, no migrations to run"

--- a/bin/set-up-current-account.sh
+++ b/bin/set-up-current-account.sh
@@ -28,7 +28,7 @@ ACCOUNT_ID=$(./bin/current-account-id.sh)
 REGION=$(./bin/current-region.sh)
 
 # Get project name
-terraform -chdir="infra/project-config" apply -refresh-only -auto-approve> /dev/null
+terraform -chdir="infra/project-config" apply -auto-approve > /dev/null
 PROJECT_NAME=$(terraform -chdir=infra/project-config output -raw project_name)
 
 TF_STATE_BUCKET_NAME="$PROJECT_NAME-$ACCOUNT_ID-$REGION-tf"


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.

- Remove all instances of `terraform <plan|apply> -refresh-only`

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

### Problem

A couple days ago, multiple people working with different git repos that use the template-infra started to notice deploy failures showing this error:

```
AWS account authentication details
  ╷
  │ Error: Cannot apply non-applyable plan
  │ 
  │ The given plan is not applyable. If this seems like a bug in Terraform,
  │ then please report it!
  ╵
  Error: Process completed with exit code 1.
```

<img width="972" alt="CleanShot 2024-04-19 at 15 18 34@2x" src="https://github.com/navapbc/template-infra/assets/67701/8dcd6fc1-49ad-441e-8dcb-72515fb502c7">

This is happening during the [Configure AWS Credentials](https://github.com/navapbc/template-infra/blob/main/.github/actions/configure-aws-credentials/action.yml) action, which is called a couple different times in the CD process.

### Trigger

Github Actions released a [new ubuntu runner image version](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240414.1) on 2024-04-14. The previous version was [ubuntu 20240407.1](https://github.com/actions/runner-images/blob/ubuntu22/20240407.1/images/ubuntu/Ubuntu2204-Readme.md) and the new version is [ubuntu 20240414.1](https://github.com/actions/runner-images/blob/ubuntu22/20240414.1/images/ubuntu/Ubuntu2204-Readme.md). 

The new runner includes some changes, including updating terraform from 1.7.5 to 1.8.0. 

#### Example

Here's an example from the [navapbc/platform-test-nextjs](https://github.com/navapbc/platform-test-nextjs) repo, which is used for testing the [next.js template](https://github.com/navapbc/template-application-nextjs):

- [Passing workflow](https://github.com/navapbc/platform-test-nextjs/actions/runs/8695954068/job/23848136556) on 2024-04-15 using the ubuntu 20240407.1.0 runner
- [Failing job](https://github.com/navapbc/platform-test-nextjs/actions/runs/8731164479/job/23956143914) on 2024-04-17 using the ubuntu 20240414.1.0 runner

### Cause

@coilysiren [🔒 tracked the issue down](https://nava.slack.com/archives/C03G1SWD9H7/p1713475794313719?thread_ts=1713300322.804609&cid=C03G1SWD9H7) to [this section](https://github.com/hashicorp/terraform/blob/3f4c2f007924c9790f44dbe399162a608de18e03/internal/terraform/context_apply.go#L105-L115) of the terraform source code and identified that it is related to our usage of `-refresh-only`. Unfortunately, the terraform source code includes this comment for this error message:

```
// This situation isn't something we expect, since our own rules
// for what "applyable" means make this scenario impossible. We'll
// reject it on the assumption that something very strange is
// going on. and so better to halt than do something incorrect.
// This error message is generic and useless because we don't
// expect anyone to ever see it in normal use.
```

After numerous trials, I confirmed that it is definitely tied to our use of `terraform apply -refresh-only`. Interestingly, running `terraform plan -refresh-only` without `terraform apply` [🔒 returns no terraform error](https://github.com/navapbc/pfml-starter-kit-app/actions/runs/8758036469/job/24037955869).

@coilysiren [🔒 pointed out](https://nava.slack.com/archives/C03G1SWD9H7/p1713568581723929?thread_ts=1713300322.804609&cid=C03G1SWD9H7) that we can reproduce this issue on 1.8.0 locally for modules that are missing a `terraform.tfstate` file.

### Resolution

This PR removes `-refresh-only` and resolves this issue (see [🔒 example](https://github.com/navapbc/pfml-starter-kit-app/actions/runs/8759775416)).

`-refresh-only` [is intended for](https://developer.hashicorp.com/terraform/cli/commands/plan#planning-modes):

> Refresh-only mode: creates a plan whose goal is only to update the Terraform state and any root module output values to match changes made to remote objects outside of Terraform. This can be useful if you've intentionally changed one or more remote objects outside of the usual workflow (e.g. while responding to an incident) and you now need to reconcile Terraform's records with those changes.

In light of this, I believe it is safe for us to remove all references to `-refresh-only` because:

- We are only calling `-refresh-only` on terraform modules that define and output locals, which terraform likely considers incorrect usage
- We are not calling `-refresh-only` on terraform modules that have remote resources defined and have any remote changes to pull in
- We only added `-refresh-only` because `terraform refresh` was deprecated and we followed the terraform guidance on replacing it (see #412). In other words, we were not trying to accomplish anything particular by introducing `-refresh-only` and we shouldn't hold onto it if it's causing us issues and removing it resolves them.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

- See [🔒 example](https://github.com/navapbc/pfml-starter-kit-app/actions/runs/8759775416)
- See CI test results