### PR TITLE
Disable WAF by default

### DIFF
--- a/docs/infra/web-application-firewall.md
+++ b/docs/infra/web-application-firewall.md
@@ -21,13 +21,11 @@ There are no specific prerequisites for enabling WAF.
 
 ## 1. Enable WAF in application config
 
-WAF is enabled by default in the template. You can find and modify this setting in your application's `app-config` module (`infra/<APP_NAME>/app-config/main.tf`):
+WAF is disabled by default in the template. You can find and modify this setting in your application's `app-config` module (`infra/<APP_NAME>/app-config/main.tf`):
 
 ```terraform
 enable_waf = true
 ```
-
-Set `enable_waf = false` if you want to disable WAF protection.
 
 ## 2. Deploy the WAF in the network layer
 

--- a/infra/{{app_name}}/app-config/main.tf
+++ b/infra/{{app_name}}/app-config/main.tf
@@ -46,7 +46,7 @@ locals {
   # Whether or not the application should enable WAF for the load balancer.
   # If enabled:
   # 1. Creates an AWS WAF web ACL with AWSManagedRulesCommonRuleSet
-  enable_waf = true
+  enable_waf = false
 
   environment_configs = {
     dev     = module.dev_config


### PR DESCRIPTION
## Ticket

N/A

## Changes

- Set enable_waf to false in app-config/main.tf
- Update instructions to say that WAF is disabled by default

## Context for reviewers

Since WAF can interfere with E2E testing, leave WAF disabled by default for now, and provide instructions for how to enable it. This also makes it more backwards compatible and allows us to have time to gather feedback from projects using it.

## Testing

I didn't test this change