### PR TITLE
Add pull request environments

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,6 +11,10 @@ Each app should have:
 - `ci-[app_name]`: must be created; should run linting and testing
 - `ci-[app_name]-vulnerability-scans`: calls `vulnerability-scans`
   - Based on [ci-app-vulnerability-scans](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-app-vulnerability-scans.yml)
+- `ci-[app_name]-pr-environment-update.yml`: calls `pr-environment-update.yml` to create or update a pull request environment (see [pull request environments](/docs/infra/pull-request-environments.md))
+  - Based on [ci-app-pr-environment-update.yml](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-app-pr-environment-update.yml)
+- `ci-[app_name]-pr-environment-destroy.yml`: calls `pr-environment-destroy.yml` to destroy the pull request environment (see [pull request environments](/docs/infra/pull-request-environments.md))
+  - Based on [ci-app-pr-environment-destroy.yml](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-app-pr-environment-destroy.yml)
 
 ### App-agnostic workflows
 
@@ -44,4 +48,3 @@ graph TD
 ## ⛑️ Helper workflows
 
 - [`check-ci-cd-auth`](./check-ci-cd-auth.yml): verifes that the project's Github repo is able to connect to AWS
-

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Get commit hash
@@ -50,7 +50,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/ci-app-pr-environment-destroy.yml
+++ b/.github/workflows/ci-app-pr-environment-destroy.yml
@@ -1,8 +1,9 @@
 name: CI App PR Environment Destroy
 on:
   workflow_dispatch:
-  pull_request:
-    types: [closed]
+  # !! Uncomment the following lines once you've set up the dev environment and are ready to enable PR environments
+  # pull_request:
+  #   types: [closed]
 jobs:
   destroy:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise

--- a/.github/workflows/ci-app-pr-environment-destroy.yml
+++ b/.github/workflows/ci-app-pr-environment-destroy.yml
@@ -1,0 +1,12 @@
+name: CI App PR Environment Destroy
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+jobs:
+  destroy:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    uses: ./.github/workflows/pr-environment-destroy.yml
+    with:
+      app_name: "app"
+      environment: "dev"

--- a/.github/workflows/ci-app-pr-environment-update.yml
+++ b/.github/workflows/ci-app-pr-environment-update.yml
@@ -1,7 +1,8 @@
 name: CI App PR Environment Update
 on:
   workflow_dispatch:
-  pull_request:
+  # !! Uncomment the following lines once you've set up the dev environment and are ready to enable PR environments
+  # pull_request:
 jobs:
   update:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise

--- a/.github/workflows/ci-app-pr-environment-update.yml
+++ b/.github/workflows/ci-app-pr-environment-update.yml
@@ -1,0 +1,11 @@
+name: CI App PR Environment Update
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  update:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    uses: ./.github/workflows/pr-environment-update.yml
+    with:
+      app_name: "app"
+      environment: "dev"

