### PR TITLE
Add deploy failure system notification

### DIFF
--- a/.github/workflows/cd-{{app_name}}.yml.jinja
+++ b/.github/workflows/cd-{{app_name}}.yml.jinja
@@ -52,3 +52,4 @@ jobs:
       app_name: "{{ app_name }}"
       environment: ${{'{{'}} inputs.environment || 'dev' {{'}}'}}
       version: ${{'{{'}} inputs.version || 'main' {{'}}'}}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,8 +71,19 @@ jobs:
     # By default, don't run e2e tests on production to avoid generating
     # junk data that may interfere with production metrics and business operations
     if: inputs.environment != 'prod'
-    needs: [deploy]
+    needs: deploy
     uses: ./.github/workflows/e2e-tests.yml
     with:
       app_name: ${{ inputs.app_name }}
       service_endpoint: ${{ needs.deploy.outputs.service_endpoint }}
+
+  notify:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    needs: e2e
+    if: failure()
+    uses: ./.github/workflows/send-system-notification.yml
+    with:
+      channel: "workflow-failures"
+      message: "❌ [Failed deploying ${{ inputs.version }} to ${{ inputs.app_name }} ${{ inputs.environment }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+    secrets: inherit
+    


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

see title

## Context for reviewers

Seems useful to send a slack notification when a deploy fails rather than relying on the email which only goes to the engineer that merged a PR

## Testing

See https://github.com/navapbc/platform-test/pull/195