### PR TITLE
Retry wait for stable service in deploy release

### DIFF
--- a/bin/deploy-release
+++ b/bin/deploy-release
@@ -26,7 +26,7 @@ cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_
 service_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_name)
 echo "Wait for service ${service_name} to become stable"
 if ! aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"; then
-  echo "First attempt to wait for service stability failed, retrying..."
+  echo "Retrying"
   aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 fi
 

--- a/bin/deploy-release
+++ b/bin/deploy-release
@@ -25,6 +25,9 @@ echo "::endgroup::"
 cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)
 service_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_name)
 echo "Wait for service ${service_name} to become stable"
-aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
+if ! aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"; then
+  echo "First attempt to wait for service stability failed, retrying..."
+  aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
+fi
 
 echo "Completed ${app_name} deploy of ${image_tag} to ${environment}"

--- a/bin/deploy-release
+++ b/bin/deploy-release
@@ -25,9 +25,13 @@ echo "::endgroup::"
 cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)
 service_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_name)
 echo "Wait for service ${service_name} to become stable"
-if ! aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"; then
-  echo "Retrying"
+wait_for_service_stability() {
   aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
+}
+
+if ! wait_for_service_stability; then
+  echo "Retrying"
+  wait_for_service_stability
 fi
 
 echo "Completed ${app_name} deploy of ${image_tag} to ${environment}"


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - If waiting for a stable ECS service fails during deploy, try it exactly one more time

## Context for reviewers
 - For two applications using the template-infra, the Nava Labs Decision Support Tool project, and an internal Nava tool, the ECS service takes slightly more than 10 minutes to become stable (typically about 11 or 13).
 - The AWS wait command can't be configured to allow more than 10 minutes
 - Other approaches considered:
   - Sleeping. This is probably the simplest solution but doesn't seem as robust as simply trying the command twice.
   - Retrying a configurable number of times in a loop. This seems like premature complexity.

## Testing
Tested on internal tool (posted in Slack)