### PR TITLE
Update obsolete GitHub Actions

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -89,7 +89,7 @@ runs:
         echo "AWS_REGION=${aws_region}" >> "$GITHUB_ENV"
       shell: bash
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -35,7 +35,7 @@ jobs:
           terraform_version: 1.8.3
           terraform_wrapper: false
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ">=1.19.0"
 

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Run Checkov check

--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version: ">=1.19.0"
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
 

--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           terraform_version: 1.8.3
           terraform_wrapper: false
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ">=1.19.0"
       - name: Configure AWS credentials


### PR DESCRIPTION
## Changes

These are actions that were still using `node16`, which is no longer supported
by GitHub. The updated versions have migrated to `node20`.

Updated:

- aws-actions/configure-aws-credentials v3 -> v4
- actions/setup-python v4 -> v5
- actions/setup-go v3 -> v5

No breaking changes listed in the updates for these actions. Though notably
`setup-go` has enabled caching by default.

## Testing

See CI, which runs all the updated workflows, except for `.github/workflows/check-ci-cd-auth.yml` I believe.
