### PR TITLE
Default has_database to true

### DIFF
--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -14,7 +14,7 @@ locals {
   # 2. Each environment's config will have a database_config property that is used to
   #    pass db_vars into the infra/modules/service module, which provides the necessary
   #    configuration for the service to access the database
-  has_database = false
+  has_database = true
 
   # Whether or not the application depends on external non-AWS services.
   # If enabled, the networks associated with this application's environments

--- a/template-only-bin/set-up-project
+++ b/template-only-bin/set-up-project
@@ -37,3 +37,9 @@ sed -i.bak "s/<DEFAULT_REGION>/$DEFAULT_REGION/" main.tf
 
 # Remove the backup file created by sed
 rm main.tf.bak
+
+cd -
+
+# Set has_database to false for template only CI since database setup takes too long
+sed -i.bak "s/has_database = true/has_database = false/" infra/app/app-config/main.tf
+rm infra/app/app-config/main.tf.bak


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Default `has_database` to `true` based on feedback from project teams. Most projects need a database anyways so it's by far the common case.

## Testing

This only changes the default config for a project, not any project specific functionality, so no specific testing is done. Template only CI should still pass, needed to revert has_database to false in template only CI since we don't want to spin up the database for template only CI.

## Rollout notes

1. Template CD will incorrectly set has_database to true in platform-test-nextjs, we'll need to revert that
2. Template CD will probably fail for platform-test and platform-test-flask since this line is already changed in those projects. We'll need to just update the .template-version file manually