### PR TITLE
template-only: Add GH actions for creating test PRs against platform-test

### DIFF
--- a/.github/workflows/template-only-ci-test-pr.yml
+++ b/.github/workflows/template-only-ci-test-pr.yml
@@ -1,0 +1,46 @@
+name: Template CI Test PRs
+run-name: ${{ github.workflow }} - ${{ inputs.action || github.event.pull_request.state }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        required: true
+        type: string
+      action:
+        type: choice
+        options:
+          - update
+          - close
+        default: update
+  pull_request:
+    paths:
+      - "**"
+      - "copier.yml"
+  pull_request_target:
+    types: [closed]
+
+# all access is via `PLATFORM_BOT_GITHUB_TOKEN`
+permissions: {}
+
+jobs:
+  update:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    uses: ./.github/workflows/template-only-create-or-update-test-pr.yml
+    if: (github.event_name == 'workflow_dispatch' && inputs.action == 'update') || github.event.pull_request.state == 'open'
+    with:
+      branch_name: ${{ inputs.branch_name || github.head_ref }}
+      project_repo: navapbc/platform-test
+    secrets:
+      access_token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
+
+  close:
+    if: (github.event_name == 'workflow_dispatch' && inputs.action == 'close') || github.event.pull_request.state == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close test PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ inputs.branch_name || github.head_ref }}
+        run: |
+          gh pr close "${BRANCH_NAME}" --delete-branch --repo navapbc/platform-test

--- a/.github/workflows/template-only-ci-test-pr.yml
+++ b/.github/workflows/template-only-ci-test-pr.yml
@@ -15,11 +15,12 @@ on:
           - update
           - close
         default: update
-  pull_request:
-    paths:
-      - "**"
-      - "!**template-only**"
-      - "copier.yml"
+  # TODO: if/when we want to automatically create
+  # pull_request:
+  #   paths:
+  #     - "**"
+  #     - "!**template-only**"
+  #     - "copier.yml"
   pull_request_target:
     types: [closed]
 

--- a/.github/workflows/template-only-ci-test-pr.yml
+++ b/.github/workflows/template-only-ci-test-pr.yml
@@ -4,8 +4,10 @@ run-name: ${{ github.workflow }} - ${{ inputs.action || github.event.pull_reques
 on:
   workflow_dispatch:
     inputs:
-      branch_name:
+      src_branch_name:
         required: true
+        type: string
+      dest_branch_name:
         type: string
       action:
         type: choice
@@ -13,10 +15,11 @@ on:
           - update
           - close
         default: update
-  pull_request:
-    paths:
-      - "**"
-      - "copier.yml"
+  # TODO: enable when ready
+  # pull_request:
+  #   paths:
+  #     - "**"
+  #     - "copier.yml"
   pull_request_target:
     types: [closed]
 
@@ -24,12 +27,39 @@ on:
 permissions: {}
 
 jobs:
+  get-params:
+    name: Get parameters with some processing
+    runs-on: ubuntu-latest
+    outputs:
+      src_branch_name: ${{ steps.get-params-step.outputs.src_branch_name }}
+      dest_branch_name: ${{ steps.get-params-step.outputs.dest_branch_name }}
+    steps:
+      - id: get-params-step
+        env:
+          GITHUB_HEAD_REF: github.head_ref
+        run: |
+          src_branch_name="${{ inputs.src_branch_name || env.GITHUB_HEAD_REF }}"
+
+          echo "src_branch_name=${src_branch_name}"
+          echo "src_branch_name=${src_branch_name}" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "${{ inputs.dest_branch_name  }}" ]]; then
+            dest_branch_name="${{ inputs.dest_branch_name }}"
+          else
+            dest_branch_name="test-pr|${{ github.repository }}|${src_branch_name}"
+          fi
+
+          echo "dest_branch_name=${dest_branch_name}"
+          echo "dest_branch_name=${dest_branch_name}" >> "$GITHUB_OUTPUT"
+
   update:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     uses: ./.github/workflows/template-only-create-or-update-test-pr.yml
     if: (github.event_name == 'workflow_dispatch' && inputs.action == 'update') || github.event.pull_request.state == 'open'
