### PR TITLE
Update template CD to use Platform CLI

### DIFF
--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: project-repo
+          # TODO: Revert to checking out main once we've tested that the update works
+          ref: lorenyu/platform-cli
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
       - name: Install nava-platform CLI
@@ -64,6 +66,4 @@ jobs:
           git add --all
           # Commit changes (if no changes then no-op)
           git diff-index --quiet HEAD || git commit -m "Template infra deploy #${{ github.run_id }}"
-
-          # TODO uncomment this line once we have validated that things are working
           # git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -37,7 +37,7 @@ jobs:
         project_repo:
           - navapbc/platform-test
           # - navapbc/platform-test-flask
-          # - navapbc/platform-test-nextjs
+          - navapbc/platform-test-nextjs
     steps:
       - name: Checkout template-infra repo
         uses: actions/checkout@v4

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: template-infra
         run: |
           git fetch origin main
-          git merge main
+          git merge origin/main
           git push
   deploy:
     name: Deploy to ${{ matrix.project_repo }}

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -54,6 +54,12 @@ jobs:
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
 
+      # Set up Python since built in Python version (3.10.12) is not supported by Platform CLI (<4.0,>=3.11)
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Install nava-platform CLI
         run: pipx install git+https://git@github.com/navapbc/platform-cli
 

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -49,10 +49,12 @@ jobs:
           path: project-repo
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
+      - name: Install nava-platform CLI
+        run: pipx install git+ssh://git@github.com/navapbc/platform-cli
 
       - name: Update infra template
         working-directory: project-repo
-        run: ../template-infra/template-only-bin/update-template
+        run: nava-platform infra update --template-uri ../template-infra --version lorenyu/platform-cli .
 
       - name: Push changes to project repo
         working-directory: project-repo
@@ -62,4 +64,6 @@ jobs:
           git add --all
           # Commit changes (if no changes then no-op)
           git diff-index --quiet HEAD || git commit -m "Template infra deploy #${{ github.run_id }}"
-          git push
+
+          # TODO uncomment this line once we have validated that things are working
+          # git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -81,4 +81,4 @@ jobs:
           git add --all
           # Commit changes (if no changes then no-op)
           git diff-index --quiet HEAD || git commit -m "Template infra deploy #${{ github.run_id }}"
-          # git push
+          git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           path: template-infra
           ref: lorenyu/platform-cli
+          # Fetch history so we can merge main into the branch
+          fetch-depth: 0
       - name: Update
         working-directory: template-infra
         run: |

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install nava-platform CLI
-        run: pipx install git+https://git@github.com/navapbc/platform-cli
+        run: pipx install --python $(python -c "import sys; print(sys.executable)") git+https://github.com/navapbc/platform-cli
 
       - name: Update infra template
         working-directory: project-repo

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -54,12 +54,6 @@ jobs:
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
 
-      # Set up Python since built in Python version (3.10.12) is not supported by Platform CLI (<4.0,>=3.11)
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
       - name: Install nava-platform CLI
         run: pipx install git+https://git@github.com/navapbc/platform-cli
 

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -19,10 +19,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: template-infra
+          ref: lorenyu/platform-cli
       - name: Update
         working-directory: template-infra
         run: |
-          git checkout lorenyu/platform-cli
+          git fetch origin main
           git merge main
           git push
   deploy:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -51,8 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: project-repo
-          # TODO: Revert to checking out main once we've tested that the update works
-          ref: lorenyu/platform-cli
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -20,12 +20,11 @@ jobs:
         with:
           path: template-infra
           ref: lorenyu/platform-cli
-          # Fetch history so we can merge main into the branch
+          # Fetch history of all branches so we can merge main into the feature branch
           fetch-depth: 0
       - name: Update
         working-directory: template-infra
         run: |
-          git fetch origin main
           git merge origin/main
           git push
   deploy:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         project_repo:
           - navapbc/platform-test
-          # - navapbc/platform-test-flask
+          - navapbc/platform-test-flask
           - navapbc/platform-test-nextjs
     steps:
       - name: Checkout template-infra repo

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -34,8 +34,8 @@ jobs:
       matrix:
         project_repo:
           - navapbc/platform-test
-          - navapbc/platform-test-flask
-          - navapbc/platform-test-nextjs
+          # - navapbc/platform-test-flask
+          # - navapbc/platform-test-nextjs
     steps:
       - name: Checkout template-infra repo
         uses: actions/checkout@v4

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -45,6 +45,8 @@ jobs:
           path: template-infra
           # TODO: Revert to checking out main once we've merged the platform-cli branch into the main branch
           ref: lorenyu/platform-cli
