### PR TITLE
Sync the e2e folder when updating the template

### DIFF
--- a/template-only-bin/install-template
+++ b/template-only-bin/install-template
@@ -16,6 +16,7 @@ cp -r \
   bin \
   docs \
   infra \
+  e2e \
   Makefile \
   .dockleconfig \
   .gitignore \

--- a/template-only-bin/update-template
+++ b/template-only-bin/update-template
@@ -24,7 +24,7 @@ git checkout "${target_version}"
 target_version_hash=$(git rev-parse HEAD)
 
 # Note: Keep this list in sync with the files copied in install-template
-git diff "${current_version}" "${target_version}" --binary -- .github bin docs infra Makefile .dockleconfig .gitignore .grype.yml .hadolint.yaml .trivyignore .terraform-version > update.patch
+git diff "${current_version}" "${target_version}" --binary -- .github bin docs infra e2e Makefile .dockleconfig .gitignore .grype.yml .hadolint.yaml .trivyignore .terraform-version > update.patch
 cd -
 
 echo "Applying patch"


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/727

## Changes

Adds `e2e` to the list of folders to install / update

## Context for reviewers

You can see the issue by looking at the different between these two commits

[template-infra commit](https://github.com/navapbc/template-infra/commit/48c76567034b229c738730972ad35a467aa1e9f8)
[platform-test commit](https://github.com/navapbc/platform-test/commit/8fcbbaecbc664b6f47bd46fb25f2713f1bc93aa9#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52)

The platform test commit is missing the `e2e` folder

## Testing

I haven't tested this, since the change is small enough that it doesn't seem worthwhile to do a standalone test for it. LMK if you disagree, though.
