### PR TITLE
Include prefix in service root `service_name` output

### DIFF
--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -18,7 +18,6 @@ pr_number="$3"
 image_tag="$4"
 
 workspace="p-${pr_number}"
-prefix="${workspace}-"
 
 echo "::group::Initialize Terraform with backend for environment: ${environment}"
 terraform -chdir="infra/${app_name}/service" init -backend-config="${environment}.s3.tfbackend"
@@ -32,7 +31,7 @@ terraform -chdir="infra/${app_name}/service" apply -input=false -auto-approve -v
 echo "::endgroup::"
 
 cluster_name="$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)"
-service_name="${prefix}$(terraform -chdir="infra/$app_name/service" output -raw service_name)"
+service_name="$(terraform -chdir="infra/$app_name/service" output -raw service_name)"
 echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 

--- a/infra/{{app_name}}/service/outputs.tf
+++ b/infra/{{app_name}}/service/outputs.tf
@@ -24,5 +24,5 @@ output "service_endpoint" {
 }
 
 output "service_name" {
-  value = local.service_config.service_name
+  value = local.service_name
 }


### PR DESCRIPTION
## Changes

The prefix was recently moved from the env-config to the service root[1], with
the effect that the `service_config.service_name` value no longer carries the
running/real service name. Special support was added to the
`bin/update-pr-environment` script to reconstruct the actual service name, but
other things also need the prefixed service name, like `bin/deploy-release` and
`bin/run-command`, and in general feels like we should output the actual service
name.

[1] ab1fda44f30077bc1084a5cabd50d9d465e21699

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
