### PR TITLE
Run e2e tests in parallel shards

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,20 +12,86 @@ on:
         type: string
 
 jobs:
+
   e2e:
-    name: "E2E Tests"
+    name: Run E2E tests (${{ matrix.shard }} of ${{ matrix.total_shards }})
+    runs-on: ubuntu-latest
+
+    strategy:
+        matrix:
+          shard: [1, 2, 3]
+          total_shards: [3] # Github Actions doesn't have a built-in method to get the length of an array
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})
+        run: |
+          make e2e-test \
+            APP_NAME=${{ inputs.app_name }} \
+            BASE_URL=${{ inputs.service_endpoint }} \
+            CURRENT_SHARD=${{ matrix.shard }} \
+            TOTAL_SHARDS=${{ matrix.total_shards }}
+
+      - name: Verify blob report directory after tests
+        run: |
+          echo "Contents of blob-report directory on host:"
+          ls -R ./e2e/blob-report || echo "blob-report directory not found"
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-shard-${{ matrix.shard }}
+          path: ./e2e/blob-report
+          retention-days: 1
+
+  create-report:
+    name: Create merged test report
+    if: ${{ !cancelled() }}
+    needs: e2e
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Run the Playwright tests inside the Docker container
-      - name: Run E2E tests in Docker container
-        run: make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+            node-version: lts/*
 
-      - name: Upload Playwright report
+      - name: Install dependencies in ./e2e to be able to run `playwright merge-reports`
+        run: make e2e-setup-ci
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-shard-*
+          merge-multiple: true
+
+      - name: Verify downloaded artifacts
+        run: |
+          echo "Contents of all-blob-reports after download:"
+          ls -R all-blob-reports
+
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Verify merged report
+        run: |
+          echo "Contents of ./playwright-report after merge:"
+          ls -R ./playwright-report || echo "No report found in ./playwright-report"
+
+      - name: Upload merged HTML report
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: ./e2e/playwright-report
+            name: merged-html-report
+            path: ./playwright-report
+            retention-days: 7

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -10,13 +10,11 @@ WORKDIR /
 # Setup npm install layer that can be cached
 COPY Makefile /Makefile
 COPY e2e/package.json e2e/package-lock.json /e2e/
+
+# install deps
 RUN make e2e-setup-ci
 
 # Copy entire e2e folder over
 COPY e2e /e2e
 
-# Change the working directory back to the root to run Makefile commands
-WORKDIR /
-
-# Default command when running the container
 CMD ["make", "e2e-test-native"]

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -20,8 +20,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   // Opt out of parallel tests on CI.
   workers: process.env.CI ? 1 : undefined,
-  // Reporter to use. See https://playwright.dev/docs/test-reporters
-  reporter: "html",
+  // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters
+  reporter: process.env.CI ? 'blob' : 'html',
   // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
   use: {
     // Base URL to use in actions like `await page.goto('/')`.
@@ -31,6 +31,13 @@ export default defineConfig({
     trace: "on-first-retry",
     screenshot: "on",
     video: "on-first-retry",
+  },
+  // Splits tests into chunks for distributed parallel execution
+  shard: {
+    // Total number of shards
+    total: parseInt(process.env.TOTAL_SHARDS || '1'),
+    // Specifies which shard this job should execute
+    current: parseInt(process.env.CURRENT_SHARD || '1'),
   },
 
   // Configure projects for major browsers


### PR DESCRIPTION
## Ticket

Resolves #720 

## Changes

- Add sharding in CI workflow
    - Creates a blob report in each shard, that is merged into an html report that is uploaded to GH Action artifacts  

## Context for reviewers

- Will likely be part 1 of 2 PR to help split up the work a bit - additional items in future PR:
     -   [make target for merge report command](https://github.com/navapbc/platform-test-nextjs/pull/89#discussion_r1831428691)
     -  [Supporting shard report upload if not all the shards complete successfully](https://github.com/navapbc/platform-test-nextjs/pull/89#discussion_r1831444642)
     -  Docker caching/build improvements 
     -  Docs updates


- On the `platform-test-nextjs` PR - there was an update to `./e2e/package-lock.json` but I believe that's not needed for final merge here as no package.json packages were updated

## Testing

- Tested on `platform-test-nextjs` => https://github.com/navapbc/platform-test-nextjs/pull/89
    - blob report successfully created in CI in each shard job and merged into html report ✅ 
    - Command works locally - with partial support for local sharding ✅ 

