### PR TITLE
Check for stale infra service test environments

### DIFF
--- a/.github/workflows/scan-orphaned-environments.yml
+++ b/.github/workflows/scan-orphaned-environments.yml
@@ -1,5 +1,7 @@
-# This workflow scans for orphaned PR environments
-name: Scan orphaned PR environments
+# This workflow scans for temporary environments that were not properly cleaned up
+# This can happen if the PR environment destroy workflow failed or didn't run
+# or if the temporary environments created by the infra service tests were not cleaned up
+name: Scan orphaned environments
 
 on:
   workflow_dispatch:
@@ -38,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         app_name: ${{ fromJson(needs.get-app-names.outputs.app_names) }}
+        scan_script: [orphaned-pr-environments, stale-test-environments]
 
     permissions:
       contents: read
@@ -58,7 +61,7 @@ jobs:
 
       - name: List PR workspaces
         run: |
-          ./bin/orphaned-pr-environments ${{ matrix.app_name }}
+          ./bin/${{ matrix.scan_script }} ${{ matrix.app_name }}
         env:
           GH_TOKEN: ${{ github.token }}
           TF_IN_AUTOMATION: "true"

--- a/bin/stale-test-environments
+++ b/bin/stale-test-environments
@@ -1,0 +1,63 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# This script checks for orphaned environments created by infra service tests
+# by checking if the environment is older than a certain threshold.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+source bin/util.sh
+
+GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-/dev/null}
+
+# 24 hours in seconds
+MAX_ENVIRONMENT_AGE_MILLIS=86400
+
+app_name="$1"
+
+echo "::group::Initialize Terraform"
+echo terraform -chdir="infra/${app_name}/service" init -input=false -reconfigure -backend-config="dev.s3.tfbackend"
+terraform -chdir="infra/${app_name}/service" init -input=false -reconfigure -backend-config="dev.s3.tfbackend"
+echo "::endgroup::"
+
+echo "::group::List test IDs of test environments"
+echo terraform -chdir="infra/${app_name}/service" workspace list
+workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
+# grep will exit with code `1` if there's no match, so ignore that for when
+# there are no PR workspaces for the application
+test_ids="$(echo "${workspaces}" | { grep -o 't-[A-Za-z0-9]\+' || test $? = 1; } | sed 's/t-//')"
+echo "Test IDs"
+echo "${test_ids}"
+echo "::endgroup::"
+
+echo "::group::Check age of each test environment"
+stale_tests=()
+for test_id in $test_ids; do
+  # Base 62 decode the test ID to get the timestamp
+  test_timestamp="$(base62_decode "${test_id}")"
+  current_timestamp="$(date +%s)"
+  age="$((current_timestamp - test_timestamp))"
+
+  if [ "${age}" -gt "${MAX_ENVIRONMENT_AGE_MILLIS}" ]; then
+    echo "stale ID:   ${test_id}   age: $((age / 3600)) hours   started: $(date -r "${test_timestamp}")"
+    echo "stale ID:   ${test_id}   age: $((age / 3600)) hours   started: $(date -r "${test_timestamp}")" >> "${GITHUB_STEP_SUMMARY}"
+    stale_tests+=("${test_id}")
+  fi
+
+  # If age is less than 0, the test ID is invalid
+  if [ "${age}" -lt 0 ]; then
+    echo "invalid ID: ${test_id}"
+    echo "invalid ID: ${test_id}" >> "${GITHUB_STEP_SUMMARY}"
+    stale_tests+=("${test_id}")
+  fi
+done
+echo "::endgroup::"
+
+# if stale_tests is not empty exit with 1 otherwise exit with 0
+if [ ${#stale_tests[@]} -gt 0 ]; then
+  echo "Found stale test environments for the following test IDs: ${stale_tests[*]}"
+  echo "Found stale test environments for the following test IDs: ${stale_tests[*]}" >> "${GITHUB_STEP_SUMMARY}"
+  exit 1
+fi
+
+echo "No stale test environments"
+echo "No stale test environments" >> "${GITHUB_STEP_SUMMARY}"

--- a/bin/util.sh
+++ b/bin/util.sh
@@ -7,3 +7,19 @@
 function get_app_names() {
   find "infra" -maxdepth 1 -type d -not -name "infra" -not -name "accounts" -not -name "modules" -not -name "networks" -not -name "project-config" -not -name "test" -exec basename {} \;
 }
+
+# Base 62 decode a string.
+# Returns: String as base 10 number.
+function base62_decode() {
+  local digits="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  local s=$1
+  local n=0
+  
+  for ((i=0;i<${#s};i++)); do
+    c=${s:$i:1}
+    pos=${digits%%"$c"*}
+    n=$((n*62 + ${#pos}))
+  done
+  
+  echo $n
+}


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/787

## Changes

- Add bin/stale-test-environments script
- Modify scan-orphaned-pr-environments workflow to scan for stale test environments too and rename the workflow

## Context for reviewers

Builds on the work in https://github.com/navapbc/template-infra/pull/885 to determine if a test environment is stale

## Testing

 See https://github.com/navapbc/platform-test/pull/190