### PR TITLE
Skip build step if image already published

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,10 +24,26 @@ on:
         type: string
 
 jobs:
+  get-commit-hash:
+    name: Get commit hash
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Get commit hash
+        id: get-commit-hash
+        run: |
+          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          echo "Commit hash: $COMMIT_HASH"
+          echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
-    concurrency: ${{ github.workflow }}-${{ github.sha }}
+    needs: get-commit-hash
+    concurrency: ${{ github.workflow }}-${{ needs.get-commit-hash.outputs.commit_hash }}
 
     permissions:
       contents: read
@@ -38,14 +54,23 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Build release
-        run: make APP_NAME=${{ inputs.app_name }} release-build
-
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials
         with:
           app_name: ${{ inputs.app_name }}
           environment: shared
 
+      - name: Check if image is already published
+        id: check-image-published
+        run: |
+          IS_IMAGE_PUBLISHED=$(./bin/is-image-published.sh "${{ inputs.app_name }}" "${{ inputs.ref }}")
+          echo "Is image published: $IS_IMAGE_PUBLISHED"
+          echo "IS_IMAGE_PUBLISHED=$IS_IMAGE_PUBLISHED" >> "$GITHUB_OUTPUT"
+
+      - name: Build release
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
+        run: make APP_NAME=${{ inputs.app_name }} release-build
+
       - name: Publish release
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
         run: make APP_NAME=${{ inputs.app_name }} release-publish

--- a/bin/is-image-published.sh
+++ b/bin/is-image-published.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Checks if an image tag has already been published to the container repository
-# Prints 1 if so, 0 otherwise
+# Prints "true" if so, "false" otherwise
 
 set -euo pipefail
 

--- a/bin/is-image-published.sh
+++ b/bin/is-image-published.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Checks if an image tag has already been published to the container repository
+# Prints 1 if so, 0 otherwise
+
+set -euo pipefail
+
+APP_NAME=$1
+GIT_REF=$2
+
+# Get commit hash
+IMAGE_TAG=$(git rev-parse "$GIT_REF")
+
+# Need to init module when running in CD since GitHub actions does a fresh checkout of repo
+terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
+IMAGE_REPOSITORY_NAME=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw image_repository_name)
+REGION=$(./bin/current-region.sh)
+
+RESULT=""
+RESULT=$(aws ecr describe-images --repository-name "$IMAGE_REPOSITORY_NAME" --image-ids "imageTag=$IMAGE_TAG" --region "$REGION" 2> /dev/null ) || true
+if [ -n "$RESULT" ];then
+  echo "true"
+else
+  echo "false"
+fi


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/610
Resolves https://github.com/navapbc/template-infra/issues/609

## Changes

- Skip build step if image already published
- Use commit hash of input.ref for build job concurrency

## Context for reviewers

The build-and-publish worklflow always builds the image and only checks if the image is already published when getting ready to publish. This change moves the published image check before the build step, allowing the workflow to skip the build step altogether if the build has already been published.

In addition, this change fixes the build job concurrency to use the commit hash of the commit being built, not the commit hash of the workflow.

## Testing

Developed and tested in platform-test in https://github.com/navapbc/platform-test/pull/100