### PR TITLE
Fix service module public_endpoint output when https enabled

### DIFF
--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -22,5 +22,5 @@ output "migrator_role_arn" {
 
 output "public_endpoint" {
   description = "The public endpoint for the service."
-  value       = "http://${aws_lb.alb.dns_name}"
+  value       = "${var.certificate_arn != null ? "https" : "http"}://${aws_lb.alb.dns_name}"
 }


### PR DESCRIPTION
## Ticket

n/a

## Changes

- Set public_endpoint to use https protocol when https is enabled

## Context for reviewers

Discovered this while working on e2e testing. Preview environments use the service module public_endpoint output to define the preview environment URL. When HTTPS is enabled we will eventually redirect from HTTP to HTTPS. For Rails apps we already do this at the app level. This means that the preview environment thinks it's at the HTTP endpoint but the server quickly redirects to HTTPS. This breaks end-to-end tests since the tests needs a consistent base URL.

## Testing

See https://github.com/navapbc/pfml-starter-kit-app/pull/269

It was failing before, and I was able to reproduce the issue and narrow it down to the http vs https cause. After the fix, the e2e tests pass on that PR.