### PR TITLE
Finish running e2e tests even when one shard fails

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,15 +12,15 @@ on:
         type: string
 
 jobs:
-
   e2e:
     name: Run E2E tests (${{ matrix.shard }} of ${{ matrix.total_shards }})
     runs-on: ubuntu-latest
 
     strategy:
-        matrix:
-          shard: [1, 2, 3]
-          total_shards: [3] # Github Actions doesn't have a built-in method to get the length of an array
+      fail-fast: false # Allows e2e test report to be merged if only some of the shards have passed
+      matrix:
+        shard: [1, 2, 3]
+        total_shards: [3] # Github Actions doesn't have a built-in method to get the length of an array
 
     steps:
       - name: Checkout code
@@ -33,11 +33,11 @@ jobs:
 
       - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})
         run: |
-          make e2e-test \
-            APP_NAME=${{ inputs.app_name }} \
-            BASE_URL=${{ inputs.service_endpoint }} \
-            CURRENT_SHARD=${{ matrix.shard }} \
-            TOTAL_SHARDS=${{ matrix.total_shards }}
+            make e2e-test \
+                APP_NAME=${{ inputs.app_name }} \
+                BASE_URL=${{ inputs.service_endpoint }} \
+                CURRENT_SHARD=${{ matrix.shard }} \
+                TOTAL_SHARDS=${{ matrix.total_shards }}
 
       - name: Verify blob report directory after tests
         run: |
@@ -66,32 +66,40 @@ jobs:
         with:
             node-version: lts/*
 
+      - name: Cache Node.js dependencies
+        id: cache-node
+        uses: actions/cache@v4
+        with:
+            path: e2e/node_modules
+            key: ${{ runner.os }}-node-${{ hashFiles('e2e/package-lock.json') }}
+
       - name: Install dependencies in ./e2e to be able to run `playwright merge-reports`
+        if: steps.cache-node.outputs.cache-hit != 'true'
         run: make e2e-setup-ci
 
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: all-blob-reports
+          path: ./e2e/blob-report
           pattern: blob-report-shard-*
           merge-multiple: true
 
       - name: Verify downloaded artifacts
         run: |
-          echo "Contents of all-blob-reports after download:"
-          ls -R all-blob-reports
+          echo "Contents of ./e2e/blob-report after download:"
+          ls -R ./e2e/blob-report
 
-      - name: Merge into HTML report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
+      - name: Merge reports
+        run: make e2e-merge-reports
 
       - name: Verify merged report
         run: |
-          echo "Contents of ./playwright-report after merge:"
-          ls -R ./playwright-report || echo "No report found in ./playwright-report"
+          echo "Contents of ./e2e/playwright-report after merge:"
+          ls -R ./e2e/playwright-report || echo "No report found in ./e2e/playwright-report"
 
       - name: Upload merged HTML report
         uses: actions/upload-artifact@v4
         with:
-            name: merged-html-report
-            path: ./playwright-report
+            name: e2e-test-report
+            path: ./e2e/playwright-report
             retention-days: 7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false # Allows e2e test report to be merged if only some of the shards have passed
+      fail-fast: false # Continue running tests to completion even if some shards fail
       matrix:
         shard: [1, 2, 3]
         total_shards: [3] # Github Actions doesn't have a built-in method to get the length of an array

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ e2e-clean-report: ## Remove the local ./e2e/playwright-report and ./e2e/test-res
 e2e-delete-image: ## Delete the Docker image for e2e tests
 	@docker rmi -f playwright-e2e 2>/dev/null || echo "Docker image playwright-e2e does not exist, skipping."
 
+e2e-merge-reports: ## Merge Playwright blob reports from multiple shards into an HTML report
+	@cd e2e && npx playwright merge-reports --reporter html blob-report
+
 e2e-setup-ci: ## Setup end-to-end tests for CI
 	@cd e2e && npm ci
 	@cd e2e && npx playwright install --with-deps
@@ -113,7 +116,7 @@ e2e-test: e2e-build
 e2e-test-native: ## Run end-to-end tests
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
-	@echo "Running tests with CI=${CI}, APP_NAME=${APP_NAME}, BASE_URL=${BASE_URL}"
+	@echo "Running e2e tests with CI=${CI}, APP_NAME=${APP_NAME}, BASE_URL=${BASE_URL}"
 	@cd e2e/$(APP_NAME) && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npx playwright test $(E2E_ARGS)
 
 ###########

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -4,6 +4,8 @@
 
 This repository uses [Playwright](https://playwright.dev/) to perform end-to-end (E2E) tests. The tests can be run locally (natively or within Docker), but they also run on [Pull Request preview environments](../infra/pull-request-environments.md). This ensures that any new code changes are validated through E2E tests before being merged.
 
+By default, tests are sharded across 3 concurrent runs to reduce total runtime. As the test suite grows, consider increasing the shard count to further optimize execution time. This is set in the [workflow file](../../.github/workflows/e2e-tests.yml#L22).
+
 ## Folder Structure
 In order to support e2e for multiple apps, the folder structure will include a base playwright config (`./e2e/playwright.config.js`), and app-specific derived playwright config that override the base config. See the example folder structure below:
 ```
@@ -54,6 +56,20 @@ Then, run the tests with your app name and base url:
 make e2e-test-native APP_NAME=app BASE_URL=http://localhost:3000
 ```
 
+#### Run tests in parallel 
+
+The following commands split test execution into 3 separate shards, with results consolidated into a merged report located in `./e2e/blob-report`. This setup emulates how the sharded tests run in CI.
+```
+# ensure app is running on port 3000
+
+make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=1 CI=true && \
+make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=2 CI=true && \
+make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=3 CI=true
+
+make e2e-merge-reports REPORT_PATH=blob-report # merge the blob reports into html
+make e2e-show-report # open the html report in browser
+make e2e-clean-report # clean the report folders
+```
 
 ### Viewing the report
 If running in docker, the report will be copied from the container to your local `./e2e/playwright-report` folder. If running natively, the report will also appear in this same folder.


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/720

## Changes
- wrap playwright merge cmd in make target `e2e-merge-reports`
- set matrix `fail-fast` to false so reports can be generated if one of the shards fails
- update docs for sharding

## Context for reviewers
- This PR tested on `platform-test-nextjs` => https://github.com/navapbc/platform-test-nextjs/pull/90 
    - See local demos there  
- Sharding part 1 PR https://github.com/navapbc/template-infra/pull/776



Diff comparison with `platform-test-nextjs` PR:
That PR: 
<img width="165" alt="image" src="https://github.com/user-attachments/assets/a5dd1aa8-febb-43f5-b621-5548184dde3f">


This PR:
![image](https://github.com/user-attachments/assets/5439ae34-ef38-423f-bfe0-51eeb8bcf575)
