### PR TITLE
Use new version of markdown link check

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -18,3 +18,5 @@ jobs:
         with:
           use-quiet-mode: "yes" # errors only.
           config-file: ".github/workflows/markdownlint-config.json"
+          check-modified-files-only: ${{ github.event_name == 'pull_request' && 'yes' || 'no' }}
+          base-branch: "main"


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Original version of markdown link check is unmaintained. New one is better and has better retry logic.

## Testing

CI