### PR TITLE
Separate e2e format and typecheck jobs

### DIFF
--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   format:

--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -11,9 +11,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  format:
-    name: Format
+  static-checks:
+    name: ${{ matrix.check.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        check:
+          - name: Format
+            command: make e2e-format-check-native
+          - name: Typecheck
+            command: make e2e-type-check-native
 
     steps:
       - name: Checkout code
@@ -35,32 +42,5 @@ jobs:
         if: steps.cache-node.outputs.cache-hit != 'true'
         run: make e2e-setup-ci
 
-      - name: Check formatting
-        run: make e2e-format-check-native
-
-  typecheck:
-    name: Typecheck
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Cache Node.js dependencies
-        id: cache-node
-        uses: actions/cache@v4
-        with:
-          path: e2e/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-node.outputs.cache-hit != 'true'
-        run: make e2e-setup-ci
-
-      - name: Check typing
-        run: make e2e-type-check-native
+      - name: ${{ matrix.check.name }}
+        run: ${{ matrix.check.command }}

--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -15,6 +15,7 @@ jobs:
     name: ${{ matrix.check.name }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         check:
           - name: Format

--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 jobs:
-  format-check:
-    name: Format check
+  format:
+    name: Format
     runs-on: ubuntu-latest
 
     steps:
@@ -36,6 +36,30 @@ jobs:
 
       - name: Check formatting
         run: make e2e-format-check-native
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Cache Node.js dependencies
+        id: cache-node
+        uses: actions/cache@v4
+        with:
+          path: e2e/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node.outputs.cache-hit != 'true'
+        run: make e2e-setup-ci
 
       - name: Check typing
         run: make e2e-type-check-native

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -6,7 +6,6 @@ test.describe('Generic Webpage Tests', () => {
   test('should load the webpage successfully', async ({ page }) => {
     const response = await page.goto('/');
     const title = await page.title();
-    
     expect(response!.status()).toBe(200);
   });
 

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -6,6 +6,7 @@ test.describe('Generic Webpage Tests', () => {
   test('should load the webpage successfully', async ({ page }) => {
     const response = await page.goto('/');
     const title = await page.title();
+    
     expect(response!.status()).toBe(200);
   });
 

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -6,7 +6,7 @@ test.describe('Generic Webpage Tests', () => {
   test('should load the webpage successfully', async ({ page }) => {
     const response = await page.goto('/');
     const title = await page.title();
-    
+
     expect(response!.status()).toBe(200);
   });
 

--- a/e2e/{{app_name}}/tests/index.spec.ts
+++ b/e2e/{{app_name}}/tests/index.spec.ts
@@ -6,7 +6,6 @@ test.describe('Generic Webpage Tests', () => {
   test('should load the webpage successfully', async ({ page }) => {
     const response = await page.goto('/');
     const title = await page.title();
-
     expect(response!.status()).toBe(200);
   });
 


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/813

## Changes

- separate e2e format and typecheck jobs in github actions with matrix strategy
- add `fail-fast:false` to allow all e2e static checks to run regardless of one failure
- add `workflow_dispatch` to manually trigger static checks [to be tested post merge]

## Context

The e2e format and typecheck calls were in the same GHA job - this PR just separates them to separate jobs so they can run in parallel. 
