### PR TITLE
Send notification for failed infra deploy status check

### DIFF
--- a/.github/workflows/check-infra-deploy-status.yml
+++ b/.github/workflows/check-infra-deploy-status.yml
@@ -69,3 +69,12 @@ jobs:
           echo "::endgroup::"
         env:
           TF_IN_AUTOMATION: "true"
+  notify:
+    name: Notify
+    needs: check
+    if: failure()
+    uses: ./.github/workflows/send-system-notification.yml
+    with:
+      channel: "workflow-failures"
+      message: "🔍 [Infrastructure state differs from configuration](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+    secrets: inherit


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/806

## Changes

see title

## Context for reviewers

Leveraging the previously added workflow to send notifications for failed infra status check workflow

## Testing

developed and tested on platform test see https://github.com/navapbc/platform-test/pull/149
