### PR TITLE
Use safe names for psql databases and schemas

### DIFF
--- a/infra/app/app-config/env-config/database.tf
+++ b/infra/app/app-config/env-config/database.tf
@@ -4,7 +4,8 @@ locals {
     cluster_name                = "${var.app_name}-${var.environment}"
     app_username                = "app"
     migrator_username           = "migrator"
-    schema_name                 = var.app_name
+    schema_name                 = local.database_safe_app_name
+    database_name               = local.database_safe_app_name
     app_access_policy_name      = "${var.app_name}-${var.environment}-app-access"
     migrator_access_policy_name = "${var.app_name}-${var.environment}-migrator-access"
 

--- a/infra/app/app-config/env-config/main.tf
+++ b/infra/app/app-config/env-config/main.tf
@@ -4,5 +4,8 @@ locals {
   # if you choose not to use workspaces set this value to "dev"
   prefix = terraform.workspace == "default" ? "" : "${terraform.workspace}-"
 
+  # Database names should not contain dashes, but can contain underscores.
+  database_safe_app_name = replace(var.app_name, "-", "_")
+
   bucket_name = "${local.prefix}${var.project_name}-${var.app_name}-${var.environment}"
 }

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -84,6 +84,7 @@ module "database" {
   app_username      = local.database_config.app_username
   migrator_username = local.database_config.migrator_username
   schema_name       = local.database_config.schema_name
+  database_name     = local.database_config.database_name
 
   vpc_id                         = data.aws_vpc.network.id
   database_subnet_group_name     = local.network_config.database_subnet_group_name

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -30,6 +30,10 @@ variable "migrator_username" {
 variable "schema_name" {
   description = "name of the Postgres schema to create that will be the schema the application will use (rather than using the public schema)"
   type        = string
+  validation {
+    condition     = can(regex("^[_\\da-z]+$", var.schema_name))
+    error_message = "use only lower case letters, numbers, and underscores (no dashes)"
+  }
 }
 
 variable "port" {


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.

- Updates environment config to create a database safe name
- Updates environment config to use new database-safe-name for the database name and the schema name
- Updates the database module to pass through a database name
- Updates the database module to validate the schema name

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

[Per the documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html), PostgreSQL identifiers should be letters, underscores, digits, or dollar signs:

> SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($).

PostgreSQL allows identifiers to include arbitrary characters if the identifier is surrounded by double quotes:

>  There is a second kind of identifier: the delimited identifier or quoted identifier. It is formed by enclosing an arbitrary sequence of characters in double-quotes (").

The infra template's directory naming convention uses hyphens (`-`) to separate multi-word names (e.g. `app-config`, `build-repository`). The `app-config` uses the application directory to generate the `local.app_name` which is used throughout the configuration.

When a project uses the infra template and renames the application directory to a multi-word, hyphenated name, such as `flowable-rest`, this will cause issues unless _every_ instance of the database and schema names is double quoted. Even though we are properly using the [pg8000 `identifier`](https://github.com/tlocke/pg8000?tab=readme-ov-file#quoted-identifiers-in-sql) in the role manager, while working on the [platform-test-rails repo](https://github.com/navapbc/platform-test-rails), I still ran into issues with the following lines because my application uses a hyphenated name (i.e. `app-rails`):

https://github.com/navapbc/template-infra/blob/6f8464ef7ff1cb20a263d0a68705a05e7c3f3206/infra/modules/database/role_manager/manage.py#L104

https://github.com/navapbc/template-infra/blob/6f8464ef7ff1cb20a263d0a68705a05e7c3f3206/infra/modules/database/role_manager/check.py#L32

This PR proposes to protect the database from hyphens by modifying the database name and the schema name to use underscores instead of hyphens.

### Breaking change

⚠️ Warning! This could potentially be a breaking change for any existing projects that use hyphenated database names and have worked around the issue!

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Tested in https://github.com/navapbc/platform-test/pull/104/files:
- Created a new application called `app-hyphen`
- Tested using a workspace: `rldb`
    - Created a database, created roles, and checked roles

A screenshot showing that the database name is correctly using an underscore when creating the database resources:
![CleanShot 2024-06-14 at 14 39 05@2x](https://github.com/navapbc/template-infra/assets/67701/b864e7be-2b0e-4dc8-ad61-84423b034be9)


Snippet showing successfully using an underscore name when creating the roles:
```text
...
postgres> ALTER DATABASE app_hyphen SET search_path TO app_hyphen
---- Configuring roles
------ Configuring role: username='migrator'
...
---- Configuring schema
------ Creating schema: schema_name='app_hyphen'
postgres> CREATE SCHEMA IF NOT EXISTS app_hyphen
------ Changing schema owner: new_owner=migrator
postgres> ALTER SCHEMA app_hyphen OWNER TO migrator
------ Granting schema usage privileges: grantee=app
postgres> GRANT USAGE ON SCHEMA app_hyphen TO app
---- Configuring superuser extensions
-- Current database configuration
---- Roles
------ Role postgres
------ Role migrator
------ Role app
---- Schema privileges
------ Schema name='public' acl='{pg_database_owner=UC/pg_database_owner,=U/pg_database_owner}'
------ Schema name='app_hyphen' acl='{migrator=UC/migrator,app=U/migrator}'
...
```

A snippet showing successfully checking roles when using the underscore name:
```text
...
-- Check that search path is %s app_hyphen
migrator> SHOW search_path
-- Check that migrator is able to create tables
-- Clean up role_manager_test table if it exists
migrator> DROP TABLE IF EXISTS role_manager_test
migrator> CREATE TABLE IF NOT EXISTS role_manager_test(created_at TIMESTAMP)
-- Check that app is able to read and write from the table
...
```