### PR TITLE
Move account name config into into env-config

### DIFF
--- a/docs/infra/set-up-app-env.md
+++ b/docs/infra/set-up-app-env.md
@@ -9,12 +9,14 @@ The application environment setup process will:
 Before setting up the application's environments you'll need to have:
 
 1. [A compatible application in the app folder](https://github.com/navapbc/template-infra/blob/main/template-only-docs/application-requirements.md)
-2. [Configure the app](/infra/app/app-config/main.tf). Make sure you update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with.
+2. [Set up the AWS account that this environment is going to use](/docs/infra/set-up-aws-account.md).
+3. [Configure the app](/infra/app/app-config/main.tf). Make sure you update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with.
    1. If you're configuring your production environment, make sure to update the `service_cpu`, `service_memory`, and `service_desired_instance_count` settings based on the project's needs. If your application is sensitive to performance, consider doing a load test.
-3. [Create a nondefault VPC to be used by the application](./set-up-network.md)
-4. (If the application has a database) [Set up the database for the application](./set-up-database.md)
-5. (If you have an incident management service) [Set up monitoring](./set-up-monitoring-alerts.md)
-6. [Set up the application build repository](./set-up-app-build-repository.md)
+   2. Make sure your application environment is using the AWS Account you want to use by checking the `account_name` property in the environment configuration and updating it if necessary.
+4. [Create a nondefault VPC to be used by the application](./set-up-network.md)
+5. (If the application has a database) [Set up the database for the application](./set-up-database.md)
+6. (If you have an incident management service) [Set up monitoring](./set-up-monitoring-alerts.md)
+7. [Set up the application build repository](./set-up-app-build-repository.md)
 
 ## 1. Configure backend
 
@@ -36,7 +38,7 @@ Before creating the application resources, you'll need to first build and publis
 There are two ways to do this:
 
 1. Trigger the "Build and Publish" workflow from your repo's GitHub Actions tab. This option requires that the `role-to-assume` GitHub workflow variable has already been set up as part of the overall infra account setup process.
-1. Alternatively, run the following from the root directory. This option can take much longer than the GitHub workflow, depending on your machine's architecture.
+2. Alternatively, run the following from the root directory. This option can take much longer than the GitHub workflow, depending on your machine's architecture.
 
     ```bash
     make release-build APP_NAME=app

--- a/docs/infra/set-up-aws-account.md
+++ b/docs/infra/set-up-aws-account.md
@@ -37,10 +37,6 @@ make infra-set-up-account ACCOUNT_NAME=<ACCOUNT_NAME>
 
 This command will create the S3 tfstate bucket and the GitHub OIDC provider. It will also create a `[account name].[account id].s3.tfbackend` file in the `infra/accounts` directory.
 
-### 3. Update the account names map in app-config
-
-In [app-config/main.tf](/infra/app/app-config/main.tf), update the `account_names_by_environment` config to reflect the account name you chose.
-
 ## Making changes to the account
 
 If you make changes to the account terraform and want to apply those changes, run

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -4,6 +4,7 @@ module "dev_config" {
   app_name                        = local.app_name
   default_region                  = module.project_config.default_region
   environment                     = "dev"
+  account_name                    = "dev"
   network_name                    = "dev"
   domain_name                     = null
   enable_https                    = false

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -1,3 +1,8 @@
+output "account_name" {
+  value       = var.account_name
+  description = "Name of the AWS account that contains the resources for the application environment."
+}
+
 output "database_config" {
   value = var.has_database ? {
     region                      = var.default_region

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -14,9 +14,10 @@ variable "environment" {
 variable "account_name" {
   description = <<EOF
     Name of the AWS account that contains the resources for the application environment.
-    The list of configured AWS accounts can be found in /infra/account
-    by looking for the backend config files of the form:
+    The list of configured AWS accounts is stored in /infra/account as 
+    backend config files with the naming convention:
       <ACCOUNT_NAME>.<ACCOUNT_ID>.s3.tfbackend
+    Provide the ACCOUNT_NAME for this variable.
     EOF
   type        = string
 }

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -11,6 +11,16 @@ variable "environment" {
   type        = string
 }
 
+variable "account_name" {
+  description = <<EOF
+    Name of the AWS account that contains the resources for the application environment.
+    The list of configured AWS accounts can be found in /infra/account
+    by looking for the backend config files of the form:
+      <ACCOUNT_NAME>.<ACCOUNT_ID>.s3.tfbackend
+    EOF
+  type        = string
+}
+
 variable "network_name" {
   description = "Human readable identifier of the network / VPC"
   type        = string

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -12,13 +12,13 @@ variable "environment" {
 }
 
 variable "account_name" {
-  description = <<EOF
+  description = <<EOT
     Name of the AWS account that contains the resources for the application environment.
     The list of configured AWS accounts is stored in /infra/account as 
     backend config files with the naming convention:
       <ACCOUNT_NAME>.<ACCOUNT_ID>.s3.tfbackend
     Provide the ACCOUNT_NAME for this variable.
-    EOF
+    EOT
   type        = string
 }
 

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -34,41 +34,12 @@ locals {
     region = module.project_config.default_region
   }
 
-  # Map from environment name to the account name for the AWS account that
-  # contains the resources for that environment. Resources that are shared
-  # across environments use the key "shared".
+  # The name of the AWS account that contains the resources shared across all
+  # application environments, such as the build repository.
   # The list of configured AWS accounts can be found in /infra/account
   # by looking for the backend config files of the form:
   #   <ACCOUNT_NAME>.<ACCOUNT_ID>.s3.tfbackend
-  #
-  # Projects/applications that use the same AWS account for all environments
-  # will refer to the same account for all environments. For example, if the
-  # project has a single account named "myaccount", then infra/accounts will
-  # have one tfbackend file myaccount.XXXXX.s3.tfbackend, and the 
-  # account_names_by_environment map will look like:
-  #
-  #   account_names_by_environment = {
-  #     shared  = "myaccount"
-  #     dev     = "myaccount"
-  #     staging = "myaccount"
-  #     prod    = "myaccount"
-  #   }
-  #
-  # Projects/applications that have separate AWS accounts for each environment
-  # might have a map that looks more like this:
-  #
-  #   account_names_by_environment = {
-  #     shared  = "dev"
-  #     dev     = "dev"
-  #     staging = "staging"
-  #     prod    = "prod"
-  #   }
-  account_names_by_environment = {
-    shared  = "dev"
-    dev     = "dev"
-    staging = "dev"
-    prod    = "prod"
-  }
+  shared_account_name = "dev"
 }
 
 module "project_config" {

--- a/infra/app/app-config/outputs.tf
+++ b/infra/app/app-config/outputs.tf
@@ -3,7 +3,13 @@ output "app_name" {
 }
 
 output "account_names_by_environment" {
-  value = local.account_names_by_environment
+  value = merge(
+    {
+      for environment, environment_config in local.environment_configs :
+      environment => environment_config.account_name
+    },
+    { shared = local.shared_account_name },
+  )
 }
 
 output "environments" {
@@ -36,4 +42,8 @@ output "build_repository_config" {
 
 output "environment_configs" {
   value = local.environment_configs
+}
+
+output "shared_account_name" {
+  value = local.shared_account_name
 }

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -4,6 +4,7 @@ module "prod_config" {
   app_name                        = local.app_name
   default_region                  = module.project_config.default_region
   environment                     = "prod"
+  account_name                    = "prod"
   network_name                    = "prod"
   domain_name                     = null
   enable_https                    = false

--- a/infra/app/app-config/staging.tf
+++ b/infra/app/app-config/staging.tf
@@ -4,6 +4,7 @@ module "staging_config" {
   app_name                        = local.app_name
   default_region                  = module.project_config.default_region
   environment                     = "staging"
+  account_name                    = "staging"
   network_name                    = "staging"
   domain_name                     = null
   enable_https                    = false


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/458

## Changes

- Add shared_account_name property to app-config
- Add account_name to env-config
- Refactor account_names_by_environment
- Update docs

## Context for reviewers

For consistency with how we map environments to networks using the environment_config.network_name, this change refactors how we map environments to AWS accounts to use environment_config.account_name. There's a special case for the build-repository which is not part of any application environment but rather shared across all environments. For this we add a new property in app-config called shared_account_name. We can then delete the old account_names_by_environment map, which was a little clunky to explain.

## Testing

Developed and tested in platform-test in https://github.com/navapbc/platform-test/pull/98