### PR TITLE
Fix e2e docker hang by never opening html playwright report

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -21,7 +21,11 @@ export default defineConfig({
   // Opt out of parallel tests on CI.
   workers: process.env.CI ? 1 : undefined,
   // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters
-  reporter: process.env.CI ? 'blob' : 'html',
+  reporter: process.env.CI
+  ? [['blob']]  :
+    // Don't open the HTML report since it hangs when running inside a container.
+    // Use make e2e-show-report for opening the HTML report
+    [['html', { open: 'never' }]],
   // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
   use: {
     // Base URL to use in actions like `await page.goto('/')`.


### PR DESCRIPTION
Ticket
Resolves #788 

## Changes
update base config ./e2e/playwright.config to never open html report

## Context

Tested on `platform-test-nextjs` https://github.com/navapbc/platform-test-nextjs/pull/92

- original slack thread https://nava.slack.com/archives/C03G1SWD9H7/p1732305995737349

This PR diff: 
![image](https://github.com/user-attachments/assets/e0dffc87-315a-4d3a-b533-73501540a377)


`platform-test-nextjs` PR diff:
![image](https://github.com/user-attachments/assets/04c351ec-c124-4ee0-905e-5465c1b25801)



