### PR TITLE
Reuse app domain for domain identity

### DIFF
--- a/infra/modules/notifications-email-domain/resources/dns.tf
+++ b/infra/modules/notifications-email-domain/resources/dns.tf
@@ -1,15 +1,11 @@
-data "aws_route53_zone" "zone" {
-  name = var.domain_name
-}
-
 resource "aws_route53_record" "dkim" {
   count = 3
 
   allow_overwrite = true
   ttl             = 60
   type            = "CNAME"
-  zone_id         = data.aws_route53_zone.zone.zone_id
-  name            = "${aws_sesv2_email_identity.sender_domain.dkim_signing_attributes[0].tokens[count.index]}._domainkey"
+  zone_id         = var.hosted_zone_id
+  name            = "${aws_sesv2_email_identity.sender_domain.dkim_signing_attributes[0].tokens[count.index]}._domainkey.${var.domain_name}"
   records         = ["${aws_sesv2_email_identity.sender_domain.dkim_signing_attributes[0].tokens[count.index]}.dkim.amazonses.com"]
 
   depends_on = [aws_sesv2_email_identity.sender_domain]
@@ -19,7 +15,7 @@ resource "aws_route53_record" "spf_mail_from" {
   allow_overwrite = true
   ttl             = "600"
   type            = "TXT"
-  zone_id         = data.aws_route53_zone.zone.zone_id
+  zone_id         = var.hosted_zone_id
   name            = aws_sesv2_email_identity_mail_from_attributes.sender_domain.mail_from_domain
   records         = ["v=spf1 include:amazonses.com ~all"]
 }
@@ -29,6 +25,6 @@ resource "aws_route53_record" "mx_receive" {
   type            = "MX"
   ttl             = "600"
   name            = local.mail_from_domain
-  zone_id         = data.aws_route53_zone.zone.zone_id
+  zone_id         = var.hosted_zone_id
   records         = ["10 feedback-smtp.${data.aws_region.current.name}.amazonaws.com"]
 }

--- a/infra/modules/notifications-email-domain/resources/variables.tf
+++ b/infra/modules/notifications-email-domain/resources/variables.tf
@@ -2,3 +2,9 @@ variable "domain_name" {
   description = "The domain name to configure SES, also used as the resource names"
   type        = string
 }
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "The Route53 hosted zone id for the domain"
+  default     = null
+}

--- a/infra/{{app_name}}/service/identity_provider.tf
+++ b/infra/{{app_name}}/service/identity_provider.tf
@@ -22,7 +22,7 @@ module "identity_provider" {
   temporary_password_validity_days = local.identity_provider_config.password_policy.temporary_password_validity_days
   verification_email_message       = local.identity_provider_config.verification_email.verification_email_message
   verification_email_subject       = local.identity_provider_config.verification_email.verification_email_subject
-  domain_name                      = local.network_config.domain_config.hosted_zone
+  domain_name                      = local.domain_name
   domain_identity_arn              = local.notifications_config == null ? null : local.domain_identity_arn
   sender_email                     = local.notifications_config == null ? null : local.notifications_config.sender_email
   sender_display_name              = local.notifications_config == null ? null : local.notifications_config.sender_display_name

--- a/infra/{{app_name}}/service/notifications.tf
+++ b/infra/{{app_name}}/service/notifications.tf
@@ -18,7 +18,8 @@ module "notifications_email_domain" {
   count  = local.notifications_config != null && !local.is_temporary ? 1 : 0
   source = "../../modules/notifications-email-domain/resources"
 
-  domain_name = local.network_config.domain_config.hosted_zone
+  domain_name    = local.domain_name
+  hosted_zone_id = local.hosted_zone_id
 }
 
 # If the app has `enable_notifications` set to true AND this *is* a temporary
@@ -27,7 +28,7 @@ module "existing_notifications_email_domain" {
   count  = local.notifications_config != null && local.is_temporary ? 1 : 0
   source = "../../modules/notifications-email-domain/data"
 
-  domain_name = local.network_config.domain_config.hosted_zone
+  domain_name = local.domain_name
 }
 
 # If the app has `enable_notifications` set to true, create a new email notification


### PR DESCRIPTION
## Ticket

N/A

## Changes

- Use service_config.domain_name for notifications-email-domain module
- DRY up usage of domain_name and hosted_zone_id in service root module by defining local variables

## Context for reviewers

We originally thought that the domain for the SES domain identity we create had to be the same as the root of the hosted zone domain rather than a subdomain, but we were wrong. This change causes the domain identity to just reuse the same domain as the app's configured domain, which simplifies things and also removes the chance of conflict between two apps that enable notifications.

## Testing

see 🔒 https://github.com/navapbc/pfml-starter-kit-app/pull/245