### PR TITLE
Fix description of VPC security group rule for service

### DIFF
--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -85,7 +85,7 @@ resource "aws_vpc_security_group_ingress_rule" "service_ingress_from_load_balanc
 
 resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_ingress_from_service" {
   security_group_id = module.network.aws_services_security_group_id
-  description       = "Allow inbound requests to VPC endpoints from role manager"
+  description       = "Allow inbound requests to VPC endpoints from service ${var.service_name}"
 
   from_port                    = 443
   to_port                      = 443


### PR DESCRIPTION
And add the service name in the description for easier scanning in the AWS Console, which shows the security group ID and description but _not_ the name (which has the service name already embedded).

## Context for reviewers

Current example from `platform-test`, see it only showing the description:

<img width="1257" height="748" alt="image" src="https://github.com/user-attachments/assets/6e727e07-5e08-4019-a228-2f702c4b2396" />

Could put the service name as the prefix instead? `${var.service_name}: Allow inbound requests to VPC endpoints from service`

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
