### PR TITLE
⚠️ Update postgres engine version to match what AWS upgraded to

### DIFF
--- a/infra/modules/database/resources/main.tf
+++ b/infra/modules/database/resources/main.tf
@@ -9,7 +9,7 @@ locals {
   # See https://aws.amazon.com/blogs/database/using-iam-authentication-to-connect-with-pgadmin-amazon-aurora-postgresql-or-amazon-rds-for-postgresql/
   db_user_arn_prefix = "arn:aws:rds-db:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_rds_cluster.db.cluster_resource_id}"
 
-  engine_version       = "16.2"
+  engine_version       = "16.6"
   engine_major_version = regex("^\\d+", local.engine_version)
 }
 


### PR DESCRIPTION
## Ticket

Resolves terraform diffs

## Changes

see title

## Context for reviewers

AWS auto upgraded postgres in RDS aurora from 16.2 to 16.6

## Migration notes

This change upgrades Postgres from 16.2 to 16.6. If you do not want to upgrade at this time, revert engine_version back to the original value.

## Testing

Made this change on platform-test locally and showed no terraform diff
<img width="577" alt="image" src="https://github.com/user-attachments/assets/d90865cc-8b52-4643-a0a1-ceac368081f8" />
