### PR TITLE
Fix configure-aws-credentials when network_name has dashes

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -48,7 +48,7 @@ runs:
 
         terraform -chdir="infra/project-config" init > /dev/null
         terraform -chdir="infra/project-config" apply -auto-approve > /dev/null
-        account_name=$(terraform -chdir="infra/project-config" output -json network_configs | jq -r ".${network_name}.account_name")
+        account_name=$(terraform -chdir="infra/project-config" output -json network_configs | jq -r ".[\"${network_name}\"].account_name")
 
         echo "Account name retrieved: ${account_name}"
         echo "account_name=${account_name}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

The configure-aws-credentials action errors if network_name has dashes in it e.g. if network_name = "non-prod"
This issue was discovered on a project.

## Testing

Tested the change in the other project