### PR TITLE
Fix role manager archive Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,8 +211,8 @@ infra-update-app-database: ## Create or update $APP_NAME's database module for $
 	terraform -chdir="infra/$(APP_NAME)/database" apply -var="environment_name=$(ENVIRONMENT)"
 
 infra-module-database-role-manager-archive: ## Build/rebuild role manager code package for Lambda deploys
-	pip3 install -r infra/modules/database/role_manager/requirements.txt -t infra/modules/database/role_manager/vendor --upgrade
-	zip -r infra/modules/database/role_manager.zip infra/modules/database/role_manager
+	pip3 install -r infra/modules/database/resources/role_manager/requirements.txt -t infra/modules/database/role_manager/vendor --upgrade
+	zip -r infra/modules/database/resources/role_manager.zip infra/modules/database/role_manager
 
 infra-update-app-database-roles: ## Create or update database roles and schemas for $APP_NAME's database in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ infra-update-app-database: ## Create or update $APP_NAME's database module for $
 	terraform -chdir="infra/$(APP_NAME)/database" apply -var="environment_name=$(ENVIRONMENT)"
 
 infra-module-database-role-manager-archive: ## Build/rebuild role manager code package for Lambda deploys
+	rm infra/modules/database/resources/role_manager.zip
 	pip3 install -r infra/modules/database/resources/role_manager/requirements.txt -t infra/modules/database/resources/role_manager/vendor --upgrade
 	zip -r infra/modules/database/resources/role_manager.zip infra/modules/database/resources/role_manager
 

--- a/Makefile
+++ b/Makefile
@@ -211,8 +211,8 @@ infra-update-app-database: ## Create or update $APP_NAME's database module for $
 	terraform -chdir="infra/$(APP_NAME)/database" apply -var="environment_name=$(ENVIRONMENT)"
 
 infra-module-database-role-manager-archive: ## Build/rebuild role manager code package for Lambda deploys
-	pip3 install -r infra/modules/database/resources/role_manager/requirements.txt -t infra/modules/database/role_manager/vendor --upgrade
-	zip -r infra/modules/database/resources/role_manager.zip infra/modules/database/role_manager
+	pip3 install -r infra/modules/database/resources/role_manager/requirements.txt -t infra/modules/database/resources/role_manager/vendor --upgrade
+	zip -r infra/modules/database/resources/role_manager.zip infra/modules/database/resources/role_manager
 
 infra-update-app-database-roles: ## Create or update database roles and schemas for $APP_NAME's database in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/Makefile
+++ b/Makefile
@@ -211,9 +211,9 @@ infra-update-app-database: ## Create or update $APP_NAME's database module for $
 	terraform -chdir="infra/$(APP_NAME)/database" apply -var="environment_name=$(ENVIRONMENT)"
 
 infra-module-database-role-manager-archive: ## Build/rebuild role manager code package for Lambda deploys
-	rm infra/modules/database/resources/role_manager.zip
+	rm -f infra/modules/database/resources/role_manager.zip
 	pip3 install -r infra/modules/database/resources/role_manager/requirements.txt -t infra/modules/database/resources/role_manager/vendor --upgrade
-	zip -r infra/modules/database/resources/role_manager.zip infra/modules/database/resources/role_manager
+	cd infra/modules/database/resources/role_manager/ && zip -r ../role_manager.zip *
 
 infra-update-app-database-roles: ## Create or update database roles and schemas for $APP_NAME's database in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)


### PR DESCRIPTION
## Changes

- Fix path for building role manager archive to include /resources subdirectory
- Remove role manager archive before building (since zip just adds to the archive so nothing ever gets removed)
- CD into the role_manager directory and run zip * to avoid recreating full infra/modules/database path in zip archive

## Context

Noticed this while working on resetting the schema for app-rails in platform-test repo

## Testing

Before:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/fcb574aa-9960-474b-8950-45d56691b071" />

After:
<img width="310" alt="image" src="https://github.com/user-attachments/assets/cadc0c36-7b52-4ebd-8d66-1c68906a1fbb" />