+    needs: get-params
     with:
-      branch_name: ${{ inputs.branch_name || github.head_ref }}
+      src_branch_name: ${{ needs.get-params.outputs.src_branch_name }}
+      dest_branch_name: ${{ needs.get-params.outputs.dest_branch_name }}
       project_repo: navapbc/platform-test
     secrets:
       access_token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
@@ -37,10 +67,15 @@ jobs:
   close:
     if: (github.event_name == 'workflow_dispatch' && inputs.action == 'close') || github.event.pull_request.state == 'closed'
     runs-on: ubuntu-latest
+    needs: get-params
     steps:
       - name: Close test PR
         env:
           GITHUB_TOKEN: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
-          BRANCH_NAME: ${{ inputs.branch_name || github.head_ref }}
+          DEST_BRANCH_NAME: ${{ needs.get-params.outputs.dest_branch_name }}
         run: |
-          gh pr close "${BRANCH_NAME}" --delete-branch --repo navapbc/platform-test
+          if gh pr view "${DEST_BRANCH_NAME}" --repo navapbc/platform-test &> /dev/null; then
+            gh pr close "${DEST_BRANCH_NAME}" --delete-branch --repo navapbc/platform-test
+          else
+            echo "PR does not exist. Nothing to close."
+          fi

--- a/.github/workflows/template-only-ci-test-pr.yml
+++ b/.github/workflows/template-only-ci-test-pr.yml
@@ -15,12 +15,11 @@ on:
           - update
           - close
         default: update
-  # TODO: enable when ready
-  # pull_request:
-  #   paths:
-  #     - "**"
-  #     - "!**template-only**"
-  #     - "copier.yml"
+  pull_request:
+    paths:
+      - "**"
+      - "!**template-only**"
+      - "copier.yml"
   pull_request_target:
     types: [closed]
 

--- a/.github/workflows/template-only-ci-test-pr.yml
+++ b/.github/workflows/template-only-ci-test-pr.yml
@@ -19,6 +19,7 @@ on:
   # pull_request:
   #   paths:
   #     - "**"
+  #     - "!**template-only**"
   #     - "copier.yml"
   pull_request_target:
     types: [closed]

--- a/.github/workflows/template-only-ci-test-pr.yml
+++ b/.github/workflows/template-only-ci-test-pr.yml
@@ -74,8 +74,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
           DEST_BRANCH_NAME: ${{ needs.get-params.outputs.dest_branch_name }}
         run: |
-          if gh pr view "${DEST_BRANCH_NAME}" --repo navapbc/platform-test &> /dev/null; then
+          PR_STATE=$(gh pr list --head "${DEST_BRANCH_NAME}" --repo navapbc/platform-test --json state --jq '.[].state')
+          echo "PR_STATE=${PR_STATE}"
+
+          if [[ "${PR_STATE}" == "OPEN" ]]; then
             gh pr close "${DEST_BRANCH_NAME}" --delete-branch --repo navapbc/platform-test
           else
-            echo "PR does not exist. Nothing to close."
+            echo "PR does not exist (or is already closed). Nothing to close."
           fi

