### PR TITLE
Setup Trivy caching of config file

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -57,6 +57,16 @@ jobs:
           ignore-unfixed: true
           vuln-type: os
           scanners: vuln,secret
+          # Enables caching of trivy config file that is used to search for the
+          # vulnerabilities. We cache it since it only updates once every 6 hours,
+          # and the confg hosts can be down, causing failures
+          cache: 'true'
+        env:
+          # Set to skip since we cache the files in the vulnerability-update-cache
+          # workflow
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
+
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure

--- a/.github/workflows/vulnerability-update-cache.yml
+++ b/.github/workflows/vulnerability-update-cache.yml
@@ -1,0 +1,37 @@
+# GitHub Actions CI workflow that updates a cache file that the scanners use for
+# their configuration. This workflow runs daily at midnight UTC by default
+
+name: Update Vulnerability Scan Caches
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

- Setup caching for the vulnerability scanner config files
- Configure trivy to use the cached config file

## Context for reviewers

The trivy action has a known issue where the host of the config file for the action is overwhelmed and causing timeout and failures. There was an update, and their [official documentation](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#updating-caches-in-the-default-branch) recommend to use caching of the file, at least at daily, and use that cached file to reduce the load on the hosts. 

This PR introduces a new cron workflow to cache that file (and any other scanner files we want to cache in the future), and then updates the trivy action to use that cached file. The cache needs to be used once a week, or the cache needs to have less than 5GB stored, or the older files will be removed, so we want to keep the cache warm for this file

## Testing

Testing will be ran from the workflow once the PR is opened (looks like I need to trigger it manually). I'll link those runs once done. I'm looking at the trivy code to see if it will cache for us on first run, or if we need to run the cache workflow first
