### PR TITLE
Remove references to template from infra/README getting started

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -70,8 +70,7 @@ Generally, you should use the Make targets or the underlying bin scripts, but yo
 
 To set up this project for the first time (i.e., it has never been deployed to the target AWS account):
 
-1. [Install this template](/README.md#installation) into an application that meets the [Application Requirements](/README.md#application-requirements). 
-    1. You may need to tweak the generated [project configuration](/infra/project-config/main.tf) depending on your needs. <!-- markdown-link-check-disable-line -->
+1. [Review and optionally update your project configuration](/infra/project-config/main.tf) <!-- markdown-link-check-disable-line -->
 2. [Set up infrastructure developer tools](/docs/infra/set-up-infrastructure-tools.md)
 3. [Set up AWS account](/docs/infra/set-up-aws-account.md)
 4. [Set up the virtual network (VPC)](/docs/infra/set-up-network.md)


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

I notice that on a fresh install of the template-infra the markdown link CI breaks

[Example run](https://github.com/navapbc/community-engagement-medicaid/actions/runs/17083339940/job/48442285233?pr=1)
<img width="928" height="437" alt="image" src="https://github.com/user-attachments/assets/e7267b5f-0956-4173-806c-b6da1e46af1a" />

This change removes references to the template README and makes the "Getting started" section more self-contained

## Testing

CI