### PR TITLE
Refine replace trigger for installation of role manager packages

### DIFF
--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "role_manager" {
 # environment.
 # Timestamp is used to always trigger replacement.
 resource "terraform_data" "role_manager_python_vendor_packages" {
-  triggers_replace = timestamp()
+  triggers_replace = fileexists(local.role_manager_package) ? file("${path.module}/role_manager/requirements.txt") : timestamp()
   provisioner "local-exec" {
     command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor --upgrade"
   }


### PR DESCRIPTION
## Ticket

N/A

## Changes

see title

## Context for reviewers

Previously we only ran installation of role manager packages when the requirements.txt file changed, but this means that new infra engineers who ran terraform apply without having the packages installed locally would update the terraform lambda function to a zip file that didn't contain the dependencies, breaking the role manager.

In this PR https://github.com/navapbc/template-infra/pull/452/files we changed the package installation to always install, which fixed the issue but created an annoying situation where the terraform plan would always show changes to apply.

This change introduces a hybrid solution that works around the new engineer issue by triggering an installation of role manager packages locally if the zip archive doesn't exist locally. Otherwise it relies on changes to requirements.txt. It's not a perfect solution in that terraform apply needs to be run twice in order to get it into a stable state where the replacement trigger is set to the contents of requirements.txt, but it's an improvement over the previous two solutions.

## Testing

Developed and tested on platform-test PR https://github.com/navapbc/platform-test/pull/107