### PR TITLE
Handle new output format from AWS CLI in `bin/current-region`

### DIFF
--- a/bin/current-region
+++ b/bin/current-region
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Print the current AWS region
 set -euo pipefail
-echo -n "$(aws configure list | grep region | awk -F '[ \t\n]+|[ ]*:[ ]*' '{print $2}')"
+echo -n "$(aws configure list | grep region | awk -F '[ \t\n:]+' '{print $2}')"

--- a/bin/current-region
+++ b/bin/current-region
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Print the current AWS region
 set -euo pipefail
-echo -n "$(aws configure list | grep region | awk '{print $2}')"
+echo -n "$(aws configure list | grep region | sed 's/://g' | awk '{print $2}')"

--- a/bin/current-region
+++ b/bin/current-region
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Print the current AWS region
 set -euo pipefail
-echo -n "$(aws configure list | grep region | sed 's/://g' | awk '{print $2}')"
+echo -n "$(aws configure list | grep region | awk -F '[ \t\n]+|[ ]*:[ ]*' '{print $2}')"

--- a/bin/current-region
+++ b/bin/current-region
@@ -1,4 +1,23 @@
 #!/bin/bash
 # Print the current AWS region
 set -euo pipefail
+
+# The output format of `aws configure list` has changed over time, in particular
+# the separator between config item name and value. We want to support both the
+# older format:
+#
+#   region                us-west-2              env    AWS_DEFAULT_REGION
+#
+# and the newer format:
+#
+#   region     : us-west-2                : env              : AWS_DEFAULT_REGION
+#
+# So tell Awk to use either whitespace OR `:` as the separator and grab the
+# second field.
+#
+# Until such a time that `aws configure list` respects the `--output`/`--query`
+# flag[1] and we can more robustly fetch just the value needed or we move away
+# from calling it altogether.
+#
+# [1] https://github.com/aws/aws-cli/issues/7373
 echo -n "$(aws configure list | grep region | awk -F '[ \t\n:]+' '{print $2}')"


### PR DESCRIPTION
A recent change in the AWS CLI[1] updates the output formatting of `aws
configure list`, which breaks the `bin/current-region` script.

In pre-2.31.0 versions the output is:
```
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key     ****************ABCD      config_file    ~/.aws/config
secret_key     ****************ABCD      config_file    ~/.aws/config
    region                us-west-2              env    AWS_DEFAULT_REGION
```

In 2.31.0+ versions the output is:
```
NAME       : VALUE                    : TYPE             : LOCATION
profile    : <not set>                : None             : None
access_key : ****************ABCD     : config_file      : ~/.aws/config
secret_key : ****************ABCD     : config_file      : ~/.aws/config
region     : us-west-2                : env              : AWS_DEFAULT_REGION
```

As `aws configure list` does not respect the `--output` flag[2], handle both
formats for now to avoid forcing everyone onto a pre or post 2.31.0 version.

[1] https://github.com/aws/aws-cli/pull/9547
[2] https://github.com/aws/aws-cli/issues/7373 (which in title is for the `aws
configure list-profiles` command, but is also relevant to the `aws configure
list` command and likely any fix there would apply to both)


## Testing

See `Template CI Infra Checks / Infra Tests` CI checks, which run `bin/set-up-current-account` which calls `bin/current-region`.
