### PR TITLE
Move prefix from env-config to service root

### DIFF
--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -18,6 +18,7 @@ pr_number="$3"
 image_tag="$4"
 
 workspace="p-${pr_number}"
+prefix="${workspace}-"
 
 echo "::group::Initialize Terraform with backend for environment: ${environment}"
 terraform -chdir="infra/${app_name}/service" init -backend-config="${environment}.s3.tfbackend"
@@ -31,7 +32,7 @@ terraform -chdir="infra/${app_name}/service" apply -input=false -auto-approve -v
 echo "::endgroup::"
 
 cluster_name="$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)"
-service_name="$(terraform -chdir="infra/$app_name/service" output -raw service_name)"
+service_name="${prefix}$(terraform -chdir="infra/$app_name/service" output -raw service_name)"
 echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 

--- a/infra/{{app_name}}/app-config/env-config/main.tf
+++ b/infra/{{app_name}}/app-config/env-config/main.tf
@@ -1,12 +1,5 @@
 locals {
-  # The prefix is used to create uniquely named resources per terraform workspace, which
-  # are needed in CI/CD for preview environments and tests.
-  #
-  # To isolate changes during infrastructure development by using manually created
-  # terraform workspaces, see: /docs/infra/develop-and-test-infrastructure-in-isolation-using-workspaces.md
-  prefix = terraform.workspace == "default" ? "" : "${terraform.workspace}-"
-
-  bucket_name = "${local.prefix}${var.project_name}-${var.app_name}-${var.environment}"
+  bucket_name = "${var.project_name}-${var.app_name}-${var.environment}"
 
   network_config = module.project_config.network_configs[var.network_name]
 }

--- a/infra/{{app_name}}/app-config/env-config/outputs.tf
+++ b/infra/{{app_name}}/app-config/env-config/outputs.tf
@@ -18,7 +18,7 @@ output "network_name" {
 
 output "service_config" {
   value = {
-    service_name             = "${local.prefix}${var.app_name}-${var.environment}"
+    service_name             = "${var.app_name}-${var.environment}"
     domain_name              = var.domain_name
     enable_https             = var.enable_https
     region                   = var.default_region

--- a/infra/{{app_name}}/service/storage.tf
+++ b/infra/{{app_name}}/service/storage.tf
@@ -1,0 +1,10 @@
+locals {
+  storage_config = local.environment_config.storage_config
+  bucket_name    = "${local.prefix}${local.storage_config.bucket_name}"
+}
+
+module "storage" {
+  source       = "../../modules/storage"
+  name         = local.bucket_name
+  is_temporary = local.is_temporary
+}


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/654

## Changes

- Move prefix local var from env-config module to service layer's root module
- Move storage resources to separate storage.tf file

## Context for reviewers

See ticket

## Testing

see https://github.com/navapbc/platform-test/pull/153