--- a/.github/workflows/template-only-create-or-update-test-pr.yml
+++ b/.github/workflows/template-only-create-or-update-test-pr.yml
@@ -1,0 +1,95 @@
+name: Template Test PR
+
+on:
+  workflow_call:
+    inputs:
+      branch_name:
+        required: true
+        type: string
+      project_repo:
+        type: string
+        required: true
+      pr_body:
+        type: string
+    secrets:
+      access_token:
+        required: true
+
+# all access is via the provided `access_token`
+permissions: {}
+
+env:
+  BRANCH_NAME: ${{ inputs.branch_name }}
+
+jobs:
+  create-or-update-pr:
+    name: Create or update PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project repo
+        uses: actions/checkout@v4
+        with:
+          path: project-repo
+          repository: ${{ inputs.project_repo }}
+          token: ${{ secrets.access_token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install nava-platform CLI
+        run: pipx install --python "$(which python)" git+https://github.com/navapbc/platform-cli
+
+      - name: Configure git
+        working-directory: project-repo
+        run: |
+          git config user.name nava-platform-bot
+          git config user.email platform-admins@navapbc.com
+
+      - name: Set up PR branch
+        working-directory: project-repo
+        run: |
+          git checkout -b "${BRANCH_NAME}"
+
+      - name: Update infra template
+        working-directory: project-repo
+        run: nava-platform infra update --template-uri ${{ github.server_url }}/${{ github.repository }} --version "${BRANCH_NAME}" .
+
+      - name: Push changes to project repo
+        working-directory: project-repo
+        run: git push --force --set-upstream origin HEAD
+
+      - name: Check for existing PR
+        id: check-pr
+        working-directory: project-repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.access_token }}
+        run: |
+          PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
+          if [[ -n "${PR_URL}" ]]; then
+            echo "PR already exists -> ${PR_URL}"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PR does not exist (or is not open)"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open Pull Request
+        if: ${{ steps.check-pr.outputs.exists != 'true' }}
+        working-directory: project-repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.access_token }}
+          PR_BODY: ${{ inputs.pr_body }}
+        run: |
+          if [[ -n "${PR_BODY}" ]]; then
+            : # we're good
+          elif [[ -n "${{ github.event.pull_request.html_url }}" ]]; then
+            PR_BODY="${{ github.event.pull_request.html_url }}"
+          else
+            PR_BODY="${{ github.server_url }}/${{ github.repository }}/tree/${BRANCH_NAME}"
+          fi
+
+          gh pr create \
+            --body "${PR_BODY}" \
+            --title "Test Template PR: ${BRANCH_NAME}"

