### PR TITLE
Add "states" (eg. AWS State Machines aka. Step Functions) permission

### DIFF
--- a/infra/project-config/aws-services.tf
+++ b/infra/project-config/aws-services.tf
@@ -30,6 +30,7 @@ locals {
     "servicediscovery",
     "sns",
     "ssm",
+    "states",
     "waf-regional",
     "wafv2",
   ]


### PR DESCRIPTION
## Ticket

Relates to https://github.com/navapbc/template-infra/issues/525

## Changes

Adds a permission that unblocks https://github.com/navapbc/platform-test/pull/130

## Context for reviewers

Me and @rocketnova are merge conflicting in both needed added permissions right now:

```
Terraform will perform the following actions:

  # module.auth_github_actions.aws_iam_policy.github_actions will be updated in-place
  ~ resource "aws_iam_policy" "github_actions" {
        id          = "arn:aws:iam::430004246987:policy/platform-test-github-actions-manage-infra"
        name        = "platform-test-github-actions-manage-infra"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action   = [
                            # (1 unchanged element hidden)
                            "waf-regional:*",
                          + "states:*",
                            "ssm:*",
                            "sns:*",
                          - "ses:*",
                            "servicediscovery:*",
                            # (7 unchanged elements hidden)
                            "pipes:*",
                          - "mobiletargeting:*",
                            "logs:*",
                            # (18 unchanged elements hidden)
                        ]
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags        = {}
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Testing

I haven't tested this 🙂 I might need another permission after this one, in-fact. We shall see.