--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -1,0 +1,42 @@
+name: PR Environment Destroy
+run-name: Destroy PR Environment ${{ github.event.number }}
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+jobs:
+  destroy:
+    name: Destroy environment
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write # Needed to comment on PR
+
+    concurrency: pr-environment-${{ github.event.number }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.8.3
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: ${{ inputs.app_name }}
+          environment: ${{ inputs.environment }}
+
+      - name: Destroy environment
+        run: ./bin/destroy-pr-environment "${{ inputs.app_name }}" "${{ inputs.environment }}" "${{ github.event.number }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-environment-update.yml
+++ b/.github/workflows/pr-environment-update.yml
@@ -1,0 +1,50 @@
+name: PR Environment Update
+run-name: Update PR Environment ${{ github.event.number }}
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+jobs:
+  build-and-publish:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    uses: ./.github/workflows/build-and-publish.yml
+    with:
+      app_name: ${{ inputs.app_name }}
+      ref: ${{ github.sha }}
+
+  update:
+    name: Update environment
+    needs: [build-and-publish]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write # Needed to comment on PR
+
+    concurrency: pr-environment-${{ github.event.number }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.8.3
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: ${{ inputs.app_name }}
+          environment: ${{ inputs.environment }}
+
+      - name: Update environment
+        run: ./bin/update-pr-environment "${{ inputs.app_name }}" "${{ inputs.environment }}" "${{ github.event.number }}" "${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Now you're ready to set up the various pieces of your infrastructure.
 After downloading and installing the template into your project:
 
 1. Follow the steps in [infra/README.md](/infra/README.md) to setup the infrastructure for your application.
-1. After setting up AWS resources, you can [set up GitHub Actions workflows](./template-only-docs/set-up-ci.md).
-1. After configuring GitHub Actions, you can [set up continuous deployment](./template-only-docs/set-up-cd.md).
-1. At any point, [set up your team workflow](./template-only-docs/set-up-team-workflow.md).
+2. After setting up AWS resources, you can [set up GitHub Actions workflows](./template-only-docs/set-up-ci.md).
+3. After configuring GitHub Actions, you can [set up continuous deployment](./template-only-docs/set-up-cd.md).
+4. After setting up continuous deployment, you can optionally [set up pull request environments](./template-only-docs/set-up-pr-environments.md)
+5. At any point, [set up your team workflow](./template-only-docs/set-up-team-workflow.md).
 
 ## Updates
 

--- a/bin/destroy-pr-environment
+++ b/bin/destroy-pr-environment
@@ -6,7 +6,7 @@
 #   app_name (required) – the name of subdirectory of /infra that holds the
 #     application's infrastructure code.
 #   environment - the name of the application environment (e.g. dev, staging, prod)
-#   pr_nubmer - the pull request number in GitHub
+#   pr_number - the pull request number in GitHub
 # -----------------------------------------------------------------------------
 set -euo pipefail
 

--- a/bin/destroy-pr-environment
+++ b/bin/destroy-pr-environment
@@ -10,9 +10,9 @@
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
-app_name=$1
-environment=$2
-pr_number=$3
+app_name="$1"
+environment="$2"
+pr_number="$3"
 
 workspace="p-${pr_number}"
 

--- a/bin/destroy-pr-environment
+++ b/bin/destroy-pr-environment
@@ -1,0 +1,37 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Destroy the temporary environment that was created for the pull request.
+#
+# Positional parameters:
+#   app_name (required) – the name of subdirectory of /infra that holds the
+#     application's infrastructure code.
+#   environment - the name of the application environment (e.g. dev, staging, prod)
+#   pr_nubmer - the pull request number in GitHub
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+app_name=$1
+environment=$2
+pr_number=$3
+
+workspace="p-${pr_number}"
+
+echo "::group::Initialize Terraform with backend for environment: ${environment}"
+terraform -chdir="infra/${app_name}/service" init -backend-config="${environment}.s3.tfbackend"
+echo "::endgroup::"
+
+echo "Select Terraform workspace: ${workspace}"
+terraform -chdir="infra/${app_name}/service" workspace select "${workspace}"
+
+echo "::group::Destroy resources"
+terraform -chdir="infra/${app_name}/service" destroy -var="environment_name=${environment}" -input=false -auto-approve
+echo "::endgroup::"
+
+echo "Select default workspace"
+terraform -chdir="infra/${app_name}/service" workspace select default
+
+echo "Delete workspace: ${workspace}"
+terraform -chdir="infra/${app_name}/service" workspace delete "${workspace}"
+
+echo "Post comment to PR confirming environment destruction"
+gh pr comment "${pr_number}" -b "Destroyed PR environment"

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -12,10 +12,10 @@
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
-app_name=$1
-environment=$2
-pr_number=$3
-image_tag=$4
+app_name="$1"
+environment="$2"
+pr_number="$3"
+image_tag="$4"
 
 workspace="p-${pr_number}"
 

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -7,7 +7,7 @@
 #   app_name (required) – the name of subdirectory of /infra that holds the
 #     application's infrastructure code.
 #   environment - the name of the application environment (e.g. dev, staging, prod)
-#   pr_nubmer - the pull request number in GitHub
+#   pr_number - the pull request number in GitHub
 #   image_tag - the commit hash to deploy for the temporary environment
 # -----------------------------------------------------------------------------
 set -euo pipefail

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -36,5 +36,5 @@ echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 
 echo "Post comment to PR with service endpoint"
-service_endpoint=$(terraform -chdir="infra/${app_name}/service" output -raw service_endpoint)
+service_endpoint="$(terraform -chdir="infra/${app_name}/service" output -raw service_endpoint)"
 gh pr comment "${pr_number}" -b "Updated PR environment at ${service_endpoint}"

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -30,8 +30,8 @@ echo "::group::Apply changes to environment using image tag: ${image_tag}"
 terraform -chdir="infra/${app_name}/service" apply -input=false -auto-approve -var="environment_name=${environment}" -var="image_tag=${image_tag}"
 echo "::endgroup::"
 
-cluster_name=$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)
-service_name=$(terraform -chdir="infra/$app_name/service" output -raw service_name)
+cluster_name="$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)"
+service_name="$(terraform -chdir="infra/$app_name/service" output -raw service_name)"
 echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -33,7 +33,7 @@ echo "::endgroup::"
 cluster_name=$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)
 service_name=$(terraform -chdir="infra/$app_name/service" output -raw service_name)
 echo "Wait for service ${service_name} to become stable"
