### PR TITLE
Make deploy steps for an app all use the same commit

### DIFF
--- a/.github/actions/build-release-image/action.yml
+++ b/.github/actions/build-release-image/action.yml
@@ -18,12 +18,19 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - id: set-image-tag
+      shell: bash
+      run: |
+        # not strictly required as long as the calling workflow has checked out
+        # the repo with the correct ref, but for good measure and making this
+        # composite action not have a hard requirement on the git repo, we can
+        # set the tag to the specified commit hash
+        echo "IMAGE_TAG=${{ inputs.commit_hash }}" >> "$GITHUB_ENV"
 
     - id: get-image-identifier
       shell: bash
       run: |
         IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-        IMAGE_TAG=$(make release-image-tag)
         echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.get-commit-hash.outputs.commit_hash }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/cd-{{app_name}}.yml.jinja
+++ b/.github/workflows/cd-{{app_name}}.yml.jinja
@@ -1,7 +1,7 @@
 name: Deploy {{ app_name }}
 # Need to set a default value for when the workflow is triggered from a git push
 # which bypasses the default configuration for inputs
-run-name: Deploy ${{'{{'}}inputs.version || 'main' {{'}}'}} to {{ app_name }} ${{'{{'}} inputs.environment || 'dev' {{'}}'}}
+run-name: Deploy ${{'{{'}} inputs.version || github.sha {{'}}'}} to {{ app_name }} ${{'{{'}} inputs.environment || 'dev' {{'}}'}}
 
 on:
   {% if app_has_dev_env_setup %}
@@ -51,5 +51,5 @@ jobs:
     with:
       app_name: "{{ app_name }}"
       environment: ${{'{{'}} inputs.environment || 'dev' {{'}}'}}
-      version: ${{'{{'}} inputs.version || 'main' {{'}}'}}
+      version: ${{'{{'}} inputs.version || github.sha {{'}}'}}
     secrets: inherit


### PR DESCRIPTION
When multiple commits hit a repo in quick succession each touching a different app, it creates a race condition as each app CD action will attempt to resolve the `HEAD` of `main`, not the ref that actually triggered the workflow. So have `cd-{{app_name}}.yml` use the commit that triggered the workflow (on `push` events) if `version` is not provided explicitly (which will be the case for dispatch events).

That alone should fix the biggest issue, but while here ensure `build-and-publish.yml` resolves the commit itself only once in the `get-commit-hash` job, and then uses that everywhere else. This is so if it is invoked manually or a deploy manually invoked with a non-commit ref, the commit is fixed once the build starts at least.

## Testing

platform-test branch: https://github.com/navapbc/platform-test/compare/doshitan/fix-cd-race-condition

Manual deploy: https://github.com/navapbc/platform-test/actions/runs/19047490583
Auto deploy: https://github.com/navapbc/platform-test/actions/runs/19047713627
