### PR TITLE
Refactor e2e/lib/EmailService

### DIFF
--- a/e2e/lib/services/email/EmailService.ts
+++ b/e2e/lib/services/email/EmailService.ts
@@ -17,7 +17,7 @@ export abstract class EmailService {
   /*
    * Generate a random email address
    */
-  abstract generateEmailAddress(): EmailAddress;
+  abstract generateEmailAddress(username: string): EmailAddress;
 
   /*
    * Get EmailContent associated with an Email
@@ -38,14 +38,15 @@ export abstract class EmailService {
   ): Promise<EmailContent>;
 
   /*
-   * Get a random base 36 alphanumeric string.
-   * Used for creating a test email address.
+   * Generate a random username
    */
-  protected randomString(length: number): string {
-    const numBytes = Math.ceil(length * 2);
-    return Array.from(crypto.getRandomValues(new Uint8Array(numBytes)))
+  generateUsername(): string {
+    const randomStringLength = 10;
+    const numBytes = Math.ceil(randomStringLength * 2);
+    const randomString = Array.from(crypto.getRandomValues(new Uint8Array(numBytes)))
       .map((b) => b.toString(36))
       .join('')
-      .slice(0, length);
+      .slice(0, randomStringLength);
+    return `test-${randomString}`;
   }
 }

--- a/e2e/lib/services/email/MailinatorService.ts
+++ b/e2e/lib/services/email/MailinatorService.ts
@@ -9,9 +9,8 @@ export class MailinatorService extends EmailService {
     this.context = context;
   }
 
-  generateEmailAddress(): EmailAddress {
-    const randomString = this.randomString(10);
-    return `test+${randomString}@mailinator.com`;
+  generateEmailAddress(username: string): EmailAddress {
+    return `${username}@mailinator.com`;
   }
 
   // Action functions

--- a/e2e/lib/services/email/MessageCheckerService.ts
+++ b/e2e/lib/services/email/MessageCheckerService.ts
@@ -9,9 +9,8 @@ export class MessageCheckerService extends EmailService {
     this.context = context;
   }
 
-  generateEmailAddress(): EmailAddress {
-    const randomString = this.randomString(10);
-    return `test+${randomString}@message-checker.appspotmail.com`;
+  generateEmailAddress(username: string): EmailAddress {
+    return `${username}@message-checker.appspotmail.com`;
   }
 
   // Action functions
@@ -58,7 +57,8 @@ export class MessageCheckerService extends EmailService {
     try {
       const matchingRow = inboxPage.getByRole('row').filter({ hasText: subjectSubstring }).first();
 
-      await matchingRow.waitFor();
+      // Email can take a while to be received
+      await matchingRow.waitFor({ timeout: 3 * 60 * 1000 });
 
       const emailHeader = await this.createEmailHeaderFromRow(matchingRow, emailAddress);
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

- Refactor EmailService#generateEmailAddress to accept a username
- Add EmailService#generateUsername

## Context for reviewers

Wanted to be able to control the username in tests to generate admin usernames

## Testing

see https://github.com/navapbc/pfml-starter-kit-app/pull/275