-aws ecs wait services-stable --cluster "$cluster_name" --services "$service_name"
+aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 
 echo "Post comment to PR with service endpoint"
 service_endpoint=$(terraform -chdir="infra/${app_name}/service" output -raw service_endpoint)

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -1,0 +1,40 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Create or update a temporary environment that will exist while a pull request
+# is open.
+#
+# Positional parameters:
+#   app_name (required) – the name of subdirectory of /infra that holds the
+#     application's infrastructure code.
+#   environment - the name of the application environment (e.g. dev, staging, prod)
+#   pr_nubmer - the pull request number in GitHub
+#   image_tag - the commit hash to deploy for the temporary environment
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+app_name=$1
+environment=$2
+pr_number=$3
+image_tag=$4
+
+workspace="p-${pr_number}"
+
+echo "::group::Initialize Terraform with backend for environment: ${environment}"
+terraform -chdir="infra/${app_name}/service" init -backend-config="${environment}.s3.tfbackend"
+echo "::endgroup::"
+
+echo "Select or create Terraform workspace: ${workspace}"
+terraform -chdir="infra/${app_name}/service" workspace select -or-create "${workspace}"
+
+echo "::group::Apply changes to environment using image tag: ${image_tag}"
+terraform -chdir="infra/${app_name}/service" apply -input=false -auto-approve -var="environment_name=${environment}" -var="image_tag=${image_tag}"
+echo "::endgroup::"
+
+cluster_name=$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)
+service_name=$(terraform -chdir="infra/$app_name/service" output -raw service_name)
+echo "Wait for service $service_name to become stable"
+aws ecs wait services-stable --cluster "$cluster_name" --services "$service_name"
+
+echo "Post comment to PR with service endpoint"
+service_endpoint=$(terraform -chdir="infra/${app_name}/service" output -raw service_endpoint)
+gh pr comment "${pr_number}" -b "Updated PR environment at ${service_endpoint}"

--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -32,7 +32,7 @@ echo "::endgroup::"
 
 cluster_name=$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)
 service_name=$(terraform -chdir="infra/$app_name/service" output -raw service_name)
-echo "Wait for service $service_name to become stable"
+echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "$cluster_name" --services "$service_name"
 
 echo "Post comment to PR with service endpoint"

--- a/docs/infra/pull-request-environments.md
+++ b/docs/infra/pull-request-environments.md
@@ -23,7 +23,7 @@ This guidance is not strict. It is still okay to combine database migrations and
 Pull request environments are created by GitHub Actions workflows. There are two reusable callable workflows that manage pull request environments:
 
 - [pr-environment-update.yml](/.github/workflows/pr-environment-update.yml) - creates or updates a temporary environment in a separate Terraform workspace for a given application and pull request
-- [pr-environment-update.yml](/.github/workflows/pr-environment-update.yml) - destroys a temporary environment and workspace for a given application and pull request
+- [pr-environment-destroy.yml](/.github/workflows/pr-environment-destroy.yml) - destroys a temporary environment and workspace for a given application and pull request
 
 Using these reusable workflows, configure PR environments for each application with application-specific workflows:
 

--- a/docs/infra/pull-request-environments.md
+++ b/docs/infra/pull-request-environments.md
@@ -16,7 +16,7 @@ Database migrations are not reflected in PR environments. In particular, PR envi
 
 Therefore, isolate database changes in their own pull request and merge that pull request first before opening pull requests with application changes that depend on those database changes. Note that it is still okay and encouraged to develop database and application changes together during local development.
 
-That this guidance is not strict. It is still okay to combine database migrations and application changes in a single pull request. However, when doing so, note that the PR environment may not be fully functional if the application changes rely on the database migrations.
+This guidance is not strict. It is still okay to combine database migrations and application changes in a single pull request. However, when doing so, note that the PR environment may not be fully functional if the application changes rely on the database migrations.
 
 ## Implementing pull request environments for each application
 

