### PR TITLE
Update app/service root module aws provider version to >=5.35.0

### DIFF
--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.56.0, < 5.0.0"
+      version = ">= 5.35.0, < 6.0.0"
     }
   }
 

--- a/infra/modules/service/jobs.tf
+++ b/infra/modules/service/jobs.tf
@@ -46,6 +46,7 @@ resource "aws_cloudwatch_event_target" "document_upload_jobs" {
   ecs_target {
     task_definition_arn = aws_ecs_task_definition.app.arn
     launch_type         = "FARGATE"
+    propagate_tags      = "TASK_DEFINITION"
 
     # Configuring Network Configuration is required when the task definition uses the awsvpc network mode.
     network_configuration {


### PR DESCRIPTION
## Ticket

Resolves #724

## Changes

> What was added, updated, or removed in this PR.
- Update app/service root module aws provider version to `>= 5.35.0, < 6.0.0`

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

This PR updates the `/infra/app/service` root module's aws provider version. It is currently pinned to `>=4.56.0, < 5.0.0`. This PR brings it to `>= 5.35.0, < 6.0.0`.

This supports more recent updates that include data and resource endpoints for AWS Pinpoint and AWS SESv2.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Tested on https://github.com/navapbc/platform-test/pull/131, where the ["Test service" CI job](https://github.com/navapbc/platform-test/actions/runs/10378887274/job/28736001582?pr=131) (with idp enabled) passed. Here's a screenshot verifying the aws provider version used in the CI job was v5.62.0.

![CleanShot 2024-08-13 at 17 02 34@2x](https://github.com/user-attachments/assets/8f4d3204-022a-4ce0-aa5d-0094e65ab571)

## ⚠️ Breaking changes for release notes

There are breaking changes between aws provider 4.x to 5.x. When upgrading to this version of the infrastructure template, projects should review and follow the [aws provider update release notes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade).