### PR TITLE
Include .gitignore in upload-template.sh

### DIFF
--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -24,7 +24,7 @@ git checkout "$TARGET_VERSION"
 TARGET_VERSION_HASH=$(git rev-parse HEAD)
 
 # Note: Keep this list in sync with the files copied in install-template.sh
-git diff "$CURRENT_VERSION" "$TARGET_VERSION" -- .github bin docs infra Makefile .dockleconfig .grype.yml .hadolint.yaml .trivyignore > update.patch
+git diff "$CURRENT_VERSION" "$TARGET_VERSION" -- .github bin docs infra Makefile .dockleconfig .gitignore .grype.yml .hadolint.yaml .trivyignore > update.patch
 cd -
 
 echo "Applying patch"


### PR DESCRIPTION
## Ticket

n/a

## Changes
- Add `.gitignore` to update-template.sh, to keep in sync with `install-template.sh`

## Context for reviewers
 - https://github.com/navapbc/template-infra/commit/ebec2561a3716c1e3e07255b07ed408040722415 updated install-template.sh