### PR TITLE
Fix orphaned PR env scan when no non-default workspaces

### DIFF
--- a/bin/orphaned-pr-environments
+++ b/bin/orphaned-pr-environments
@@ -17,6 +17,9 @@ echo "::endgroup::"
 echo "::group::List PRs with PR environments"
 echo terraform -chdir="infra/${app_name}/service" workspace list
 workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
+
+# Search for workspaces that start with "p-" and extract the PR numbers
+# The "|| true" is used to avoid errors if there are no PR environments
 pr_nums="$(echo "${workspaces}" | grep -o 'p-[0-9]\+' || true | sed 's/p-//')"
 echo "PRs"
 echo "${pr_nums}"

--- a/bin/orphaned-pr-environments
+++ b/bin/orphaned-pr-environments
@@ -17,7 +17,7 @@ echo "::endgroup::"
 echo "::group::List PRs with PR environments"
 echo terraform -chdir="infra/${app_name}/service" workspace list
 workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
-pr_nums="$(echo "${workspaces}" | grep -o 'p-[0-9]\+' | sed 's/p-//')"
+pr_nums="$(echo "${workspaces}" | grep -o 'p-[0-9]\+' || true | sed 's/p-//')"
 echo "PRs"
 echo "${pr_nums}"
 echo "::endgroup::"


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

- Add "or true" to grep command that searches for non-default workspaces

## Context for reviewers

The Scan orphaned PR environments workflow was failing (Most recent failed run: https://github.com/navapbc/pfml-starter-kit-app/actions/runs/13625676007)

When there's only one workspace, `terraform workspace list` will return `* default`, which doesn't get found by `grep -o 'p-[0-9]\+'` which is only looking for lines without the `*`. This means that the grep returns a status code of 1, causing the line `workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"` to fail, terminating the script.

This change fixes this issue by adding `|| true` to the grep part of the command pipeline.

## Testing

see https://github.com/navapbc/pfml-starter-kit-app/pull/266