### PR TITLE
Consolidate domain configs

### DIFF
--- a/infra/modules/identity-provider/resources/main.tf
+++ b/infra/modules/identity-provider/resources/main.tf
@@ -4,10 +4,6 @@
 ## - Configures MFA
 ############################################################################################
 
-locals {
-  dash_domain = var.domain_name != null ? replace(var.domain_name, ".", "-") : null
-}
-
 resource "aws_cognito_user_pool" "main" {
   name = var.name
 
@@ -34,7 +30,6 @@ resource "aws_cognito_user_pool" "main" {
     # Optionally configures the FROM address and the REPLY-TO address.
     # Optionally configures using the Cognito default email or using SES.
     source_arn            = var.domain_identity_arn
-    configuration_set     = local.dash_domain
     email_sending_account = var.domain_identity_arn != null ? "DEVELOPER" : "COGNITO_DEFAULT"
     # Customize the name that users see in the "From" section of their inbox, so that it's clearer who the email is from.
     # This name also needs to be updated manually in the Cognito console for each environment's Advanced Security emails.

--- a/infra/modules/identity-provider/resources/variables.tf
+++ b/infra/modules/identity-provider/resources/variables.tf
@@ -1,9 +1,3 @@
-variable "domain_name" {
-  description = "The domain name to configure SES"
-  type        = string
-  default     = null
-}
-
 variable "domain_identity_arn" {
   description = "The ARN of the domain identity to in use for SES"
   type        = string

--- a/infra/{{app_name}}/app-config/env-config/domain.tf
+++ b/infra/{{app_name}}/app-config/env-config/domain.tf
@@ -1,0 +1,7 @@
+locals {
+  domain_config = {
+    hosted_zone  = local.network_config.domain_config.hosted_zone
+    domain_name  = var.domain_name
+    enable_https = var.enable_https
+  }
+}

--- a/infra/{{app_name}}/app-config/env-config/outputs.tf
+++ b/infra/{{app_name}}/app-config/env-config/outputs.tf
@@ -16,11 +16,13 @@ output "network_name" {
   value = var.network_name
 }
 
+output "domain_config" {
+  value = local.domain_config
+}
+
 output "service_config" {
   value = {
     service_name             = "${var.app_name}-${var.environment}"
-    domain_name              = var.domain_name
-    enable_https             = var.enable_https
     region                   = var.default_region
     cpu                      = var.service_cpu
     memory                   = var.service_memory

--- a/infra/{{app_name}}/service/domain.tf
+++ b/infra/{{app_name}}/service/domain.tf
@@ -1,14 +1,16 @@
 locals {
-  domain_name    = local.service_config.domain_name
-  hosted_zone_id = local.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
+  domain_config = local.environment_config.domain_config
+
+  hosted_zone_id  = local.domain_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
+  certificate_arn = local.domain_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
 }
 
 data "aws_acm_certificate" "certificate" {
-  count  = local.service_config.enable_https ? 1 : 0
-  domain = local.domain_name
+  count  = local.domain_config.enable_https ? 1 : 0
+  domain = local.domain_config.domain_name
 }
 
 data "aws_route53_zone" "zone" {
-  count = local.domain_name != null ? 1 : 0
-  name  = local.network_config.domain_config.hosted_zone
+  count = local.domain_config.domain_name != null ? 1 : 0
+  name  = local.domain_config.hosted_zone
 }

--- a/infra/{{app_name}}/service/identity_provider.tf
+++ b/infra/{{app_name}}/service/identity_provider.tf
@@ -24,7 +24,6 @@ module "identity_provider" {
   temporary_password_validity_days = local.identity_provider_config.password_policy.temporary_password_validity_days
   verification_email_message       = local.identity_provider_config.verification_email.verification_email_message
   verification_email_subject       = local.identity_provider_config.verification_email.verification_email_subject
-  domain_name                      = local.domain_name
   domain_identity_arn              = local.notifications_config == null ? null : local.domain_identity_arn
   sender_email                     = local.notifications_config == null ? null : local.notifications_config.sender_email
   sender_display_name              = local.notifications_config == null ? null : local.notifications_config.sender_display_name

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -67,9 +67,9 @@ module "service" {
   public_subnet_ids  = data.aws_subnets.public.ids
   private_subnet_ids = data.aws_subnets.private.ids
 
-  domain_name     = local.domain_name
+  domain_name     = local.domain_config.domain_name
   hosted_zone_id  = local.hosted_zone_id
-  certificate_arn = local.service_config.enable_https ? data.aws_acm_certificate.certificate[0].arn : null
+  certificate_arn = local.certificate_arn
 
   cpu                      = local.service_config.cpu
   memory                   = local.service_config.memory

--- a/infra/{{app_name}}/service/notifications.tf
+++ b/infra/{{app_name}}/service/notifications.tf
@@ -20,7 +20,7 @@ module "notifications_email_domain" {
   count  = local.notifications_config != null && !local.is_temporary ? 1 : 0
   source = "../../modules/notifications-email-domain/resources"
 
-  domain_name    = local.domain_name
+  domain_name    = local.domain_config.domain_name
   hosted_zone_id = local.hosted_zone_id
 }
 
@@ -30,7 +30,7 @@ module "existing_notifications_email_domain" {
   count  = local.notifications_config != null && local.is_temporary ? 1 : 0
   source = "../../modules/notifications-email-domain/data"
 
-  domain_name = local.domain_name
+  domain_name = local.domain_config.domain_name
 }
 
 # If the app has `enable_notifications` set to true, create a new email notification


### PR DESCRIPTION
## Ticket

n/a

## Changes

- Consolidate hosted_zone, domain_name, and enable_https to a domain_config object separate from the service_config object
- Remove unnecessary domain_name variable from identity-provider/resources

## Context for reviewers

While working on another PR I realized the domain configs are intermingled with service configs. This PR cleans that up. There should be no functional changes in this PR, just reorganizing things.

## Testing

see https://github.com/navapbc/platform-test/pull/157