--- a/docs/infra/pull-request-environments.md
+++ b/docs/infra/pull-request-environments.md
@@ -1,0 +1,33 @@
+# Pull request environments
+
+A temporary environment is created for each pull request that stays up while the pull request is open. Use cases for the temporary pull request environment includes:
+
+- Allow other delivery stakeholders—including product managers, designers, and business owners—to review changes before being merged and deployed
+- Enable automated end-to-end tests on the pull request
+- Enable automated accessibility checks on the pull request
+
+## Lifecycle of pull request environments
+
+A pull request environment is created when a pull request is opened or reopened, and destroyed when the pull request is merged or closed. When new commits are pushed up to the pull request, the pull request environment is updated.
+
+## Isolate database migrations into separate pull requests
+
+Database migrations are not reflected in PR environments. In particular, PR environments shares the same database with the dev environment, so database migrations that exist in the pull request are not run on the database to avoid impacting the dev environment.
+
+Therefore, isolate database changes in their own pull request and merge that pull request first before opening pull requests with application changes that depend on those database changes. Note that it is still okay and encouraged to develop database and application changes together during local development.
+
+That this guidance is not strict. It is still okay to combine database migrations and application changes in a single pull request. However, when doing so, note that the PR environment may not be fully functional if the application changes rely on the database migrations.
+
+## Implementing pull request environments for each application
+
+Pull request environments are created by GitHub Actions workflows. There are two reusable callable workflows that manage pull request environments:
+
+- [pr-environment-update.yml](/.github/workflows/pr-environment-update.yml) - creates or updates a temporary environment in a separate Terraform workspace for a given application and pull request
+- [pr-environment-update.yml](/.github/workflows/pr-environment-update.yml) - destroys a temporary environment and workspace for a given application and pull request
+
+Using these reusable workflows, configure PR environments for each application with application-specific workflows:
+
+- `ci-[app_name]-pr-environment-update.yml`
+  - Based on [ci-app-pr-environment-update.yml](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-app-pr-environment-update.yml)
+- `ci-[app_name]-pr-environment-destroy.yml`
+  - Based on [ci-app-pr-environment-destroy.yml](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-app-pr-environment-destroy.yml)

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -22,7 +22,7 @@ locals {
   # make calls to the internet.
   has_external_non_aws_service = false
 
-  has_incident_management_service = true
+  has_incident_management_service = false
 
   environment_configs = {
     dev     = module.dev_config

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -22,7 +22,7 @@ locals {
   # make calls to the internet.
   has_external_non_aws_service = false
 
-  has_incident_management_service = false
+  has_incident_management_service = true
 
   environment_configs = {
     dev     = module.dev_config

--- a/template-only-docs/set-up-pr-environments.md
+++ b/template-only-docs/set-up-pr-environments.md
@@ -2,4 +2,7 @@
 
 [Pull request environments](/docs/infra/pull-request-environments.md) are temporary environments that exist during a pull request. Enable them after [setting up the app environment](/docs/infra/set-up-app-env.md):
 
-- Uncommenting the PR environment triggers by searching for `!!` in [ci-app-pr-environment-update.yml](/.github/workflows/ci-app-pr-environment-update.yml) and [ci-app-pr-environment-destroy.yml](/.github/workflows/ci-app-pr-environment-destroy.yml). You can verify that PR environments are working by opening a new PR and waiting for the PR Environment Update job to finish.
+- In [ci-app-pr-environment-update.yml](/.github/workflows/ci-app-pr-environment-update.yml) and [ci-app-pr-environment-destroy.yml](/.github/workflows/ci-app-pr-environment-destroy.yml), search for `!!`. 
+- Uncomment the PR environment triggers. 
+
+You can verify that PR environments are working by opening a new PR and waiting for the "PR Environment Update" job to finish.

--- a/template-only-docs/set-up-pr-environments.md
+++ b/template-only-docs/set-up-pr-environments.md
@@ -1,0 +1,5 @@
+# Set up PR environments
+
+[Pull request environments](/docs/infra/pull-request-environments.md) are temporary environments that exist during a pull request. Enable them after [setting up the app environment](/docs/infra/set-up-app-env.md):
+
+- Uncommenting the PR environment triggers by searching for `!!` in [ci-app-pr-environment-update.yml](/.github/workflows/ci-app-pr-environment-update.yml) and [ci-app-pr-environment-destroy.yml](/.github/workflows/ci-app-pr-environment-destroy.yml). You can verify that PR environments are working by opening a new PR and waiting for the PR Environment Update job to finish.


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/139

## Changes

Add callable reusable github action workflows that:
- creates or updates a temporary environment in a separate workspace
- destroys the temporary environment and workspace

Add template github action workflows for an app that calls the above reusable workflows to:
- create or update a temporary dev environment when a PR is opened, updated, or reopened
- destroys the temporary environment when the PR is closed

Add documentation around PR environments

## Context for reviewers

This is a feature that has proven to be quite useful on a number of projects, enabling product managers and designers to see and collaborate with engineers on in progress features to UAT the feature or otherwise give feedback on it.

This feature will also enable things like end-to-end testing on PRs and accessibility checks on PRs by providing a full environment they can access that is agnostic to the underlying web stack.

## Testing

Developed and tested in platform-test in this PR: https://github.com/navapbc/platform-test/pull/114
(See testing notes there)