### PR TITLE
fix: Setup Terraform in CI/CD workflows

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials
         with:

--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -22,10 +22,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up Terraform
-        uses: ./.github/actions/setup-terraform
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/check-infra-deploy-status.yml
+++ b/.github/workflows/check-infra-deploy-status.yml
@@ -44,10 +44,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.8.3
-          terraform_wrapper: false
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
 
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -30,10 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.8.3
-          terraform_wrapper: false
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -42,11 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.8.3
-          terraform_wrapper: false
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
 
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -28,11 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.8.3
-          terraform_wrapper: false
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
 
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.8.3
-          terraform_wrapper: false
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
       - uses: actions/setup-go@v5
         with:
           go-version: ">=1.19.0"


### PR DESCRIPTION
## Ticket

Resolves #974

## Changes
 - Consistently set up Terraform before later steps that rely on it
 - Replace direct references to the Hashicorp action with the custom action that uses .terraform-version

## Context for reviewers
 - Latest Ubuntu removed Terraform
 - Note that I checked for instances of the AWS credentials workflow only since I know those require Terraform -- I didn't do a wider audit of other workflows that might require it too.

## Testing
Updated actions running (or at least successfully getting past the AWS credentials step) in platform-test: 
build-and-publish.yml: 🟢 [here](https://github.com/navapbc/platform-test/actions/runs/12432940237/job/34713434814)
check-ci-cd-auth.yml: TBD, need ARN of IAM role to assume
check-infra-deploy-status.yml: 🟢 [here](https://github.com/navapbc/platform-test/actions/runs/12432991469)
ci-infra-service.yml: 🟢 [here](https://github.com/navapbc/platform-test/actions/runs/12433032651)
pr-environment-checks.yml: 🟢 [here](https://github.com/navapbc/platform-test/actions/runs/12433046386/job/34713767738?pr=145)
pr-environment-destroy.yml: 🟢 [here](https://github.com/navapbc/platform-test/actions/runs/12433159699)
template-only-ci-infra.yml: Not tested

see platform test PR https://github.com/navapbc/platform-test/pull/145