### PR TITLE
Remove no longer needed manual deletion in CI Infra Service Checks

### DIFF
--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/stretchr/testify/require"
 )
 
 var uniqueId = strings.ToLower(random.UniqueId())
@@ -103,49 +102,7 @@ func RunEndToEndTests(t *testing.T, terraformOptions *terraform.Options) {
 	fmt.Println("::endgroup::")
 }
 
-func EnableDestroyService(t *testing.T, terraformOptions *terraform.Options) {
-	fmt.Println("::group::Set force_destroy = true and prevent_destroy = false for s3 buckets in service layer")
-	shell.RunCommand(t, shell.Command{
-		Command: "sed",
-		Args: []string{
-			"-i.bak",
-			"s/force_destroy = false/force_destroy = true/g",
-			"infra/modules/service/access-logs.tf",
-		},
-		WorkingDir: "../../",
-	})
-	shell.RunCommand(t, shell.Command{
-		Command: "sed",
-		Args: []string{
-			"-i.bak",
-			"s/prevent_destroy = true/prevent_destroy = false/g",
-			"infra/modules/service/access-logs.tf",
-		},
-		WorkingDir: "../../",
-	})
-	shell.RunCommand(t, shell.Command{
-		Command: "sed",
-		Args: []string{
-			"-i.bak",
-			"s/force_destroy = false/force_destroy = true/g",
-			"infra/modules/storage/main.tf",
-		},
-		WorkingDir: "../../",
-	})
-
-	// Clone the options and set targets to only apply to the buckets
-	terraformOptions, err := terraformOptions.Clone()
-	require.NoError(t, err)
-	terraformOptions.Targets = []string{
-		"module.service.aws_s3_bucket.access_logs",
-		"module.storage.aws_s3_bucket.storage",
-	}
-	terraform.Apply(t, terraformOptions)
-	fmt.Println("::endgroup::")
-}
-
 func DestroyService(t *testing.T, terraformOptions *terraform.Options) {
-	EnableDestroyService(t, terraformOptions)
 	fmt.Println("::group::Destroy service layer")
 	terraform.Destroy(t, terraformOptions)
 	fmt.Println("::endgroup::")


### PR DESCRIPTION
## Ticket

N/A

## Changes

> What was added, updated, or removed in this PR.
- Updates CI test called in "CI Infra Service Checks"

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

Now that #649 has been merged, the `infra_test.go` service layer test no longer needs to run a separate `terraform apply` to remove deletion protection on service resources. Since the CI job runs in a terraform workspace, the resources are no longer deployed with deletion protection. 

This PR removes the no longer needed code in the test.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Tested on https://github.com/navapbc/platform-test/pull/116 with a link to the [passing test](https://github.com/navapbc/platform-test/actions/runs/9683309382/job/26718436731?pr=116).