### PR TITLE
Add ability to run task commands in PR environment

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -27,6 +27,7 @@ set -euo pipefail
 # Parse optional parameters
 environment_variables=""
 task_role_arn=""
+workspace_name=""
 while :; do
   case "$1" in
     --environment-variables)
@@ -35,6 +36,10 @@ while :; do
       ;;
     --task-role-arn)
       task_role_arn="$2"
+      shift 2
+      ;;
+    --workspace)
+      workspace_name="$2"
       shift 2
       ;;
     *)
@@ -56,7 +61,19 @@ echo "  environment=${environment}"
 echo "  command=${command}"
 echo "  environment_variables=${environment_variables:-}"
 echo "  task_role_arn=${task_role_arn:-}"
+echo "  workspace_name=${workspace_name:-}"
 echo
+
+# Initialize terraform and select workspace if specified
+./bin/terraform-init "infra/${app_name}/service" "${environment}"
+
+if [ -n "${workspace_name}" ]; then
+  # Set up trap to restore workspace on script exit
+  original_workspace=$(terraform -chdir="infra/${app_name}/service" workspace show)
+  trap 'terraform -chdir="infra/${app_name}/service" workspace select "${original_workspace}"' EXIT
+
+  terraform -chdir="infra/${app_name}/service" workspace select "${workspace_name}"
+fi
 
 # Use the same cluster, task definition, and network configuration that the application service uses
 cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/718
Resolves https://github.com/navapbc/template-infra/issues/878

## Changes

- Add optional parameter --workspace <workspace_name> to bin/run-command
- Fix bug where run-command ignored environment parameter and just ran in currently initialized environment

## Context for reviewers

This feature makes it possible to test changes to background jobs in a PR environment by using the run-command script

## Testing

See https://github.com/navapbc/platform-test/pull/181