### PR TITLE
Workaround GitHub CLI bug that requires project read permissions

### DIFF
--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write # Needed to comment on PR
+      repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
 
     concurrency: pr-environment-${{ inputs.pr_number }}
 

--- a/.github/workflows/pr-environment-update.yml
+++ b/.github/workflows/pr-environment-update.yml
@@ -32,6 +32,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write # Needed to comment on PR
+      repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
 
     concurrency: pr-environment-${{ inputs.pr_number }}
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Not exactly sure what the exact repro is, but in some situations `gh pr edit` tries to read the organization's github projects, which is a bug in github cli. this change workaround that issue by providing the read access.

## Testing

Developed and tested on an internal project
see 🔒 [slack thread ](https://nava.slack.com/archives/C069Y4MEUR3/p1722026153896419?thread_ts=1721923216.427679&cid=C069Y4MEUR3)