### PR TITLE
Fix ThrottlingError when running migrations

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -161,7 +161,7 @@ while true; do
     echo "Timing out task ${ecs_task_id} waiting for logs"
     exit 1
   fi
-  is_log_stream_created=$(aws logs describe-log-streams --no-cli-pager --log-group-name "${log_group}" --query "length(logStreams[?logStreamName==\`${log_stream}\`])")
+  is_log_stream_created=$(aws logs describe-log-streams --no-cli-pager --log-group-name "${log_group}" --log-stream-name-prefix "${log_stream}" --query "length(logStreams)")
   if [ "${is_log_stream_created}" == "1" ]; then
     break
   fi


### PR DESCRIPTION
## Ticket

N/A - No Ticket

## Changes

* Fix ThrottlingError when running migrations

## Context for reviewers

We've been getting a ThrottlingError when running migrations a few times
(see [1], [2], [3]).

It's because the `--query` argument is evaluated client-side after
receiving the full list from the server, and therefore the
`describe-log-streams` call is paginating through all 174 pages of our
8300+ log streams just to select the single one we're looking for.
Github Actions' internet connection seems to be fast enough to hit the
[25 requests/second rate limit][4].

Let's use the `--log-stream-name-prefix` option instead to filter it
server-side. We can still use a (simpler) `--query` to count the
results client-side.

[1]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/13775537056/job/38524000928
[2]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/13730036473/job/38405238446
[3]: https://github.com/DSACMS/iv-cbv-payroll/actions/runs/13727774147/job/38398210761
[4]: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html


## Testing

Tested in https://github.com/DSACMS/iv-cbv-payroll.
