### PR TITLE
Retry link check on 429

### DIFF
--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -15,5 +15,6 @@
       "pattern": "^/",
       "replacement": "{{BASEURL}}/"
     }
-  ]
+  ],
+  "retryOn429": true
 }


### PR DESCRIPTION
## Ticket

N/A

## Changes

see title

## Context for reviewers

Medium links often fail with 429 status (too many requests) e.g. https://github.com/navapbc/template-infra/actions/runs/12958908504/job/36150424574?pr=852

<img width="748" alt="image" src="https://github.com/user-attachments/assets/ba12b1d3-fc2b-4153-8ffb-4e7955153632" />

As a side note looks like as of May 2024 the author of the link checker recommends using a new tool https://github.com/UmbrellaDocs/linkspector

## Testing

CI