### PR TITLE
Better handling of DB upgrades

### DIFF
--- a/infra/modules/database/resources/main.tf
+++ b/infra/modules/database/resources/main.tf
@@ -62,6 +62,11 @@ resource "aws_rds_cluster" "db" {
   vpc_security_group_ids = [aws_security_group.db.id]
 
   enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  # Many DB modifications are by default queued up for the next maintenance
+  # window, but when you want changes to happen now, set this.
+  #
+  # apply_immediately = true
 }
 
 resource "aws_rds_cluster_instance" "primary" {
@@ -73,6 +78,11 @@ resource "aws_rds_cluster_instance" "primary" {
   auto_minor_version_upgrade = true
   monitoring_role_arn        = aws_iam_role.rds_enhanced_monitoring.arn
   monitoring_interval        = 30
+
+  # Many DB modifications are by default queued up for the next maintenance
+  # window, but when you want changes to happen now, set this.
+  #
+  # apply_immediately = true
 }
 
 resource "aws_kms_key" "db" {
@@ -98,5 +108,10 @@ resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
     name = "log_min_duration_statement"
     # Logs all statements that run 100ms or longer
     value = "100"
+  }
+
+  lifecycle {
+    # To support major version updates.
+    create_before_destroy = true
   }
 }


### PR DESCRIPTION
## Changes

A few tweaks to make it more straightforward to just run the DB upgrade immediately if that's what you want to do.

## Context for reviewers

Replaces https://github.com/navapbc/template-infra/pull/760

## Testing

Upgraded multiple environments from v14 to v16 in https://github.com/navapbc/flex-sdk-demo/pull/379
