### PR TITLE
Add style guide for GitHub Actions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,12 +31,15 @@ jobs:
   get-commit-hash:
     name: Get commit hash
     runs-on: ubuntu-latest
+
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+
       - name: Get commit hash
         id: get-commit-hash
         run: |
@@ -44,6 +47,7 @@ jobs:
           COMMIT_HASH=$(git rev-parse HEAD)
           echo "Commit hash: $COMMIT_HASH"
           echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-{{app_name}}.yml.jinja
+++ b/.github/workflows/cd-{{app_name}}.yml.jinja
@@ -46,7 +46,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     uses: ./.github/workflows/deploy.yml
     with:
       app_name: "{{ app_name }}"

--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -19,12 +19,15 @@ jobs:
   caller-identity:
     name: Check caller identity
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.role_to_assume }}
+
       - run: aws sts get-caller-identity

--- a/.github/workflows/check-infra-deploy-status.yml
+++ b/.github/workflows/check-infra-deploy-status.yml
@@ -14,16 +14,20 @@ jobs:
   collect-configs:
     name: Collect configs
     runs-on: ubuntu-latest
+
     outputs:
       root_module_configs: ${{ steps.collect-infra-deploy-status-check-configs.outputs.root_module_configs }}
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Collect root module configurations
         id: collect-infra-deploy-status-check-configs
         run: |
           root_module_configs="$(./bin/infra-deploy-status-check-configs)"
           echo "${root_module_configs}"
           echo "root_module_configs=${root_module_configs}" >> "$GITHUB_OUTPUT"
+
   check:
     name: ${{ matrix.root_module_subdir }} ${{ matrix.backend_config_name }}
     runs-on: ubuntu-latest
@@ -69,8 +73,9 @@ jobs:
           echo "::endgroup::"
         env:
           TF_IN_AUTOMATION: "true"
+
   notify:
-    name: Notify
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     needs: check
     if: failure()
     uses: ./.github/workflows/send-system-notification.yml

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       # This is the GitHub Actions-friendly port of the linter used in the Makefile.
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
         with:

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -20,50 +20,68 @@ jobs:
     # This job configuration is largely copied from https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
+
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color
         shell: bash
+
   lint-scripts:
     name: Lint scripts
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Shellcheck
         run: make infra-lint-scripts
+
   check-terraform-format:
     name: Check Terraform format
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
+
       - name: Run infra-lint-terraform
         run: |
           echo "If this fails, run 'make infra-format'"
           make infra-lint-terraform
+
   validate-terraform:
     name: Validate Terraform modules
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
+
       - name: Validate
         run: make infra-validate-modules
+
   check-compliance-with-checkov:
     name: Check compliance with checkov
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
       - name: Run Checkov check
         # Pin to specific checkov version rather than running from checkov@master
         # since checkov frequently adds new checks that can cause CI checks to fail unpredictably.
@@ -75,6 +93,7 @@ jobs:
           directory: infra
           framework: terraform
           quiet: true # only displays failed checks
+
   check-compliance-with-tfsec:
     name: Check compliance with tfsec
     runs-on: ubuntu-latest
