### PR TITLE
Migrate template CI to nava-platform-infra account

### DIFF
--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -52,8 +52,8 @@ jobs:
           # (see https://docs.aws.amazon.com/cli/latest/reference/iam/create-open-id-connect-provider.html)
           #
           # For this test, use PlatformTestUser20220726 credentials
-          aws-access-key-id: ${{ secrets.PLATFORM_TESTER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PLATFORM_TESTER_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.TESTER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TESTER_AWS_SECRET_ACCESS_KEY }}
 
       - name: Run Terratest
         run: make -f template-only.mak test

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -28,7 +28,7 @@ func TestEndToEnd(t *testing.T) {
 
 func ValidateAccount(t *testing.T) {
 	projectName := projectName
-	accountId := "368823044688"
+	accountId := "533267424629"
 	region := "us-east-1"
 	ValidateAccountBackend(t, region, projectName)
 	ValidateGithubActionsAuth(t, accountId, projectName)

--- a/template-only-test/template_infra_test.go
+++ b/template-only-test/template_infra_test.go
@@ -131,7 +131,7 @@ func SetUpDevEnvironment(t *testing.T) {
 
 func ValidateAccountBackend(t *testing.T, region string, projectName string) {
 	fmt.Println("::group::Validating terraform backend for account")
-	expectedTfStateBucket := fmt.Sprintf("%s-368823044688-%s-tf", projectName, region)
+	expectedTfStateBucket := fmt.Sprintf("%s-533267424629-%s-tf", projectName, region)
 	expectedTfStateKey := "infra/account.tfstate"
 	aws.AssertS3BucketExists(t, region, expectedTfStateBucket)
 	_, err := aws.GetS3ObjectContentsE(t, region, expectedTfStateBucket, expectedTfStateKey)

--- a/template-only.mak
+++ b/template-only.mak
@@ -4,8 +4,6 @@
 PROJECT_NAME ?= platform-template-infra
 PROJECT_OWNER ?= platform-admins
 PROJECT_REGION ?= us-east-1
-ACCOUNT ?= account
-ACCOUNT_ID ?= 368823044688
 
 .PHONY : \
   clean \


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/686

## Changes

see title

## Context for reviewers

(see ticket)
tldr: Moving to a fresh new account to make it easier to clean up things when template CI fails since old account has extra stuff in it

## Testing

Template CI should still work