### PR TITLE
Support ephemeral write mounts for services

### DIFF
--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -169,3 +169,9 @@ variable "vpc_id" {
   type        = string
   description = "Uniquely identifies the VPC."
 }
+
+variable "ephemeral_write_volumes" {
+  type        = set(string)
+  description = "A set of absolute paths in the container to be mounted as writable for the life of the task. These need to be declared with `VOLUME` instructions in the container build file."
+  default     = []
+}

--- a/infra/{{app_name}}/app-config/env-config/outputs.tf
+++ b/infra/{{app_name}}/app-config/env-config/outputs.tf
@@ -41,6 +41,8 @@ output "service_config" {
       # For job configs that don't define a source_bucket, add the source_bucket config property
       job_name => merge({ source_bucket = local.bucket_name }, job_config)
     }
+
+    ephemeral_write_volumes = []
   }
 }
 

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -125,5 +125,7 @@ module "service" {
     } : {},
   )
 
+  ephemeral_write_volumes = local.service_config.ephemeral_write_volumes
+
   is_temporary = local.is_temporary
 }


### PR DESCRIPTION
## Ticket

Half of solving https://github.com/navapbc/template-application-rails/issues/58

## Changes

Fargate tasks come with 20 GiB of ephemeral storage[1] by default (the container image size itself eats into this) and can be increased up to a maximum of 200 GiB.

While generally encouraged to store files/write data to a network location/a database, there are situations where it is useful to have some "local" file space to write data to (e.g., tmpfiles, processing a large data file).

Fargate can be configured to mount its allocated ephemeral space into the container to facilitate this. This has a few pieces[2], in summary:
1. Create the desired writable locations in the container image, with the
   appropriate permissions/owner, and declare them with a `VOLUME` instruction:

    ```dockerfile
    VOLUME /var/scratch
    ```
2. In the task definition `volumes` section, define a bind mount:

    ```json
    "volumes": [
        {
            "name": "scratch_space"
        }
    ]
    ```
    (the name doesn't really matter, but is limited to 255 characters of a limited set[3])
3. For the appropriate entries in the `containerDefintions` part of the task
   definition, define a `mountPoints` entry connecting the volume name from step
   2, with the `VOLUME` path from step 1:

    ```json
    "containerDefinitions": [
        {
          "name": "my-app",
          "image": "my-repo/my-app",
          "cpu": 100,
          "memory": 100,
          "essential": true,
          "mountPoints": [
              {
                 "sourceVolume": "scratch_space",
                 "containerPath": "/var/scratch",
                 "readOnly": false
              }
          ]
        }
    ]
    ```

This will result in a mounted location in the container, with as much space as is free in the allocated ephemeral storage of the Fargate task, whose contents are thrown away when the task stops.

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html#fargate-task-storage-linux-pv
[2] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mount-examples.html#:~:text=To%20provide%20an%20empty%20data%20volume%20for%20one%20or%20more%20containers
[3] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specify-bind-mount-config.html

## Testing

https://github.com/navapbc/platform-test/pull/175