### PR TITLE
Fix role manager print strings

### DIFF
--- a/infra/modules/database/role_manager/check.py
+++ b/infra/modules/database/role_manager/check.py
@@ -28,12 +28,12 @@ def check(config: dict):
 
 
 def check_search_path(migrator_conn: Connection, schema_name: str):
-    print("-- Check that search path is %s", schema_name)
+    print(f"-- Check that search path is {schema_name}")
     assert db.execute(migrator_conn, "SHOW search_path") == [[schema_name]]
 
 
 def check_migrator_create_table(migrator_conn: Connection):
-    print(f"-- Check that migrator is able to create tables")
+    print("-- Check that migrator is able to create tables")
     cleanup_migrator_drop_table(migrator_conn)
     db.execute(
         migrator_conn,

--- a/infra/modules/database/role_manager/db.py
+++ b/infra/modules/database/role_manager/db.py
@@ -12,13 +12,7 @@ def connect_as_master_user() -> Connection:
     database = os.environ["DB_NAME"]
     password = get_master_password()
 
-    print(
-        "Connecting to database: user=%s host=%s port=%s database=%s",
-        user,
-        host,
-        port,
-        database,
-    )
+    print(f"Connecting to database: {user=} {host=} {port=} {database=}")
     return Connection(
         user=user,
         host=host,
@@ -32,7 +26,7 @@ def connect_as_master_user() -> Connection:
 def get_master_password() -> str:
     ssm = boto3.client("ssm", region_name=os.environ["AWS_REGION"])
     param_name = os.environ["DB_PASSWORD_PARAM_NAME"]
-    print("Fetching password from parameter store:\n%s" % param_name)
+    print(f"Fetching password from parameter store:\n{param_name}")
     result = json.loads(
         ssm.get_parameter(Name=param_name, WithDecryption=True)["Parameter"]["Value"]
     )
@@ -45,13 +39,7 @@ def connect_using_iam(user: str) -> Connection:
     port = os.environ["DB_PORT"]
     database = os.environ["DB_NAME"]
     token = client.generate_db_auth_token(DBHostname=host, Port=port, DBUsername=user)
-    print(
-        "Connecting to database: user=%s host=%s port=%s database=%s",
-        user,
-        host,
-        port,
-        database,
-    )
+    print(f"Connecting to database: {user=} {host=} {port=} {database=}")
     return Connection(
         user=user,
         host=host,


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.
- Update database layer's role manager print strings

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

In `/infra/modules/database/role_manager`, some of the `print()` calls introduced in #622 aren't formatted correctly. 

This PR:
- Uses python fstrings for all `print()` string interpolation 
- Uses regular strings (i.e. removes the fstring) if the `print()` call isn't doing any string interpolation

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Tested in https://github.com/navapbc/platform-test/pull/105:
- Created a new workspace `rldb`
- Created resources and roles

### Comparing role manager: `manage`

Before (on platform-test `main`):

![CleanShot 2024-06-14 at 18 37 20@2x](https://github.com/navapbc/template-infra/assets/67701/19bdec23-4e5e-407d-a702-0c1da3d0c96a)

After (on platform-test `rocket/db-role-manager-fstrings` using the workspace `rldb`):

![CleanShot 2024-06-14 at 18 36 47@2x](https://github.com/navapbc/template-infra/assets/67701/0fa90c65-cfd8-4126-9b21-b3549e598c1e)

### Comparing role manager: `check`

Before:

![CleanShot 2024-06-14 at 18 41 35@2x](https://github.com/navapbc/template-infra/assets/67701/d3f717e3-c122-4960-b494-078188c0dd76)

After:

![CleanShot 2024-06-14 at 18 30 21@2x](https://github.com/navapbc/template-infra/assets/67701/1071d533-ceda-459c-9955-0d93328da734)
