### PR TITLE
Add workflow that scans orphaned PR environments

### DIFF
--- a/.github/workflows/scan-orphaned-pr-environments.yml
+++ b/.github/workflows/scan-orphaned-pr-environments.yml
@@ -1,0 +1,68 @@
+# This workflow scans for orphaned PR environments
+name: Scan orphaned PR environments
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every day at 07:30 UTC (3:30am ET, 12:30am PT) after engineers are likely done with work
+    - cron: "30 7 * * *"
+
+jobs:
+  get-app-names:
+    name: Get app names
+    runs-on: ubuntu-latest
+    outputs:
+      app_names: ${{ steps.get-app-names.outputs.app_names }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get app names
+        id: get-app-names
+        run: |
+          source bin/util.bash
+          app_names="$(get_app_names)"
+          # turn app_names into a json list using jq
+          app_names="$(echo "${app_names}" | jq -R -s -c 'split("\n")[:-1]')"
+          echo "App names retrieved: ${app_names}"
+          echo "app_names=${app_names}" >> "$GITHUB_OUTPUT"
+        shell: bash
+  scan:
+    name: Scan
+    runs-on: ubuntu-latest
+    needs: get-app-names
+
+    strategy:
+      matrix:
+        app_name: ${{ fromJson(needs.get-app-names.outputs.app_names) }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: ${{ matrix.app_name }}
+          environment: dev
+
+      - name: List PR workspaces
+        run: |
+          ./bin/orphaned-prs ${{ matrix.app_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TF_IN_AUTOMATION: "true"
+
+  notify:
+    name: Notify
+    needs: scan
+    if: failure()
+    uses: ./.github/workflows/send-system-notification.yml
+    with:
+      channel: "workflow-failures"
+      message: "🧹 [Orphaned PR environments for ${{ github.repository }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+    secrets: inherit

--- a/.github/workflows/send-system-notification.yml
+++ b/.github/workflows/send-system-notification.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
       - name: Get channel configuration
         id: get-channel-type
         run: |
@@ -51,6 +54,10 @@ jobs:
             slack_token_secret_name="$(echo "${channel_config}" | jq -r ".slack_token_secret_name")"
             echo "Slack token secret name: ${slack_token_secret_name}"
             echo "SLACK_TOKEN_SECRET_NAME=${slack_token_secret_name}" >> "$GITHUB_ENV"
+
+            # Convert Markdown links in message [text](url) to Slack format <url|text>
+            echo "Convert message from Markdown to Slack format"
+            echo "SLACK_MESSAGE=$(echo "${{ inputs.message }}" | sed -E 's/\[(.+)\]\((.+)\)/<\2|\1>/g')" >> "$GITHUB_ENV"
           fi
         shell: bash
 
@@ -62,4 +69,4 @@ jobs:
           token: ${{ secrets[env.SLACK_TOKEN_SECRET_NAME] }}
           payload: |
             channel: ${{ secrets[env.CHANNEL_ID_SECRET_NAME] }}
-            text: ${{ inputs.message }}
+            text: ${{ env.SLACK_MESSAGE }}

--- a/bin/infra-deploy-status-check-configs
+++ b/bin/infra-deploy-status-check-configs
@@ -47,6 +47,8 @@
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
+source bin/util.bash
+
 # Return the names of Terraform backend configuration files in (without the ".s3.tfbackend" suffix)
 # for the root module given by "infra/${root_module_subdir}".
 #
@@ -83,13 +85,6 @@ function get_root_module_configs() {
   for backend_config_name in ${backend_config_names}; do
     echo "{\"backend_config_name\": \"${backend_config_name}\", \"infra_layer\": \"${infra_layer}\", \"root_module_subdir\": \"${root_module_subdir}\"}"
   done
-}
-
-# Retrieve the names of the applications in the repo by listing the directories in the "infra" directory
-# and filtering out the directories that are not applications.
-# Returns: A list of application names.
-function get_app_names() {
-  find "infra" -maxdepth 1 -type d -not -name "infra" -not -name "accounts" -not -name "modules" -not -name "networks" -not -name "project-config" -not -name "test" -exec basename {} \;
 }
 
 function get_account_layer_configs() {

--- a/bin/orphaned-prs
+++ b/bin/orphaned-prs
@@ -1,0 +1,45 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# This script checks for orphaned PR environments by listing all PR workspaces
+# and checking if the associated PR is closed. If the PR is closed the
+# resources in the workspace should have been destroyed and the workspace
+# deleted, so existing workspaces for closed PRs are considered orphaned.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+app_name="$1"
+
+echo "::group::Initialize Terraform"
+echo terraform -chdir="infra/${app_name}/service" init -input=false -reconfigure -backend-config="dev.s3.tfbackend"
+terraform -chdir="infra/${app_name}/service" init -input=false -reconfigure -backend-config="dev.s3.tfbackend"
+echo "::endgroup::"
+
+echo "::group::List PRs with PR environments"
+echo terraform -chdir="infra/${app_name}/service" workspace list
+workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
+pr_nums="$(echo "${workspaces}" | grep -o 'p-[0-9]\+' | sed 's/p-//')"
+echo "PRs"
+echo "${pr_nums}"
+echo "::endgroup::"
+
+echo "::group::Check status of each PR"
+closed_prs=()
+for pr_num in $pr_nums; do
+  pr_status="$(gh pr view "$pr_num" --json state --jq ".state")"
+  echo "PR ${pr_num}: ${pr_status}"
+
+  if [ "$pr_status" == "CLOSED" ]; then
+    closed_prs+=("$pr_num")
+  fi
+done
+echo "::endgroup::"
+
+# if closed_prs is not empty exit with 1 otherwise exit with 0
+if [ ${#closed_prs[@]} -gt 0 ]; then
+  echo "Orphaned PR environments: ${closed_prs[*]}"
+  echo "Orphaned PR environments: ${closed_prs[*]}" >> "${GITHUB_STEP_SUMMARY}"
+  exit 1
+fi
+
+echo "No orphaned PR environments"
+echo "No orphaned PR environments" >> "${GITHUB_STEP_SUMMARY}"

--- a/bin/util.bash
+++ b/bin/util.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Utility functions
+
+# Retrieve the names of the applications in the repo by listing the directories in the "infra" directory
+# and filtering out the directories that are not applications.
+# Returns: A list of application names.
+function get_app_names() {
+  find "infra" -maxdepth 1 -type d -not -name "infra" -not -name "accounts" -not -name "modules" -not -name "networks" -not -name "project-config" -not -name "test" -exec basename {} \;
+}

--- a/infra/project-config/system-notifications.tf
+++ b/infra/project-config/system-notifications.tf
@@ -7,10 +7,11 @@ locals {
   system_notifications_config = {
     channels = {
       workflow-failures = {
-        "type" = "slack" # or "teams"
-        # Name of the secret in GitHub
-        "channel_id_secret_name"  = "SYSTEM_NOTIFICATIONS_SLACK_CHANNEL_ID"
-        "slack_token_secret_name" = "SYSTEM_NOTIFICATIONS_SLACK_BOT_TOKEN"
+        # Uncomment if you want to send notifications to a Slack channel
+        # "type" = "slack"
+        # # Name of the secret in GitHub
+        # "channel_id_secret_name"  = "SYSTEM_NOTIFICATIONS_SLACK_CHANNEL_ID"
+        # "slack_token_secret_name" = "SYSTEM_NOTIFICATIONS_SLACK_BOT_TOKEN"
       }
     }
   }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/709

## Changes

- Add bin/orphaned-prs
- Add scan-orphaned-pr-environments.yml workflow
- Pulled out get_app_names into reusable function in util.bash
- Commented out default system notifications config

## Context for reviewers

While implementing this I realize it's simpler to implement this as a separate workflow scan-app-orphaned-pr-environments per app rather than building a single workflow that runs for all apps. Not sure if it's worth it to do the more complex thing.

I also pulled out get_app_names function from infra-deploy-status-check-configs into a utils.bash library file.

## Testing

Developed and tested on https://github.com/navapbc/platform-test/pull/143