### PR TITLE
bin/orphaned-pr-environments: Handle no PR envs and merged PRs better

### DIFF
--- a/bin/orphaned-pr-environments
+++ b/bin/orphaned-pr-environments
@@ -7,6 +7,8 @@
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
+GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-/dev/null}
+
 app_name="$1"
 
 echo "::group::Initialize Terraform"

--- a/bin/orphaned-pr-environments
+++ b/bin/orphaned-pr-environments
@@ -19,6 +19,8 @@ echo "::endgroup::"
 echo "::group::List PRs with PR environments"
 echo terraform -chdir="infra/${app_name}/service" workspace list
 workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
+# grep will exit with code `1` if there's no match, so ignore that for when
+# there are no PR workspaces for the application
 pr_nums="$(echo "${workspaces}" | { grep -o 'p-[0-9]\+' || test $? = 1; } | sed 's/p-//')"
 echo "PRs"
 echo "${pr_nums}"

--- a/bin/orphaned-pr-environments
+++ b/bin/orphaned-pr-environments
@@ -17,7 +17,7 @@ echo "::endgroup::"
 echo "::group::List PRs with PR environments"
 echo terraform -chdir="infra/${app_name}/service" workspace list
 workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
-pr_nums="$(echo "${workspaces}" | grep -o 'p-[0-9]\+' | sed 's/p-//')"
+pr_nums="$(echo "${workspaces}" | { grep -o 'p-[0-9]\+' || test $? = 1; } | sed 's/p-//')"
 echo "PRs"
 echo "${pr_nums}"
 echo "::endgroup::"
@@ -28,7 +28,7 @@ for pr_num in $pr_nums; do
   pr_status="$(gh pr view "$pr_num" --json state --jq ".state")"
   echo "PR ${pr_num}: ${pr_status}"
 
-  if [ "$pr_status" == "CLOSED" ]; then
+  if [ "$pr_status" == "CLOSED" ] || [ "$pr_status" == "MERGED" ]; then
     closed_prs+=("$pr_num")
   fi
 done


### PR DESCRIPTION
## Changes

When there are no PR environments for an application, `grep 'pr-'` against the
workspace names will not match anything, in which case grep returns a code of
`1`. Since `-o pipefail` is set, `grep` returning `1` will fail the pipeline,
and since `-e` is set, the pipeline will fail the script. So catch a return of
`1` from `grep` and continue on.

Also handle merged PR statuses in addition to closed, as that will sometimes be
the case.

Also set a default for `GITHUB_STEP_SUMMARY` for when running the script
locally. 

## Testing

### Before

Errors out when there are no PR envs.

![image](https://github.com/user-attachments/assets/ecd51d8c-86ff-463a-a605-03f7e929d8e9)

### After

Does not error out.

![image](https://github.com/user-attachments/assets/e38c601a-9860-4ec8-b233-5127d6da52dc)


### Before

Doesn't flag dangling PR environment from a merged PR.

![image](https://github.com/user-attachments/assets/67808bf7-4693-44a3-afda-06a55be175a3)

### After

![image](https://github.com/user-attachments/assets/70f4cd11-5526-4e78-80a6-40ee43dbb64e)