### PR TITLE
Move monitoring config out of service root module

### DIFF
--- a/docs/infra/set-up-monitoring-alerts.md
+++ b/docs/infra/set-up-monitoring-alerts.md
@@ -4,26 +4,21 @@
 
 The monitoring module defines metric-based alerting policies that provide awareness into issues with the cloud application. The module supports integration with external incident management tools like Splunk-On-Call or Pagerduty. It also supports email alerts.
 
-### Set up email alerts.
+### Set up email alerts
 
-1. Add the `email_alerts_subscription_list` variable to the monitoring module call in the service layer
+The monitoring module supports a simple email-based alerting system that does not rely on an external incident management service.
 
-For example:
-```
-module "monitoring" {
-  source = "../../modules/monitoring"
-  email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
-  ...
-}
-```
+1. Update the `email_alert_recipients` variable in `app-config/env-config/monitoring.tf`
+
 2. Run `make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>` to apply the changes to each environment.
-When any of the alerts described by the module are triggered notification will be sent to all emails specified in the `email_alerts_subscription_list`
 
-### Set up External incident management service integration.
+### Integrate with an incident management service
 
 1. Set setting `has_incident_management_service = true` in app-config/main.tf
 2. Get the integration URL for the incident management service and store it in AWS SSM Parameter Store by running the following command for each environment:
-```
-make infra-configure-monitoring-secrets APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT> URL=<WEBHOOK_URL>
-```
+
+    ```bash
+    make infra-configure-monitoring-secrets APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT> URL=<WEBHOOK_URL>
+    ```
+
 3. Run `make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>` to apply the changes to each environment.

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
 #email integration
 
 resource "aws_sns_topic_subscription" "email_integration" {
-  for_each  = var.email_alerts_subscription_list
+  for_each  = var.email_alert_recipients
   topic_arn = aws_sns_topic.this.arn
   protocol  = "email"
   endpoint  = each.value

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -1,4 +1,4 @@
-variable "email_alerts_subscription_list" {
+variable "email_alert_recipients" {
   type        = set(string)
   default     = []
   description = "List of emails to subscribe to alerts"

--- a/infra/{{app_name}}/app-config/env-config/monitoring.tf
+++ b/infra/{{app_name}}/app-config/env-config/monitoring.tf
@@ -1,0 +1,12 @@
+locals {
+  monitoring_config = {
+    # Emails to notify for alerts.
+    # Use this as a simple notification mechanism if you don't have an incident management service.
+    email_alert_recipients = []
+
+    incident_management_service = var.has_incident_management_service ? {
+      integration_url_param_name = "/monitoring/${var.app_name}/${var.environment}/incident-management-integration-url"
+    } : null
+  }
+}
+

--- a/infra/{{app_name}}/app-config/env-config/outputs.tf
+++ b/infra/{{app_name}}/app-config/env-config/outputs.tf
@@ -10,10 +10,8 @@ output "scheduled_jobs" {
   value = local.scheduled_jobs
 }
 
-output "incident_management_service_integration" {
-  value = var.has_incident_management_service ? {
-    integration_url_param_name = "/monitoring/${var.app_name}/${var.environment}/incident-management-integration-url"
-  } : null
+output "monitoring_config" {
+  value = local.monitoring_config
 }
 
 output "network_name" {

--- a/infra/{{app_name}}/service/monitoring.tf
+++ b/infra/{{app_name}}/service/monitoring.tf
@@ -1,21 +1,21 @@
 locals {
-  incident_management_service_integration_config = local.environment_config.incident_management_service_integration
+  monitoring_config                           = local.environment_config.monitoring_config
+  incident_management_service_integration_url = module.app_config.has_incident_management_service && !local.is_temporary ? data.aws_ssm_parameter.incident_management_service_integration_url[0].value : null
 }
 
 # Retrieve url for external incident management tool (e.g. Pagerduty, Splunk-On-Call)
 
 data "aws_ssm_parameter" "incident_management_service_integration_url" {
   count = module.app_config.has_incident_management_service ? 1 : 0
-  name  = local.incident_management_service_integration_config.integration_url_param_name
+  name  = local.monitoring_config.incident_management_service.integration_url_param_name
 }
 
 module "monitoring" {
   source = "../../modules/monitoring"
-  #Email subscription list:
-  #email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
 
   # Module takes service and ALB names to link all alerts with corresponding targets
   service_name                                = local.service_name
   load_balancer_arn_suffix                    = module.service.load_balancer_arn_suffix
-  incident_management_service_integration_url = module.app_config.has_incident_management_service && !local.is_temporary ? data.aws_ssm_parameter.incident_management_service_integration_url[0].value : null
+  email_alert_recipients                      = local.monitoring_config.email_alert_recipients
+  incident_management_service_integration_url = local.incident_management_service_integration_url
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/547

## Changes

- Create new env-config object monitoring_config defined in monitoring.tf
- Move incident_management_service_integration config to monitoring_config as incident_management_service attribute
- Rename email_alerts_subscription_list to email_alert_recipients

## Context for reviewers

Tech debt to clean up the configuration for monitoring

## Testing

See https://github.com/navapbc/platform-test/pull/183