### PR TITLE
Remove manually defined CloudWatch log resource policy

### DIFF
--- a/infra/modules/feature-flags/logs.tf
+++ b/infra/modules/feature-flags/logs.tf
@@ -2,46 +2,20 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_cloudwatch_log_group" "logs" {
-  name = "feature-flags/${local.evidently_project_name}"
+  # Prefix log group name with /aws/vendedlogs/ to handle situations where the resource policy
+  # that AWS automatically creates to allow Evidently to send logs to CloudWatch exceeds the
+  # 5120 character limit.
+  # see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-vended-logs-permissions
+  # see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length
+  #
+  # Note that manually creating resource policies is also not ideal, as there is a quote of
+  # up to 10 CloudWatch Logs resource policies per Region per account, which can't be changed.
+  # see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
+  name = "/aws/vendedlogs/feature-flags/${local.evidently_project_name}"
 
   # checkov:skip=CKV_AWS_158:Feature flag evaluation logs are not sensitive
 
   # Conservatively retain logs for 5 years.
   # Looser requirements may allow shorter retention periods
   retention_in_days = 1827
-}
-
-# Manually create policy allowing AWS services to deliver logs to this log group
-# so that the automatically created one by AWS doesn't exceed the character limit
-# see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-vended-logs-permissions
-# see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length
-resource "aws_cloudwatch_log_resource_policy" "logs" {
-  policy_name     = "/log-delivery/feature-flags/${local.evidently_project_name}-logs"
-  policy_document = data.aws_iam_policy_document.logs.json
-}
-
-data "aws_iam_policy_document" "logs" {
-  statement {
-    sid    = "AWSLogDeliveryWrite"
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["delivery.logs.amazonaws.com"]
-    }
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-    resources = ["${aws_cloudwatch_log_group.logs.arn}:log-stream:*"]
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceAccount"
-      values   = [data.aws_caller_identity.current.account_id]
-    }
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
-    }
-  }
 }

--- a/infra/modules/feature-flags/main.tf
+++ b/infra/modules/feature-flags/main.tf
@@ -10,9 +10,6 @@ resource "aws_evidently_project" "feature_flags" {
       log_group = aws_cloudwatch_log_group.logs.name
     }
   }
-  # Make sure the resource policy is created first so that AWS doesn't try to
-  # automatically create one
-  depends_on = [aws_cloudwatch_log_resource_policy.logs]
 }
 
 resource "aws_evidently_feature" "feature_flag" {


### PR DESCRIPTION
## Ticket

N/A

## Changes

- Remove manually defined CloudWatch log resource policy for Evidently

## Context for reviewers

We started hitting the Cloudwatch Log resource group policy limit which is causing PR environments to fail to be created (see [example failure](https://github.com/navapbc/pfml-starter-kit-app/actions/runs/10238456987/job/28322961337?pr=198)). You can only have [up to 10 resource policies per region per account, a quota that can't be changed](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html). AWS automatically creates and modifies a resource policy, but that policy has a 5120 character limit. According to AWS docs, [the mitigation is to use log groups that have a prefix of /aws/vendedlogs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-vended-logs-permissions).

<img width="1240" alt="image" src="https://github.com/user-attachments/assets/b92f0ceb-889b-4c69-bdcc-3ef881b12cd8">

## Testing

Developed and tested in 🔒 https://github.com/navapbc/pfml-starter-kit-app/pull/199