### PR TITLE
Manually manage WAF Logs resource policy

### DIFF
--- a/infra/modules/network/resources/waf.tf
+++ b/infra/modules/network/resources/waf.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_wafv2_web_acl" "main" {
   name        = module.interface.waf_acl_name
   description = "WAF to protect application load balancers in the ${var.name} network"
@@ -68,7 +70,40 @@ resource "aws_cloudwatch_log_group" "waf_logs" {
   retention_in_days = 30
 }
 
-resource "aws_wafv2_web_acl_logging_configuration" "main" {
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
   log_destination_configs = [aws_cloudwatch_log_group.waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.main.arn
+
+  depends_on = [
+    aws_cloudwatch_log_group.waf_logs,
+    aws_cloudwatch_log_resource_policy.waf_logs
+  ]
+}
+
+resource "aws_cloudwatch_log_resource_policy" "waf_logs" {
+  policy_document = data.aws_iam_policy_document.waf_logs.json
+  policy_name     = "webacl-policy-uniq-name"
+}
+
+data "aws_iam_policy_document" "waf_logs" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["${aws_cloudwatch_log_group.waf_logs.arn}:*"]
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      variable = "aws:SourceArn"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [tostring(data.aws_caller_identity.current.account_id)]
+      variable = "aws:SourceAccount"
+    }
+  }
 }


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

This change helps resolve an issue that can happen when using the AWS managed resource policy
```
module.network.aws_wafv2_web_acl_logging_configuration.main: Creating...
╷
│ Error: putting WAFv2 WebACL Logging Configuration (arn:aws:wafv2:us-east-1:775316947779:regional/webacl/dev/6b2d3994-2183-49c7-85ab-528dddf3d102): WAFLogDestinationPermissionIssueException: Unable to deliver logs to the configured destination. You might need to grant log delivery permissions for the destination. If you're using S3 as your log destination, you might have exceeded your bucket limit.
│ 
│   with module.network.aws_wafv2_web_acl_logging_configuration.main,
│   on ../modules/network/resources/waf.tf line 71, in resource "aws_wafv2_web_acl_logging_configuration" "main":
│   71: resource "aws_wafv2_web_acl_logging_configuration" "main" {
│ 
```

## Testing

see https://github.com/navapbc/pfml-starter-kit-app/pull/288