### PR TITLE
Update network docs

### DIFF
--- a/docs/infra/set-up-network.md
+++ b/docs/infra/set-up-network.md
@@ -17,7 +17,7 @@ Before setting up the network you'll need to have:
 3. [Configure the app](/infra/app/app-config/main.tf).
    1. Update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with. This setting determines whether or not to create VPC endpoints needed by the database layer.
    2. Update `has_external_non_aws_service` to `true` or `false` depending on whether or not your application makes calls to an external non-AWS service. This setting determines whether or not to create NAT gateways, which allows the service in the private subnet to make requests to the internet.
-   3. Update `network_name` for your application environments. This mapping ensures that each network is configured appropriately based on the application(s) in that network (see `local.apps_in_network` in [/infra/networks/main.tf](/infra/networks/main.tf)) Failure to set the network name properly means that the network layer may not receive the correct application configurations for `has_database` and `has_external_non_aws_service`.
+   3. If you made changes to the configuration of the networks in the optional step 2 above and or to the default application environments: Update `network_name` for your application environments. This mapping ensures that each network is configured appropriately based on the application(s) in that network (see `local.apps_in_network` in [/infra/networks/main.tf](/infra/networks/main.tf)) Failure to set the network name properly means that the network layer may not receive the correct application configurations for `has_database` and `has_external_non_aws_service`.
 
 ## 1. Configure backend
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

 - Small tweak to network documentation to clarify that you only need to take a step if you've made previous (optional) changes during the network set up.

## Context for reviewers
 - This confused me when I was trying to set up the template by myself; I then talked to a colleague who mentioned they had the same issue. (n=2)
 - This update reflects my own understanding of what could cause this step to be non-optional (either a change to the default environments of dev/stage/prod, or a change to the default network) -- if that's not right or I'm missing something, please let me know!