### PR TITLE
Add AWS defaults to container definitions to produce clean tf plan

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -98,10 +98,13 @@ resource "aws_ecs_task_definition" "app" {
       portMappings = [
         {
           containerPort = var.container_port,
+          hostPort      = var.container_port,
+          protocol      = "tcp"
         }
       ],
       linuxParameters = {
         capabilities = {
+          add  = []
           drop = ["ALL"]
         },
         initProcessEnabled = true
@@ -114,6 +117,9 @@ resource "aws_ecs_task_definition" "app" {
           "awslogs-stream-prefix" = local.log_stream_prefix
         }
       }
+      mountPoints    = []
+      systemControls = []
+      volumesFrom    = []
     }
   ])
 


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/600

## Changes

see title

## Context for reviewers

Unclear when this started happening, it's possible it's related to when we upgraded either terraform or when we upgraded the AWS provider, but in any case the terraform plan in the service layer is always showing a diff now even after applying any changes. This change adds some AWS default parameters to container_definitions.json to cause the plan to show a clean diff.

## Testing

Developed and tested on platform test in https://github.com/navapbc/platform-test/pull/97