### PR TITLE
Redirect HTTP traffic to HTTPS

### DIFF
--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -119,7 +119,6 @@ resource "aws_lb_listener" "alb_listener_https" {
   }
 }
 
-
 resource "aws_lb_listener_rule" "app_https_forward" {
   count = var.certificate_arn != null ? 1 : 0
 

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -56,7 +56,33 @@ resource "aws_lb_listener" "alb_listener_http" {
   }
 }
 
+resource "aws_lb_listener_rule" "http_to_https_redirect" {
+  count = var.certificate_arn != null ? 1 : 0
+
+  listener_arn = aws_lb_listener.alb_listener_http.arn
+  priority     = 50
+
+  action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+      host        = "#{host}"
+      path        = "/#{path}"
+      query       = "#{query}"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
 resource "aws_lb_listener_rule" "app_http_forward" {
+  count = var.certificate_arn == null ? 1 : 0
+
   listener_arn = aws_lb_listener.alb_listener_http.arn
   priority     = 100
 
@@ -92,6 +118,7 @@ resource "aws_lb_listener" "alb_listener_https" {
     }
   }
 }
+
 
 resource "aws_lb_listener_rule" "app_https_forward" {
   count = var.certificate_arn != null ? 1 : 0


### PR DESCRIPTION
## Ticket

Resolves #880 

## Changes

- Added HTTP to HTTPS redirect rule with priority 50 (lower than the forward rule) when certificate_arn is not null

## Context for reviewers

Paired with Devin AI to implement this

## Testing

see https://github.com/navapbc/platform-test/pull/198