### PR TITLE
Fix permissions for scan orphaned PRs workflow

### DIFF
--- a/.github/workflows/scan-orphaned-pr-environments.yml
+++ b/.github/workflows/scan-orphaned-pr-environments.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Noticed this problem on a private repo. Didn't notice this problem before because platform-test is a public repo so it didn't need explicit permissions to access the pull requests of the public repo.

## Testing

developed and tested in the private repo