@@ -85,6 +104,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Run tfsec check
         uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
         with:

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -24,11 +24,12 @@ concurrency: database-migrations-${{ inputs.app_name }}-${{ inputs.environment }
 
 jobs:
   build-and-publish:
-    name: Build
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     uses: ./.github/workflows/build-and-publish.yml
     with:
       app_name: ${{ inputs.app_name }}
       ref: ${{ inputs.version }}
+
   run-migrations:
     name: Run migrations
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,19 +26,22 @@ jobs:
   # Don't need to call the build-and-publish workflow since the database-migrations
   # workflow already calls it
   database-migrations:
-    name: Database migrations
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     uses: ./.github/workflows/database-migrations.yml
     with:
       app_name: ${{ inputs.app_name }}
       environment: ${{ inputs.environment }}
       version: ${{ inputs.version }}
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [database-migrations]
+
     permissions:
       contents: read
       id-token: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/scan-orphaned-pr-environments.yml
+++ b/.github/workflows/scan-orphaned-pr-environments.yml
@@ -11,10 +11,13 @@ jobs:
   get-app-names:
     name: Get app names
     runs-on: ubuntu-latest
+
     outputs:
       app_names: ${{ steps.get-app-names.outputs.app_names }}
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Get app names
         id: get-app-names
         run: |
@@ -25,6 +28,7 @@ jobs:
           echo "App names retrieved: ${app_names}"
           echo "app_names=${app_names}" >> "$GITHUB_OUTPUT"
         shell: bash
+
   scan:
     name: Scan
     runs-on: ubuntu-latest
@@ -60,7 +64,7 @@ jobs:
           TF_IN_AUTOMATION: "true"
 
   notify:
-    name: Notify
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     needs: scan
     if: failure()
     uses: ./.github/workflows/send-system-notification.yml

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -13,6 +13,7 @@ jobs:
   deploy:
     name: Deploy to ${{ matrix.project_repo }}
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +22,7 @@ jobs:
           - navapbc/platform-test-flask
           - navapbc/platform-test-nextjs
           - navapbc/pfml-starter-kit-app
+
     steps:
       - name: Checkout project repo
         uses: actions/checkout@v4

--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -23,10 +23,13 @@ jobs:
   lint:
     name: Lint template scripts
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Shellcheck
         run: make -f template-only.mak lint-template-scripts
+
   test:
     name: Infra Tests
     runs-on: ubuntu-latest

--- a/docs/infra/style-guide.md
+++ b/docs/infra/style-guide.md
@@ -12,6 +12,7 @@
       - [.gitignore](#gitignore)
       - [Integration and unit testing](#integration-and-unit-testing)
       - [Policy](#policy)
+  - [GitHub Actions style](#github-actions-style)
   - [Shell script style](#shell-script-style)
 
 ## Terraform code style
@@ -53,6 +54,43 @@ Here are some exceptions (and additions) to Hashicorp's Terraform style guide.
 #### Policy
 
 - For policy enforcement and compliance checks, [Tfsec](https://github.com/aquasecurity/tfsec) is used instead of [Terraform's policy enforcement framework](https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement)
+
+## GitHub Actions style
+
+- Use short job names with at most 3 words to improve readability within the GitHub UI. Long job names get cut off with an ellipsis (…).
+- Use a single whitespace character for job names when calling reusable workflows. This is because in pull requests and in the workflow visualization, GitHub shows the job name as `<job name in calling workflow> / <job name in reusable workflow>` and the calling workflow job name is usually redundant. For example:
+
+    ```yaml
+    build-and-publish:
+      name: " "
+      uses: ./.github/workflows/build-and-publish.yml
+    ```
+
+- Separate jobs with a blank line to improve scannability.
+- Separate steps with a blank line to improve scannability. For example:
+
+    ```yaml
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+    ```
+
+- Separate job attributes that have nested attributes (i.e. object attributes) with a blank line to improve scannability. For example:
+
+    ```yaml
+    e2e:
+      name: E2E tests
+      runs-on: ubuntu-latest
+
+      strategy:
+        matrix:
+          shard: [1, 2, 3]
+
+      steps:
+    ```
 
 ## Shell script style
 

--- a/docs/infra/style-guide.md
+++ b/docs/infra/style-guide.md
@@ -58,6 +58,7 @@ Here are some exceptions (and additions) to Hashicorp's Terraform style guide.
 ## GitHub Actions style
 
 - Use short job names with at most 3 words to improve readability within the GitHub UI. Long job names get cut off with an ellipsis (…).
+- Use imperative phrases for step names. Examples: "Build and publish", "Run migrations", "Set up Terraform".
 - Use a single whitespace character for job names when calling reusable workflows. This is because in pull requests and in the workflow visualization, GitHub shows the job name as `<job name in calling workflow> / <job name in reusable workflow>` and the calling workflow job name is usually redundant. For example:
 
     ```yaml
@@ -78,7 +79,7 @@ Here are some exceptions (and additions) to Hashicorp's Terraform style guide.
         uses: actions/setup-node@v4
     ```
 
-- Separate job attributes that have nested attributes (i.e. object attributes) with a blank line to improve scannability. For example:
+- Separate job attributes that have nested attributes (i.e. object attributes) with a blank line to improve scannability except for the `with` clause when calling reusable workflows. For example:
 
     ```yaml
     e2e:
@@ -90,6 +91,16 @@ Here are some exceptions (and additions) to Hashicorp's Terraform style guide.
           shard: [1, 2, 3]
 
       steps:
+    ```
+
+    Exception: Do not include whitespace when calling reusable workflows. For example:
+
+    ```yaml
+    build-and-publish:
+      name: " "
+      uses: ./.github/workflows/build-and-publish.yml
+      with:
+        app_name: app
     ```
 
 ## Shell script style


### PR DESCRIPTION
## Ticket

N/A

## Changes

- Add style guide for GitHub Actions workflows
- Update workflows to follow style guide

## Context for reviewers

I couldn't find a good style guide on the internet so decided to write my own.

## Testing

Didn't really do testing, (I'm assuming the changes I'm making are safe)

To demonstrate the change regarding replacing calling workflow job names with whitespace:

### Before
Before, long job names, lots of redundancy, and extra prefixes that reveal more about the implementation details rather than being useful e.g. "Deploy / Database Migrations / Build / Build and Publish", "Deploy / Deploy":
<img width="1684" alt="image" src="https://github.com/user-attachments/assets/0d2415e5-fdaf-4723-be10-6fecd9000485" />

### After
After, some awkwardness with "/ / " prefixes but otherwise much cleaner job names:
<img width="1877" alt="image" src="https://github.com/user-attachments/assets/17e3c65e-dd59-42c4-9dc9-09ec52dc5b01" />

Also, for checks in pull requests, without replacing job names with "" the job names would be so long that you can't actually see the job being run, you can only see the prefixes which will all be the same:
<img width="942" alt="image" src="https://github.com/user-attachments/assets/4729a5ee-756e-4992-86e1-eda9f79e7105" />
