### PR TITLE
Fix current-region for old AWS CLI versions

### DIFF
--- a/bin/current-region
+++ b/bin/current-region
@@ -13,11 +13,14 @@ set -euo pipefail
 #   region     : us-west-2                : env              : AWS_DEFAULT_REGION
 #
 # So tell Awk to use either whitespace OR `:` as the separator and grab the
-# second field.
+# second field. Also explicitly strip leading/trailing whitespace (as well as
+# collapsing all whitespace in general) with an initial call to Awk, as when
+# specifying a non-default field separator Awk will no longer do that
+# internally.
 #
 # Until such a time that `aws configure list` respects the `--output`/`--query`
 # flag[1] and we can more robustly fetch just the value needed or we move away
 # from calling it altogether.
 #
 # [1] https://github.com/aws/aws-cli/issues/7373
-echo -n "$(aws configure list | grep region | xargs | awk -F '[ \t\n:]+' '{print $2}')"
+echo -n "$(aws configure list | grep region | awk '{$1=$1;print}' | awk -F '[ \t\n:]+' '{print $2}')"


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

see title

## Context for reviewers

I have an older version of AWS CLI locally which is how I discovered this bug.

It looks like the old version of AWS CLI outputs leading/trailing whitespace so using whitespace as the delimeter causes the first item to be returned rather than the second. This change fixes it.

## Testing

Tested in OSCER repo

### Output of AWS CLI configure list | grep region
<img width="620" height="30" alt="image" src="https://github.com/user-attachments/assets/5f6ac848-d42f-4b30-a56c-05fc6ca8dd97" />

### Before
<img width="540" height="30" alt="image" src="https://github.com/user-attachments/assets/c80376e0-05df-4180-be92-d7cddbcbaff6" />

### After
<img width="538" height="30" alt="image" src="https://github.com/user-attachments/assets/bb4456b1-4f86-4788-a12b-2947c9f10d8c" />
