### PR TITLE
Update CODEOWNERS and move to .github/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @navapbc/strata-platform-templates

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navapbc/platform-infra

--- a/copier.yml
+++ b/copier.yml
@@ -104,7 +104,7 @@ _exclude:
   - /.git
   - /copier.yml
   - /code.json
-  - /CODEOWNERS
+  - /.github/CODEOWNERS
   - /CODE_OF_CONDUCT.md
   - /CONTRIBUTING.md
   - /LICENSE.md


### PR DESCRIPTION
## Changes

`@navapbc/platform-infra` is an interest group, not owners. The `CODEOWNERS` is specific to GitHub, so put it under `.github/`.

## Testing

Installing the template fresh, no `.github/CODEOWNERS` is present in the generated project.