### PR TITLE
Fix trigger for PR environment destroy workflow

### DIFF
--- a/.github/workflows/ci-app-pr-environment-destroy.yml
+++ b/.github/workflows/ci-app-pr-environment-destroy.yml
@@ -6,7 +6,7 @@ on:
         required: true
         type: string
   # !! Uncomment the following lines once you've set up the dev environment and are ready to enable PR environments
-  # pull_request:
+  # pull_request_target:
   #   types: [closed]
 jobs:
   destroy:


### PR DESCRIPTION
Fixes bug where PR environment destroy workflow is not triggered when there is a conflict with the base branch

## Ticket

Resolves https://github.com/navapbc/template-infra/issues/826

## Changes

see title

## Context for reviewers

see ticket. i looked into why PRs were being orphaned and discovered it's not because PR destroy workflow was failing but because it wasn't being triggered at all.

## Testing

developed in platform test https://github.com/navapbc/platform-test/pull/151 but realized it's hard to test since the change won't be on the base branch since it's not merged yet. So gonna bypass testing and merge this for now.