### PR TITLE
Fix PR environment destroy race condition

### DIFF
--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -15,6 +15,9 @@ on:
       commit_hash:
         required: true
         type: string
+
+concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
+
 jobs:
   build-and-publish:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
@@ -33,8 +36,6 @@ jobs:
       id-token: write
       pull-requests: write # Needed to comment on PR
       repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
-
-    concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
 
     outputs:
       service_endpoint: ${{ steps.update-environment.outputs.service_endpoint }}

--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -12,6 +12,9 @@ on:
       pr_number:
         required: true
         type: string
+
+concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
+
 jobs:
   destroy:
     name: Destroy environment
@@ -22,8 +25,6 @@ jobs:
       id-token: write
       pull-requests: write # Needed to comment on PR
       repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
-
-    concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/937

## Changes

see title 

## Context for reviewers

I noticed that occasionally the PR environment gets destroyed (successfully) before it gets created again. Looking into it, it looks like if the PR is closed or merged before the PR environment check's build-and-publish job is completed, the PR environment destroy job will actually run first. This change fixes that issue by moving the concurrency key to operate at the workflow level rather than just at on the job level.

## Testing

Tested on https://github.com/navapbc/platform-test/pull/208