### PR TITLE
Run e2e tests at end of deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
       contents: read
       id-token: write
 
+    outputs:
+      service_endpoint: ${{ steps.deploy-release.outputs.service_endpoint }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -55,4 +58,17 @@ jobs:
           environment: ${{ inputs.environment }}
 
       - name: Deploy release
-        run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ needs.database-migrations.outputs.commit_hash }}
+        id: deploy-release
+        run: |
+          make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ needs.database-migrations.outputs.commit_hash }}
+          service_endpoint=$(terraform -chdir="infra/${{ inputs.app_name }}/service" output -raw service_endpoint)
+          echo "service_endpoint=${service_endpoint}"
+          echo "service_endpoint=${service_endpoint}" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    needs: [deploy]
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      app_name: ${{ inputs.app_name }}
+      service_endpoint: ${{ needs.deploy.outputs.service_endpoint }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   e2e:
-    name: Run E2E tests (${{ matrix.shard }} of ${{ matrix.total_shards }})
+    name: E2E tests (${{ matrix.shard }} of ${{ matrix.total_shards }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -62,7 +62,7 @@ jobs:
           retention-days: 1
 
   create-report:
-    name: Create merged test report
+    name: E2E test report
     if: ${{ !cancelled() }}
     needs: e2e
     runs-on: ubuntu-latest

--- a/infra/modules/service/dns.tf
+++ b/infra/modules/service/dns.tf
@@ -1,8 +1,12 @@
+locals {
+  domain_name = !var.is_temporary && var.domain_name != null ? var.domain_name : null
+}
+
 resource "aws_route53_record" "app" {
   # Don't create DNS record for temporary environments (e.g. ones spun up by CI/)
-  count = !var.is_temporary && var.domain_name != null && var.hosted_zone_id != null ? 1 : 0
+  count = local.domain_name != null && var.hosted_zone_id != null ? 1 : 0
 
-  name    = var.domain_name
+  name    = local.domain_name
   zone_id = var.hosted_zone_id
   type    = "A"
   alias {

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -22,5 +22,5 @@ output "migrator_role_arn" {
 
 output "public_endpoint" {
   description = "The public endpoint for the service."
-  value       = "${var.certificate_arn != null ? "https" : "http"}://${aws_lb.alb.dns_name}"
+  value       = "${var.certificate_arn != null ? "https" : "http"}://${local.domain_name != null ? local.domain_name : aws_lb.alb.dns_name}"
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/729

## Changes

- Run e2e tests at end of deploy.yml
- Update modules/service service_endpoint output to use custom domain if set
- Tweak job names to improve readability of job workflows
  - Rename job names to " " when calling callable workflows
  - Shorten job names to be within 3 words
- Prefix individual shard's blob report artifact names with e2e-test

## Context for reviewers

Run e2e tests at the end of every deploy

## Testing

see https://github.com/navapbc/platform-test/pull/187