+          # Fetch history because the Platform CLI needs it to do the update
+          fetch-depth: 0
       - name: Checkout project repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -10,9 +10,25 @@ on:
 concurrency: platform-template-only-cd
 
 jobs:
+  # TODO: Get rid of this job once we've merged the platform-cli branch into the main branch
+  update-platform-cli-branch:
+    name: Update platform-cli branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout template-infra repo
+        uses: actions/checkout@v4
+        with:
+          path: template-infra
+      - name: Update
+        working-directory: template-infra
+        run: |
+          git checkout lorenyu/platform-cli
+          git merge main
+          git push
   deploy:
     name: Deploy to ${{ matrix.project_repo }}
     runs-on: ubuntu-latest
+    needs: update-platform-cli-branch
     strategy:
       fail-fast: true
       matrix:
@@ -25,6 +41,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: template-infra
+          # TODO: Revert to checking out main once we've merged the platform-cli branch into the main branch
+          ref: lorenyu/platform-cli
       - name: Checkout project repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Install nava-platform CLI
         run: pipx install --python python3.13 git+https://github.com/navapbc/platform-cli
 
+      - name: Configure git
+        run: |
+          git config user.name nava-platform-bot
+          git config user.email platform-admins@navapbc.com
+
       - name: Update infra template
         working-directory: project-repo
         run: nava-platform infra update --template-uri ../template-infra --version lorenyu/platform-cli .
@@ -70,8 +75,6 @@ jobs:
       - name: Push changes to project repo
         working-directory: project-repo
         run: |
-          git config user.name nava-platform-bot
-          git config user.email platform-admins@navapbc.com
           git add --all
           # Commit changes (if no changes then no-op)
           git diff-index --quiet HEAD || git commit -m "Template infra deploy #${{ github.run_id }}"

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -64,6 +64,7 @@ jobs:
         run: pipx install --python python3.13 git+https://github.com/navapbc/platform-cli
 
       - name: Configure git
+        working-directory: project-repo
         run: |
           git config user.name nava-platform-bot
           git config user.email platform-admins@navapbc.com

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -53,6 +53,13 @@ jobs:
           ref: lorenyu/platform-cli
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
+
+      # Set up Python since built in Python version (3.10.12) is not supported by Platform CLI (<4.0,>=3.11)
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Install nava-platform CLI
         run: pipx install git+https://git@github.com/navapbc/platform-cli
 

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -54,7 +54,7 @@ jobs:
           repository: ${{ matrix.project_repo }}
           token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
       - name: Install nava-platform CLI
-        run: pipx install git+ssh://git@github.com/navapbc/platform-cli
+        run: pipx install git+https://git@github.com/navapbc/platform-cli
 
       - name: Update infra template
         working-directory: project-repo

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -77,8 +77,4 @@ jobs:
 
       - name: Push changes to project repo
         working-directory: project-repo
-        run: |
-          git add --all
-          # Commit changes (if no changes then no-op)
-          git diff-index --quiet HEAD || git commit -m "Template infra deploy #${{ github.run_id }}"
-          git push
+        run: git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install nava-platform CLI
-        run: pipx install --python $(python -c "import sys; print(sys.executable)") git+https://github.com/navapbc/platform-cli
+        run: pipx install --python python3.13 git+https://github.com/navapbc/platform-cli
 
       - name: Update infra template
         working-directory: project-repo


### PR DESCRIPTION
## Ticket

n/a

## Changes

Update template CD to:
- Keep lorenyu/platform-cli branch up to date with main
- Install nava-platform CLI
- Use nava-platform CLI to update platform-test repos

## Context for reviewers

As part of migrating to use the Platform CLI we are going to first get the platform-test* repos to start updating using the Platform CLI

## Testing

Temporarily pushed to corresponding lorenyu/platform-cli branches on the platform-test repos:
- https://github.com/navapbc/platform-test-nextjs/compare/main...lorenyu/platform-cli
- https://github.com/navapbc/platform-test-flask/compare/main...lorenyu/platform-cli

Successful run: https://github.com/navapbc/template-infra/actions/runs/11508261320

Screenshot of the resulting diff in one of the platform-test repos
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/a680a98b-7b7b-46fa-b69c-1a70c0729b14">