--- a/.github/workflows/template-only-create-or-update-test-pr.yml
+++ b/.github/workflows/template-only-create-or-update-test-pr.yml
@@ -37,13 +37,8 @@ jobs:
           repository: ${{ inputs.project_repo }}
           token: ${{ secrets.access_token }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-
-      - name: Install nava-platform CLI
-        run: pipx install --python "$(which python)" git+https://github.com/navapbc/platform-cli
+      - name: Set up navapbc/platform-cli
+        uses: navapbc/platform-cli/.github/actions/setup-cli@e565096992407a70e73e5a85167421f9bd85addb
 
       - name: Configure git
         working-directory: project-repo

--- a/.github/workflows/template-only-create-or-update-test-pr.yml
+++ b/.github/workflows/template-only-create-or-update-test-pr.yml
@@ -91,7 +91,20 @@ jobs:
           elif [[ -n "${{ github.event.pull_request.html_url }}" ]]; then
             PR_BODY="${{ github.event.pull_request.html_url }}"
           else
-            PR_BODY="${{ github.server_url }}/${{ github.repository }}/tree/${SRC_BRANCH_NAME}"
+            # There may be a PR associated with the source branch, but the
+            # workflow wasn't triggered by the PR itself (either the PR author
+            # doesn't have permission to run the workflow, there was some error
+            # and we want to manually re-run, etc). It's valuable to connect the
+            # two PRs with a mention regardless, so check if we have a PR to
+            # link.
+            src_pr_url=$(gh pr --repo ${{ github.repository }} list --head "${SRC_BRANCH_NAME}" --state open --limit 1 --json url --jq .[].url || true)
+            echo "src_pr_url=${src_pr_url}"
+
+            if [[ -n ${src_pr_url} ]]; then
+              PR_BODY="${src_pr_url}"
+            else
+              PR_BODY="${{ github.server_url }}/${{ github.repository }}/tree/${SRC_BRANCH_NAME}"
+            fi
           fi
 
           gh pr create \

--- a/.github/workflows/template-only-create-or-update-test-pr.yml
+++ b/.github/workflows/template-only-create-or-update-test-pr.yml
@@ -31,14 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: project-repo
           repository: ${{ inputs.project_repo }}
           token: ${{ secrets.access_token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/template-only-create-or-update-test-pr.yml
+++ b/.github/workflows/template-only-create-or-update-test-pr.yml
@@ -108,5 +108,6 @@ jobs:
           fi
 
           gh pr create \
+            --draft \
             --body "${PR_BODY}" \
             --title "[${{ github.repository }}] Test Template PR: ${SRC_BRANCH_NAME}"

--- a/.github/workflows/template-only-create-or-update-test-pr.yml
+++ b/.github/workflows/template-only-create-or-update-test-pr.yml
@@ -3,7 +3,10 @@ name: Template Test PR
 on:
   workflow_call:
     inputs:
-      branch_name:
+      src_branch_name:
+        required: true
+        type: string
+      dest_branch_name:
         required: true
         type: string
       project_repo:
@@ -19,7 +22,8 @@ on:
 permissions: {}
 
 env:
-  BRANCH_NAME: ${{ inputs.branch_name }}
+  SRC_BRANCH_NAME: ${{ inputs.src_branch_name }}
+  DEST_BRANCH_NAME: ${{ inputs.dest_branch_name }}
 
 jobs:
   create-or-update-pr:
@@ -50,11 +54,11 @@ jobs:
       - name: Set up PR branch
         working-directory: project-repo
         run: |
-          git checkout -b "${BRANCH_NAME}"
+          git checkout -b "${DEST_BRANCH_NAME}"
 
       - name: Update infra template
         working-directory: project-repo
-        run: nava-platform infra update --template-uri ${{ github.server_url }}/${{ github.repository }} --version "${BRANCH_NAME}" .
+        run: nava-platform infra update --template-uri ${{ github.server_url }}/${{ github.repository }} --version "${SRC_BRANCH_NAME}" .
 
       - name: Push changes to project repo
         working-directory: project-repo
@@ -66,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.access_token }}
         run: |
-          PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
+          PR_URL="$(gh pr list --head "${DEST_BRANCH_NAME}" --state open --json url --jq .[].url)"
           if [[ -n "${PR_URL}" ]]; then
             echo "PR already exists -> ${PR_URL}"
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -87,9 +91,9 @@ jobs:
           elif [[ -n "${{ github.event.pull_request.html_url }}" ]]; then
             PR_BODY="${{ github.event.pull_request.html_url }}"
           else
-            PR_BODY="${{ github.server_url }}/${{ github.repository }}/tree/${BRANCH_NAME}"
+            PR_BODY="${{ github.server_url }}/${{ github.repository }}/tree/${SRC_BRANCH_NAME}"
           fi
 
           gh pr create \
             --body "${PR_BODY}" \
-            --title "Test Template PR: ${BRANCH_NAME}"
+            --title "[${{ github.repository }}] Test Template PR: ${SRC_BRANCH_NAME}"


### PR DESCRIPTION
The current template development flow remains primarily to _start_ development
in some sort of project environment[1] (like `platform-test`) and then bring
back to the template. But there are some changes, typically smaller, where it's
easier to make the change in the template first. This GH Action helps automate
some of the boilerplate involved with creating a `platform-test` PR with the
changes so all the CI can run there to provide evidence the changes will work.

Repo maintainers/folks with access can run from the Actions web page or from the
CLI:

```
gh workflow run template-only-ci-test-pr.yml -f src_branch_name=<branch name>
```

It's not perfect and will fail in a variety of situations, but that can be still
be useful info (e.g., the changes don't apply cleanly with a simple update).
That will get better as the CLI tool gets better, and we may decide to add more
knobs or magic for things in this action.

[1] https://github.com/navapbc/template-infra/blob/0825b33af5beead110aa5ca838be1a07e837d0ac/template-only-docs/template-development-workflow.md#developing-infrastructure-changes

## Testing

See all the runs: https://github.com/navapbc/template-infra/actions/workflows/template-only-ci-test-pr.yml
