### PR TITLE
Update playwright config to use workers in the CI

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -13,8 +13,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   // Retry on CI only
   retries: process.env.CI ? 2 : 0,
-  // Opt out of parallel tests on CI.
-  workers: process.env.CI ? 1 : undefined,
+  // Parallelize tests.
+  workers: 10,
   // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters
   reporter: process.env.CI
     ? [['blob']]


### PR DESCRIPTION
## Changes

On grants.gov we recently tested using workers in Github Actions: https://github.com/HHS/simpler-grants-gov/pull/5615 . We've seen test times drop on average by half (~4 mins to ~2 mins).

This is an optimization that helps locally too and has been tested by a couple of devs.