### PR TITLE
Fix race condition when publishing images

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Get commit hash
         id: get-commit-hash
         run: |
-          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          # HEAD should be the same as inputs.ref since we checked out inputs.ref
+          COMMIT_HASH=$(git rev-parse HEAD)
           echo "Commit hash: $COMMIT_HASH"
           echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
   build-and-publish:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -48,7 +48,7 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     needs: get-commit-hash
-    concurrency: ${{ github.workflow }}-${{ needs.get-commit-hash.outputs.commit_hash }}
+    concurrency: ${{ github.workflow }}-${{ inputs.app_name }}-${{ needs.get-commit-hash.outputs.commit_hash }}
 
     permissions:
       contents: read

--- a/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
+++ b/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
@@ -47,8 +47,6 @@ on:
         description: Tag or branch or SHA to test
 
 jobs:
-  # `make infra-test-service` will build and publish the release itself, but
-  #  doing it explicitly with the re-usable workflow helps avoid race conditions
   build-and-publish:
     name: Build
     uses: ./.github/workflows/build-and-publish.yml

--- a/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
+++ b/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
@@ -31,13 +31,13 @@ on:
   #     - infra/{{ app_name }}/service/**
   #     - infra/modules/**
   #     - infra/test/**
-  #     - .github/workflows/ci-{{app_name}}-infra-service.yml
+  #     - .github/workflows/ci-{{ app_name }}-infra-service.yml
   # pull_request:
   #   paths:
   #     - infra/{{ app_name }}/service/**
   #     - infra/modules/**
   #     - infra/test/**
-  #     - .github/workflows/ci-{{app_name}}-infra-service.yml
+  #     - .github/workflows/ci-{{ app_name }}-infra-service.yml
   {% endif %}
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
+++ b/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
@@ -31,20 +31,35 @@ on:
   #     - infra/{{ app_name }}/service/**
   #     - infra/modules/**
   #     - infra/test/**
-  #     - .github/workflows/ci-infra-service.yml
+  #     - .github/workflows/ci-{{app_name}}-infra-service.yml
   # pull_request:
   #   paths:
   #     - infra/{{ app_name }}/service/**
   #     - infra/modules/**
   #     - infra/test/**
-  #     - .github/workflows/ci-infra-service.yml
+  #     - .github/workflows/ci-{{app_name}}-infra-service.yml
   {% endif %}
   workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        default: "main"
+        description: Tag or branch or SHA to test
 
 jobs:
+  # `make infra-test-service` will build and publish the release itself, but
+  #  doing it explicitly with the re-usable workflow helps avoid race conditions
+  build-and-publish:
+    name: Build
+    uses: ./.github/workflows/build-and-publish.yml
+    with:
+      app_name: {{ app_name }}
+      ref: ${{ inputs.version || github.ref }}
+
   infra-test-e2e:
     name: Test service
     runs-on: ubuntu-latest
+    needs: [build-and-publish]
 
     permissions:
       contents: read
@@ -52,6 +67,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version || github.ref }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
+++ b/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/build-and-publish.yml
     with:
       app_name: {{ app_name }}
-      ref: ${{ inputs.version || github.ref }}
+      ref: ${{'{{'}} inputs.version || github.ref {{'}}'}}
 
   infra-test-e2e:
     name: Test service
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version || github.ref }}
+          ref: ${{'{{'}} inputs.version || github.ref {{'}}'}}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -1,3 +1,10 @@
+// Package test contains infrastructure tests for testing the service layer.
+// Prerequisite: Ensure the container image for the current git hash has
+// been built and published to the container image repository.
+// When running in CI, use the build-and-publish workflow.
+// When running locally, run `make release-build` followed by
+// `make release-publish`.
+
 package test
 
 import (
@@ -19,8 +26,6 @@ var workspaceName = fmt.Sprintf("t-%s", uniqueId)
 var testAppName = os.Getenv("APP_NAME")
 
 func TestService(t *testing.T) {
-	BuildAndPublish(t)
-
 	imageTag := shell.RunCommandAndGetOutput(t, shell.Command{
 		Command:    "git",
 		Args:       []string{"rev-parse", "HEAD"},
@@ -51,36 +56,6 @@ func TestService(t *testing.T) {
 
 	WaitForServiceToBeStable(t, workspaceName)
 	RunEndToEndTests(t, terraformOptions)
-}
-
-func BuildAndPublish(t *testing.T) {
-	fmt.Println("::group::Initialize build-repository module")
-	// terratest currently does not support passing a file as the -backend-config option
-	// so we need to manually call terraform rather than using terraform.Init
-	// see https://github.com/gruntwork-io/terratest/issues/517
-	// it looks like this PR would add functionality for this: https://github.com/gruntwork-io/terratest/pull/558
-	// after which we add BackendConfig: []string{"dev.s3.tfbackend": terraform.KeyOnly} to terraformOptions
-	// and replace the call to terraform.RunTerraformCommand with terraform.Init
-	TerraformInit(t, &terraform.Options{
-		TerraformDir: fmt.Sprintf("../%s/build-repository/", testAppName),
-	}, "shared.s3.tfbackend")
-	fmt.Println("::endgroup::")
-
-	fmt.Println("::group::Build release")
-	shell.RunCommand(t, shell.Command{
-		Command:    "make",
-		Args:       []string{"release-build", fmt.Sprintf("APP_NAME=%s", testAppName)},
-		WorkingDir: "../../",
-	})
-	fmt.Println("::endgroup::")
-
-	fmt.Println("::group::Publish release")
-	shell.RunCommand(t, shell.Command{
-		Command:    "make",
-		Args:       []string{"release-publish", fmt.Sprintf("APP_NAME=%s", testAppName)},
-		WorkingDir: "../../",
-	})
-	fmt.Println("::endgroup::")
 }
 
 func WaitForServiceToBeStable(t *testing.T, workspaceName string) {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/836

## Changes

The `ci-{{app_name}}-infra-service.yml` and `cd-{{app_name}}.yml` workflows
occasionally run into issues trying to publish an already existing image tag[1],
failing with something like:

> tag invalid: The image tag '48995925face06c5fcb68fc52c50e7d57bb46ff6' already exists in the 'platform-nextjs-app' repository and cannot be overwritten because the repository is immutable.

I believe what's happening is that for merges to `main`, the two workflows get
kicked off at the same time, both needing build and publish an image for the
same commit and using different methods for doing that building/publishing.
`ci-{{app_name}}-infra-service.yml` runs the commands internally to its test
logic, `cd-{{app_name}}.yml` uses the `build-and-publish.yml` workflow.

By having `ci-{{app_name}}-infra-service.yml` use the re-usable
build-and-publish workflow that `cd-{{app_name}}.yml` is using, which has an
internal concurrency limit, the workflows should no longer race against each
other to build the same commit.

[1] https://github.com/navapbc/platform-test-nextjs/actions/runs/12484891877/job/34842946860

## Testing

see https://github.com/navapbc/platform-test/pull/146