### PR TITLE
⚠️ Add WAF protection to application load balancers

### DIFF
--- a/infra/modules/network/data/main.tf
+++ b/infra/modules/network/data/main.tf
@@ -42,3 +42,9 @@ data "aws_security_groups" "aws_services" {
     values = [data.aws_vpc.network.id]
   }
 }
+
+data "aws_wafv2_web_acl" "network" {
+  name  = module.interface.waf_acl_name
+  scope = "REGIONAL"
+}
+

--- a/infra/modules/network/data/outputs.tf
+++ b/infra/modules/network/data/outputs.tf
@@ -21,3 +21,7 @@ output "private_subnet_ids" {
 output "vpc_id" {
   value = data.aws_vpc.network.id
 }
+
+output "waf_arn" {
+  value = data.aws_wafv2_web_acl.network.arn
+}

--- a/infra/modules/network/interface/outputs.tf
+++ b/infra/modules/network/interface/outputs.tf
@@ -17,3 +17,7 @@ output "private_subnet_tags" {
 output "public_subnet_tags" {
   value = { subnet_type = "public" }
 }
+
+output "waf_acl_name" {
+  value = var.name
+}

--- a/infra/modules/network/resources/waf.tf
+++ b/infra/modules/network/resources/waf.tf
@@ -1,0 +1,74 @@
+resource "aws_wafv2_web_acl" "main" {
+  name        = module.interface.waf_acl_name
+  description = "WAF to protect application load balancers in the ${var.name} network"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.name}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_cloudwatch_log_group" "waf_logs" {
+  # checkov:skip=CKV_AWS_158:The KMS key triggered an operation error
+  name              = "aws-waf-logs-${var.name}"
+  retention_in_days = 30
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "main" {
+  log_destination_configs = [aws_cloudwatch_log_group.waf_logs.arn]
+  resource_arn            = aws_wafv2_web_acl.main.arn
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -51,6 +51,12 @@ variable "enable_command_execution" {
   description = "Whether the service should enable ECS Exec, such as for debugging"
 }
 
+variable "enable_waf" {
+  type        = bool
+  description = "Whether to enable WAF protection for the load balancer"
+  default     = false
+}
+
 variable "extra_environment_variables" {
   type        = map(string)
   description = "Additional environment variables to pass to the service container. Map from environment variable name to the value."

--- a/infra/modules/service/waf.tf
+++ b/infra/modules/service/waf.tf
@@ -1,0 +1,5 @@
+resource "aws_wafv2_web_acl_association" "main" {
+  count        = var.enable_waf ? 1 : 0
+  resource_arn = aws_lb.alb.arn
+  web_acl_arn  = module.network.waf_arn
+}

--- a/infra/{{app_name}}/app-config/main.tf
+++ b/infra/{{app_name}}/app-config/main.tf
@@ -43,6 +43,11 @@ locals {
   # 2. Configures email notifications using AWS SES
   enable_notifications = false
 
+  # Whether or not the application should enable WAF for the load balancer.
+  # If enabled:
+  # 1. Creates an AWS WAF web ACL with AWSManagedRulesCommonRuleSet
+  enable_waf = true
+
   environment_configs = {
     dev     = module.dev_config
     staging = module.staging_config

--- a/infra/{{app_name}}/app-config/outputs.tf
+++ b/infra/{{app_name}}/app-config/outputs.tf
@@ -34,6 +34,10 @@ output "enable_notifications" {
   value = local.enable_notifications
 }
 
+output "enable_waf" {
+  value = local.enable_waf
+}
+
 output "shared_network_name" {
   value = local.shared_network_name
 }

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -70,6 +70,8 @@ module "service" {
   hosted_zone_id  = module.domain.hosted_zone_id
   certificate_arn = module.domain.certificate_arn
 
+  enable_waf = module.app_config.enable_waf
+
   cpu                      = local.service_config.cpu
   memory                   = local.service_config.memory
   desired_instance_count   = local.service_config.desired_instance_count


### PR DESCRIPTION
## Ticket

Resolves #165 #462 

## Changes

This PR adds Web Application Firewall (WAF) protection to the service layer by:

1. Adding a WAF resource to the network module
2. Adding WAF data source to the network data module
3. Adding WAF input to service module
4. Adding enable_waf config option to app-config (default: true)
5. Updating service root module to attach WAF if enabled

The WAF uses the AWS Managed Common Rule Set for baseline protection.

## Migration notes

This PR adds an `enable_waf` configuration to the `app-config` module which defaults to `true`. However, the WAF needs to first be created at the network layer before applying any changes at the service layer, otherwise the service layer will not be able to find the WAF to apply. To do this, apply the network changes by running

```bash
make infra-update-network NETWORK_NAME=<NETWORK_NAME>
```

Alternatively, set `enable_waf` to `false` in `app-config/main.tf`

## Context for reviewers

Paired with Devin AI to implement this

## Testing

see https://github.com/navapbc/platform-test/pull/197