### PR TITLE
Fix unbound variable in migrate-s3-locking script

### DIFF
--- a/bin/migrate-terraform-state-locking-to-s3
+++ b/bin/migrate-terraform-state-locking-to-s3
@@ -139,7 +139,7 @@ if [[ "${reinit}" == true ]]; then
     if [ -f "${tf_vars_file}" ]; then
       tf_vars_args+=("-var-file=${config_name}.tfvars")
     fi
-    if ! terraform -chdir="${module_dir}" plan -input=false "${tf_vars_args[@]}"; then
+    if ! terraform -chdir="${module_dir}" plan -input=false ${tf_vars_args[@]+"${tf_vars_args[@]}"}; then
       echo "  ERROR: terraform plan failed for ${module_dir} ${config_name}"
       errors=$((errors + 1))
       continue


### PR DESCRIPTION
## Summary

- Fix crash when `--reinit` flag is used on modules without a `.tfvars` file
- Empty bash array with `set -u` (nounset) causes `unbound variable` error — use the `${arr[@]+...}` idiom to safely expand

## Context

Discovered while running the migration on `platform-test`. The `--reinit` path was not exercised in CI tests for #999.

## Test plan

- [ ] Run `bin/migrate-terraform-state-locking-to-s3 --reinit` on a project with modules that don't have `.tfvars` files