### PR TITLE
Move emailService to fixture for e2e tests

### DIFF
--- a/e2e/fixtures/email-service-fixture.ts
+++ b/e2e/fixtures/email-service-fixture.ts
@@ -14,7 +14,7 @@ type EmailServiceFixtures = {
 export const test = base.extend<EmailServiceOptions & EmailServiceFixtures>({
   emailServiceType: ['MessageChecker', { option: true }],
   emailService: async ({ emailServiceType, context }, use) => {
-    let emailService;
+    let emailService: EmailService;
     if (emailServiceType === 'MessageChecker') {
       emailService = new MessageCheckerService(context);
     } else if (emailServiceType === 'Mailinator') {

--- a/e2e/fixtures/email-service-fixture.ts
+++ b/e2e/fixtures/email-service-fixture.ts
@@ -22,6 +22,6 @@ export const test = base.extend<EmailServiceOptions & EmailServiceFixtures>({
     } else {
       throw new Error(`Unknown email service type: ${emailServiceType}`);
     }
-    use(emailService);
+    await use(emailService);
   }
 });

--- a/e2e/fixtures/email-service-fixture.ts
+++ b/e2e/fixtures/email-service-fixture.ts
@@ -1,0 +1,27 @@
+import { test as base } from '@playwright/test';
+import { EmailService } from '../lib/services/email/EmailService';
+import { MessageCheckerService } from '../lib/services/email/MessageCheckerService';
+import { MailinatorService } from '../lib/services/email/MailinatorService';
+
+type EmailServiceOptions = {
+  emailServiceType: string
+};
+
+type EmailServiceFixtures = {
+  emailService: EmailService;
+};
+
+export const test = base.extend<EmailServiceOptions & EmailServiceFixtures>({
+  emailServiceType: ['MessageChecker', { option: true }],
+  emailService: async ({ emailServiceType, context }, use) => {
+    let emailService;
+    if (emailServiceType === 'MessageChecker') {
+      emailService = new MessageCheckerService(context);
+    } else if (emailServiceType === 'Mailinator') {
+      emailService = new MailinatorService(context);
+    } else {
+      throw new Error(`Unknown email service type: ${emailServiceType}`);
+    }
+    use(emailService);
+  }
+});

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,0 +1,4 @@
+import { mergeTests } from "playwright/test";
+import { test as emailServiceTest } from "./email-service-fixture";
+
+export const test = mergeTests(emailServiceTest);

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-import { mergeTests } from "playwright/test";
+import { mergeTests } from "@playwright/test";
 import { test as emailServiceTest } from "./email-service-fixture";
 
 export const test = mergeTests(emailServiceTest);

--- a/e2e/{{app_name}}/playwright.config.js.jinja
+++ b/e2e/{{app_name}}/playwright.config.js.jinja
@@ -6,7 +6,8 @@ export default defineConfig(deepMerge(
   baseConfig,
   {
     use: {
-      baseURL: baseConfig.use.baseURL || "localhost:{{ app_local_port }}"
+      baseURL: baseConfig.use.baseURL || "localhost:{{ app_local_port }}",
+      // emailServiceType: "Mailinator", // Options: ["MessageChecker", "Mailinator"]. Default: "MessageChecker"
     },
   }
 ));


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Individual tests should not need to know which email service is being used. That should be defined at the e2e test suite configuration level. This change adds an emailService fixture using Playwright fixtures with the default using MessageChecker.

## Testing

see https://github.com/navapbc/pfml-starter-kit-app/pull/267