### PR TITLE
Ignore HTTPS errors by default on e2e tests

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -26,6 +26,12 @@ export default defineConfig({
     // Base URL to use in actions like `await page.goto('/')`.
     baseURL: process.env.BASE_URL,
 
+    // Pull request environments don't have HTTPS certificates
+    ignoreHTTPSErrors: true,
+
+    // Email service provider to use. Options are "MessageChecker" or "Mailinator". Defaults to "MessageChecker"
+    // emailServiceType: "Mailinator",
+
     // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
     trace: 'on-first-retry',
     screenshot: 'on',

--- a/e2e/{{app_name}}/playwright.config.js.jinja
+++ b/e2e/{{app_name}}/playwright.config.js.jinja
@@ -6,7 +6,6 @@ export default defineConfig(
   deepMerge(baseConfig, {
     use: {
       baseURL: baseConfig.use.baseURL || 'localhost:{{ app_local_port }}',
-      // emailServiceType: "Mailinator", // Options: ["MessageChecker", "Mailinator"]. Default: "MessageChecker"
     },
   })
 );


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

- Add ignoreHTTPSErrors to e2e base config
- Remove ignoreHTTPSErrors from e2e app config

## Context for reviewers

This commit https://github.com/navapbc/template-infra/commit/a79e0a595fb64f5500a704d44fd305d598816054 fixed a bug but introduced another one. In particular, e2e tests will always fail on a PR environment if HTTPS is enabled. This change tells e2e tests to ignore HTTPS certificate errors. In the future we could only ignore on PR environments.

## Testing

e2e tests on CI should now pass