### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/navapbc/template-infra)
+
 <p>
   <img src="template-only-docs/assets/Nava-Strata-Logo-V02.svg" alt="Nava Strata" width="400">
 </p>


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/navapbc/template-infra) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.