### PR TITLE
Streamline vulnerability scan workflow to build docker image once

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -1,8 +1,9 @@
-# GitHub Actions CI workflow that runs vulnerability scans on the application's Docker image
-# to ensure images built are secure before they are deployed.
+# GitHub Actions CI workflow that runs vulnerability scans on the application's 
+# Dockerfile or Docker image to ensure images built are secure before they are deployed.
 
-# NOTE: The workflow isn't able to pass the docker image between jobs, so each builds the image.
-#       A future PR will pass the image between the scans to reduce overhead and increase speed
+# The docker image is built once and cached, with that image used by the jobs that 
+# require access to the image. 
+
 name: Vulnerability Scans
 
 on:
@@ -41,8 +42,64 @@ jobs:
         if: always() # Runs even if there is a failure
         run: cat hadolint-results.txt >> "$GITHUB_STEP_SUMMARY"
 
+  build-and-cache:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.shared-output.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          driver: docker
+
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ inputs.app_name }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-buildx-
+
+      - name: Ensure Buildx cache exists
+        run: |
+          mkdir -p /tmp/.buildx-cache
+
+      - name: Set shared outputs
+        id: shared-output
+        run: |
+          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
+          IMAGE_TAG=$(make release-image-tag)
+          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build and tag Docker image for scanning
+        # If there's an exact match in cache, skip build entirely
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          make release-build \
+          APP_NAME=${{ inputs.app_name }} \
+          OPTIONAL_BUILD_FLAGS=" \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          --cache-to=type=local,dest=/tmp/.buildx-cache"
+
+      - name: Save Docker image
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          docker save ${{ steps.shared-output.outputs.image }} > /tmp/docker-image.tar
+
+      - name: Cache Docker image
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+
   trivy-scan:
     runs-on: ubuntu-latest
+    needs: build-and-cache
 
     steps:
       - uses: actions/checkout@v4
@@ -59,19 +116,23 @@ jobs:
         with:
           files: ${{ inputs.app_name }}/trivy-secret.yaml trivy-secret.yaml
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-docker-image-
+
+      - name: Load cached Docker image
         run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          docker load < /tmp/docker-image.tar
 
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: image
-          image-ref: ${{ steps.build-image.outputs.image }}
+          image-ref: ${{ needs.build-and-cache.outputs.image }}
           format: table
           exit-code: 1
           ignore-unfixed: true
@@ -88,6 +149,7 @@ jobs:
 
   anchore-scan:
     runs-on: ubuntu-latest
+    needs: build-and-cache
 
     steps:
       - uses: actions/checkout@v4
@@ -99,18 +161,22 @@ jobs:
             ${{ inputs.app_name }}/.grype.yml
             .grype.yml
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-docker-image-
+
+      - name: Load cached Docker image
         run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          docker load < /tmp/docker-image.tar
 
       - name: Run Anchore vulnerability scan
         uses: anchore/scan-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ needs.build-and-cache.outputs.image }}
           output-format: table
         env:
           GRYPE_CONFIG: ${{ steps.grype-config.outputs.found_file }}
@@ -121,6 +187,7 @@ jobs:
 
   dockle-scan:
     runs-on: ubuntu-latest
+    needs: build-and-cache
 
     steps:
       - uses: actions/checkout@v4
@@ -132,13 +199,17 @@ jobs:
             ${{ inputs.app_name }}/.dockleconfig
             .dockleconfig
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-docker-image-
+
+      - name: Load cached Docker image
         run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          docker load < /tmp/docker-image.tar
 
       # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
       # variable, this will save the variable in this file to env for Dockle
@@ -151,7 +222,7 @@ jobs:
       - name: Run Dockle container linter
         uses: erzz/dockle-action@v1.3.1
         with:
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ needs.build-and-cache.outputs.image }}
           exit-code: "1"
           failure-threshold: WARN
           accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}
@@ -164,3 +235,4 @@ jobs:
             cat dockle-report.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -235,4 +235,3 @@ jobs:
             cat dockle-report.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-


### PR DESCRIPTION
## Ticket

Implements a proposed improvement documented in workflow vulnerability-scans.yml:

>  NOTE: The workflow isn't able to pass the docker image between jobs, so each builds the image.
      A future PR will pass the image between the scans to reduce overhead and increase speed

## Changes

Refactors creation of the app's docker image in the vulnerability-scans.yml workflow:
- new job: build-and-cache: builds the image and puts it in a cache
- updates other jobs to use the cached image, instead of building the image as part of the job

## Context for reviewers

This is taken from the implementation in HHS/simpler-grants-gov: https://github.com/HHS/simpler-grants-gov/blob/6dadc31f8474c386b824654d3ce2bb428bec584f/.github/workflows/vulnerability-scans.yml , which was authored by @daphnegold (thank you!).
Minor adjustment to use ubuntu-latest.

## Testing

https://github.com/navapbc/platform-test/pull/196
