### PR TITLE
Simplify e2e setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ __check_defined = \
 	e2e-clean-image \
 	e2e-clean-report \
 	e2e-merge-reports \
+	e2e-setup \
 	e2e-setup-ci \
-	e2e-setup-native \
 	e2e-show-report \
 	e2e-test \
 	e2e-test-native \
@@ -96,17 +96,16 @@ e2e-clean-report: ## Remove the local e2e report folders and content
 	rm -rf ./e2e/test-results
 
 e2e-merge-reports: ## Merge E2E blob reports from multiple shards into an HTML report
-	cd e2e && npm run e2e-merge-reports
+	cd e2e && npm run merge-reports
+
+e2e-setup: ## Setup end-to-end tests
+	cd e2e && npm install
 
 e2e-setup-ci: ## Setup end-to-end tests for CI
-	cd e2e && npm run e2e-setup
-
-e2e-setup-native: ## Setup end-to-end tests
-	cd e2e && npm install
-	cd e2e && npm run e2e-setup
+	cd e2e && npm ci
 
 e2e-show-report: ## Show the E2E report
-	cd e2e && npm run e2e-show-report
+	cd e2e && npm run show-report
 
 e2e-test: ## Run E2E tests in a Docker container and copy the report locally
 e2e-test: e2e-build
@@ -122,18 +121,18 @@ e2e-test: e2e-build
 		-v $(PWD)/e2e/playwright-report:/e2e/playwright-report \
 		-v $(PWD)/e2e/blob-report:/e2e/blob-report \
 		$(E2E_IMAGE_NAME) \
-		$(E2E_ARGS)
+		npm test -- $(E2E_ARGS)
 	@echo "Run 'make e2e-show-report' to view the test report"
 
 e2e-test-native: ## Run end-to-end tests natively
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@echo "Running e2e tests with CI=${CI}, APP_NAME=${APP_NAME}, BASE_URL=${BASE_URL}"
-	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npm run e2e-test -- $(E2E_ARGS)
+	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npm test -- $(E2E_ARGS)
 
 e2e-test-native-ui: ## Run end-to-end tests natively in UI mode
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@echo "Running e2e UI tests natively with APP_NAME=$(APP_NAME), BASE_URL=$(BASE_URL)"
-	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npm run e2e-test:ui -- $(E2E_ARGS)
+	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npm run test:ui -- $(E2E_ARGS)
 
 ###########
 ## Infra ##

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -48,13 +48,14 @@ First, make sure the application you want to test is running.
 To run end-to-end tests natively, first install Playwright with:
 
 ```bash
-make e2e-setup-native
+make e2e-setup
 ```
 
 Then, run the tests with your app name and base url:
 ```bash
 make e2e-test-native APP_NAME=app
 ```
+
 >* `BASE_URL` is optional for both `e2e-test-native` and `e2e-test-native-ui` targets. It will by default use the app-specific (`/e2e/<APP_NAME>/playwright.config.js`) `baseURL`
 
 ### Run tests in UI mode

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -12,12 +12,8 @@ COPY e2e/package.json e2e/package-lock.json ./
 
 # install deps
 RUN npm ci
-RUN npm run e2e-setup
 
 # Copy entire e2e folder over
 COPY e2e /e2e
 
-ENTRYPOINT ["npm", "run", "e2e-test", "--"]
-
-# Optional additional args
-CMD [""]
+CMD ["npm", "test", "--"]

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,122 +1,115 @@
 {
-    "name": "e2e",
-    "version": "1.0.0",
-    "lockfileVersion": 3,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "e2e",
-            "version": "1.0.0",
-            "dependencies": {
-                "@axe-core/playwright": "^4.10.1",
-                "dotenv": "^16.4.7",
-                "playwright": "^1.49.0"
-            },
-            "devDependencies": {
-                "@playwright/test": "^1.49.0",
-                "@types/node": "^22.10.1"
-            }
-        },
-        "node_modules/@axe-core/playwright": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
-            "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
-            "dependencies": {
-                "axe-core": "~4.10.2"
-            },
-            "peerDependencies": {
-                "playwright-core": ">= 1.0.0"
-            }
-        },
-        "node_modules/@playwright/test": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-            "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
-            "dev": true,
-            "dependencies": {
-                "playwright": "1.49.0"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@types/node": {
-            "version": "22.10.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-            "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
-            "dev": true,
-            "dependencies": {
-                "undici-types": "~6.20.0"
-            }
-        },
-        "node_modules/axe-core": {
-            "version": "4.10.2",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-            "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "16.4.7",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-            "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/playwright": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-            "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
-            "dependencies": {
-                "playwright-core": "1.49.0"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
-            }
-        },
-        "node_modules/playwright-core": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-            "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
-            "bin": {
-                "playwright-core": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/undici-types": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-            "dev": true
-        }
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.1",
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.10.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.2"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     }
+  }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,20 +1,15 @@
 {
-    "name": "e2e",
-    "version": "1.0.0",
-    "scripts": {
-      "e2e-merge-reports": "npx playwright merge-reports --reporter html blob-report",
-      "e2e-setup": "npx playwright install --with-deps",
-      "e2e-show-report": "npx playwright show-report",
-      "e2e-test": "./run-e2e-test",
-      "e2e-test:ui": "./run-e2e-test --ui"
-    },
-    "devDependencies": {
-      "@playwright/test": "^1.49.0",
-      "@types/node": "^22.10.1"
-    },
-    "dependencies": {
-      "@axe-core/playwright": "^4.10.1",
-      "dotenv": "^16.4.7",
-      "playwright": "^1.49.0"
-    }
+  "name": "e2e",
+  "version": "1.0.0",
+  "scripts": {
+    "merge-reports": "npx playwright merge-reports --reporter html blob-report",
+    "show-report": "npx playwright show-report",
+    "test": "./run-e2e-test",
+    "test:ui": "./run-e2e-test --ui"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.1",
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.10.1"
   }
+}

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,9 +1,4 @@
-// Load environment variables from .env file if it exists
-import * as dotenv from 'dotenv';
-
 import { defineConfig, devices } from "@playwright/test";
-
-dotenv.config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/e2e/run-e2e-test
+++ b/e2e/run-e2e-test
@@ -5,7 +5,7 @@
 
 # Ensure APP_NAME is provided
 if [[ -z "${APP_NAME}" ]]; then
-  echo "You must pass in a specific APP_NAME. IE: APP_NAME=app npm run e2e-test" >&2
+  echo "You must pass in a specific APP_NAME. IE: APP_NAME=app npm test" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

- Remove unused dotenv package
- Remove redundant package playwright (already have playwright/test)
- Remove dotenv package
- Consolidate dependencies and devDependencies

## Context for reviewers

- Testing out whether we need `npm run e2e-setup` to do `npx install playwright` or whether we can just do `npm ci` like any other package 
- I didn't see any .env file so I didn't see the point of the dotenv package either, seems like we can simplify

## Testing

See https://github.com/navapbc/pfml-starter-kit-app/pull/272