### PR TITLE
Better match only `p-<num>` format for orphaned PR environment detection

### DIFF
--- a/bin/orphaned-pr-environments
+++ b/bin/orphaned-pr-environments
@@ -21,7 +21,7 @@ echo terraform -chdir="infra/${app_name}/service" workspace list
 workspaces="$(terraform -chdir="infra/${app_name}/service" workspace list)"
 # grep will exit with code `1` if there's no match, so ignore that for when
 # there are no PR workspaces for the application
-pr_nums="$(echo "${workspaces}" | { grep -o 'p-[0-9]\+' || test $? = 1; } | sed 's/p-//')"
+pr_nums="$(echo "${workspaces}" | { grep -o 'p-[0-9]\+$' || test $? = 1; } | sed 's/p-//')"
 echo "PRs"
 echo "${pr_nums}"
 echo "::endgroup::"


### PR DESCRIPTION
## Changes

Avoid capturing workspaces named like `p-123-2` or `app-57-test`.

## Testing

In `platform-test` right now, workspace list for `app-flask/service`:

```
❯ terraform workspace list                   
  default
  docai-test
  p-212
* p-232-2
  p-233
  p-237
  p-238
  p-240
  p-245
  p-246
  p-247
  p-248

```

Running `./bin/orphaned-pr-environments app-flask` before:

```
::group::Initialize Terraform
terraform -chdir=infra/app-flask/service init -input=false -reconfigure -backend-config=dev.s3.tfbackend
Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.
Initializing modules...
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Reusing previous version of hashicorp/external from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Reusing previous version of hashicorp/aws from the dependency lock file
- Using previously-installed hashicorp/external v2.3.5
- Using previously-installed hashicorp/random v3.7.2
- Using previously-installed hashicorp/aws v5.100.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
::endgroup::
::group::List PRs with PR environments
terraform -chdir=infra/app-flask/service workspace list
PRs
212
232
233
237
238
240
245
246
247
248
::endgroup::
::group::Check status of each PR
PR 212: OPEN
PR 232: CLOSED
PR 233: OPEN
PR 237: OPEN
PR 238: OPEN
PR 240: OPEN
PR 245: OPEN
PR 246: OPEN
PR 247: OPEN
PR 248: OPEN
::endgroup::
🧹 Found orphaned PR environments for the following PRs: **232**
```

After:

```
::group::Initialize Terraform
terraform -chdir=infra/app-flask/service init -input=false -reconfigure -backend-config=dev.s3.tfbackend
Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.
Initializing modules...
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Reusing previous version of hashicorp/random from the dependency lock file
- Reusing previous version of hashicorp/external from the dependency lock file
- Reusing previous version of hashicorp/aws from the dependency lock file
- Using previously-installed hashicorp/random v3.7.2
- Using previously-installed hashicorp/external v2.3.5
- Using previously-installed hashicorp/aws v5.100.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
::endgroup::
::group::List PRs with PR environments
terraform -chdir=infra/app-flask/service workspace list
PRs
212
233
237
238
240
245
246
247
248
::endgroup::
::group::Check status of each PR
PR 212: OPEN
PR 233: OPEN
PR 237: OPEN
PR 238: OPEN
PR 240: OPEN
PR 245: OPEN
PR 246: OPEN
PR 247: OPEN
PR 248: OPEN
::endgroup::
✅ No orphaned PR environments
```
