### PR TITLE
Remove inaccurate comment

### DIFF
--- a/infra/modules/database/resources/role_manager.tf
+++ b/infra/modules/database/resources/role_manager.tf
@@ -20,7 +20,6 @@ resource "aws_lambda_function" "role_manager" {
   role             = aws_iam_role.role_manager.arn
   kms_key_arn      = aws_kms_key.role_manager.arn
 
-  # Only allow 1 concurrent execution at a time
   reserved_concurrent_executions = 1
 
   vpc_config {


### PR DESCRIPTION
## Context

Here's the docs for this attribute https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html

Copy pasting them in here in case the link dies

> Reserved concurrency – This represents the maximum number of concurrent instances allocated to your function. When a function has reserved concurrency, no other function can use that concurrency. Reserved concurrency is useful for ensuring that your most critical functions always have enough concurrency to handle incoming requests. Configuring reserved concurrency for a function incurs no additional charges

Reserved concurrency is like a reservation at a restaurant, where the restaurant also has free-floating seating. The reservation is for you, but you can also sit elsewhere. It doesn't relate to maximum concurrent executions.