### PR TITLE
Add e2e typescript

### DIFF
--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Check formatting
         run: make e2e-format-check-native
+
+      - name: Check typing
+        run: make e2e-type-check-native

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ __check_defined = \
 	e2e-test \
 	e2e-test-native \
 	e2e-test-native-ui \
+	e2e-type-check \
+	e2e-type-check-native \
 	help \
 	infra-check-app-database-roles \
 	infra-check-compliance-checkov \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ __check_defined = \
 	infra-lint-scripts \
 	infra-lint-terraform \
 	infra-lint-workflows \
-	infra-module-database-role-manager \
+	infra-module-database-role-manager-archive \
 	infra-set-up-account \
 	infra-test-service \
 	infra-update-app-build-repository \

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,12 @@ e2e-test-native-ui: ## Run end-to-end tests natively in UI mode
 	@echo "Running e2e UI tests natively with APP_NAME=$(APP_NAME), BASE_URL=$(BASE_URL)"
 	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npm run test:ui -- $(E2E_ARGS)
 
+e2e-type-check: ## Run TypeScript type checking in Docker
+	docker run --rm -v $(CURDIR)/e2e:/e2e $(E2E_IMAGE_NAME) npm run type-check -- $(TYPE_CHECK_ARGS)
+
+e2e-type-check-native: ## Run TypeScript type checking natively
+	cd e2e && npm run type-check -- $(TYPE_CHECK_ARGS)
+
 ###########
 ## Infra ##
 ###########

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -11,7 +11,8 @@
         "@axe-core/playwright": "^4.10.1",
         "@playwright/test": "^1.49.0",
         "@types/node": "^22.10.1",
-        "prettier": "^3.5.3"
+        "prettier": "^3.5.3",
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -120,6 +121,19 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,12 +7,14 @@
     "merge-reports": "npx playwright merge-reports --reporter html blob-report",
     "show-report": "npx playwright show-report",
     "test": "./run-e2e-test",
-    "test:ui": "./run-e2e-test --ui"
+    "test:ui": "./run-e2e-test --ui",
+    "type-check": "tsc --noEmit"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
     "@playwright/test": "^1.49.0",
     "@types/node": "^22.10.1",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.2"
   }
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    "baseUrl": ".",
+    "target": "es2016",
+    "module": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "*.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -2,12 +2,8 @@ import { Page, expect, test } from '@playwright/test';
 
 import AxeBuilder from '@axe-core/playwright';
 
-type PlaywrightTestParams = {
-  page: Page;
-};
-
 test.describe('Generic Webpage Tests', () => {
-  test('should load the webpage successfully', async ({ page }: PlaywrightTestParams) => {
+  test('should load the webpage successfully', async ({ page }) => {
     const response = await page.goto('/');
     if (!response) {
       throw new Error('Failed to navigate');
@@ -17,7 +13,7 @@ test.describe('Generic Webpage Tests', () => {
     await expect(response.status()).toBe(200);
   });
 
-  test('should take a screenshot of the webpage', async ({ page }: PlaywrightTestParams) => {
+  test('should take a screenshot of the webpage', async ({ page }) => {
     await page.goto('/');
     await page.screenshot({ path: 'example-screenshot.png', fullPage: true });
   });

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -5,12 +5,8 @@ import AxeBuilder from '@axe-core/playwright';
 test.describe('Generic Webpage Tests', () => {
   test('should load the webpage successfully', async ({ page }) => {
     const response = await page.goto('/');
-    if (!response) {
-      throw new Error('Failed to navigate');
-    }
-
     const title = await page.title();
-    await expect(response.status()).toBe(200);
+    expect(response!.status()).toBe(200);
   });
 
   test('should take a screenshot of the webpage', async ({ page }) => {

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -1,15 +1,23 @@
-const { test, expect } = require('@playwright/test');
+import { Page, expect, test } from '@playwright/test';
 
 import AxeBuilder from '@axe-core/playwright';
 
+type PlaywrightTestParams = {
+    page: Page;
+  };
+
 test.describe('Generic Webpage Tests', () => {
-  test('should load the webpage successfully', async ({ page }) => {
+  test('should load the webpage successfully', async ({ page }: PlaywrightTestParams) => {
     const response = await page.goto('/');
+    if (!response) {
+        throw new Error('Failed to navigate');
+     }
+
     const title = await page.title();
     await expect(response.status()).toBe(200);
   });
 
-  test('should take a screenshot of the webpage', async ({ page }) => {
+  test('should take a screenshot of the webpage', async ({ page }: PlaywrightTestParams) => {
     await page.goto('/');
     await page.screenshot({ path: 'example-screenshot.png', fullPage: true });
   });

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -3,15 +3,15 @@ import { Page, expect, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
 type PlaywrightTestParams = {
-    page: Page;
-  };
+  page: Page;
+};
 
 test.describe('Generic Webpage Tests', () => {
   test('should load the webpage successfully', async ({ page }: PlaywrightTestParams) => {
     const response = await page.goto('/');
     if (!response) {
-        throw new Error('Failed to navigate');
-     }
+      throw new Error('Failed to navigate');
+    }
 
     const title = await page.title();
     await expect(response.status()).toBe(200);


### PR DESCRIPTION
## Ticket

Resolves #813 

## Changes

- Add config to run typescript from Makefile
- Add checks on PR / CI
- Update `index.spec.ts` to pass type check

## Context
Original PR:
https://github.com/navapbc/pfml-starter-kit-app/pull/276

### Diff comparison before updating `e2e/{{app_name}}/tests/index.spec.ts` 

Diff on `pfml-starter-kit-app` PR: 
![image](https://github.com/user-attachments/assets/4aa21e94-ff6d-43c9-b9c5-9824d8565e60)

Diff on this PR:
![image](https://github.com/user-attachments/assets/2fc65d6c-d660-4a34-a021-e1b18598f9a3)

* After editing `e2e/{{app_name}}/tests/index.spec.ts`  - the line diffs obviously won't line up
    - also added the type check make targets to the makefile `.PHONY` list

