### PR TITLE
Ignore changes to DDE blueprints list to mitigate noise

### DIFF
--- a/docs/infra/document-data-extraction.md
+++ b/docs/infra/document-data-extraction.md
@@ -53,7 +53,7 @@ blueprints are currently ignored. So after initial creation, if you wish to
 change the blueprints, you will need to take a few extra steps:
 
 1. Update `blueprints` config item as appropriate
-1. Comment out `custom_output_configuration.blueprints` line in the from the
+1. Comment out `custom_output_configuration.blueprints` line in the
    `ignore_changes` block on `awscc_bedrock_data_automation_project` in the [DDE
    module][dde-module].
 1. Update the service (`make infra-update-app-service APP_NAME=<APP_NAME>
@@ -63,7 +63,7 @@ change the blueprints, you will need to take a few extra steps:
 
 If you don't use the `check-infra-deploy-status.yml` workflow and/or are
 expecting frequent changes to the needed blueprints, you could remove the
-`ignore_chnages` block so that changes take effect via the regular deployment
+`ignore_changes` block so that changes take effect via the regular deployment
 process.
 
 [dde-module]: /infra/modules/document-data-extraction/resources/main.tf

--- a/docs/infra/document-data-extraction.md
+++ b/docs/infra/document-data-extraction.md
@@ -1,0 +1,69 @@
+# Document Data Extraction
+
+The Document Data Extraction feature (abbreviated as DDE) sets up resources for
+identifying and extracting data from "documents" (image and PDF files primarily
+composed of written information).
+
+## Enable feature in application config
+
+In your application's `app-config` module
+(`/infra/<APP_NAME>/app-config/main.tf`), set:
+
+```terraform
+enable_document_data_extraction = true
+```
+
+Tweak settings as desired in
+`/infra/<APP_NAME>/app-config/env-config/document_data_extraction.tf`, notably
+the `blueprints` item (see the next section for more info).
+
+Then update the service layer to create the resources:
+
+```bash
+make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>
+```
+
+## Custom blueprints
+
+The DDE module utilizes AWS's Bedrock Data Automation (BDA) service, which
+supports "blueprints" for fine-tuning some data extraction logic. See the [AWS
+docs][bda-blueprint-docs] for more info on use case and structure.
+
+The DDE module has flexible support for loading these blueprints via either
+project source files or pre-built blueprints from the AWS catalog.
+
+By default things are set up to load any files in the directory
+`/infra/<APP_NAME>/service/document-data-extraction-blueprints/` as custom
+blueprints. You can change this location, or add AWS catalog blueprints via
+their ARN in the `blueprints` config list in
+`/infra/<APP_NAME>/app-config/env-config/document_data_extraction.tf`.
+
+[bda-blueprint-docs]: https://docs.aws.amazon.com/bedrock/latest/userguide/bda-blueprint-info.html
+
+## Updating blueprints
+
+Due to [underlying provider
+limitations](https://github.com/navapbc/template-infra/issues/1027), when
+specifying blueprints to use, the BDA project resource will always show a diff
+between the IaC and current state.
+
+To eliminate this noise (and facilitate a useful automated checks like
+`/.github/workflows/check-infra-deploy-status.yml`), changes to the list of
+blueprints are currently ignored. So after initial creation, if you wish to
+change the blueprints, you will need to take a few extra steps:
+
+1. Update `blueprints` config item as appropriate
+1. Comment out `custom_output_configuration.blueprints` line in the from the
+   `ignore_changes` block on `awscc_bedrock_data_automation_project` in the [DDE
+   module][dde-module].
+1. Update the service (`make infra-update-app-service APP_NAME=<APP_NAME>
+   ENVIRONMENT=<ENVIRONMENT>`) to apply the blueprint changes
+1. Uncomment `custom_output_configuration.blueprints` line in the [DDE
+   module][dde-module] to restore the silencing.
+
+If you don't use the `check-infra-deploy-status.yml` workflow and/or are
+expecting frequent changes to the needed blueprints, you could remove the
+`ignore_chnages` block so that changes take effect via the regular deployment
+process.
+
+[dde-module]: /infra/modules/document-data-extraction/resources/main.tf

--- a/docs/infra/document-data-extraction.md
+++ b/docs/infra/document-data-extraction.md
@@ -54,13 +54,16 @@ blueprints are currently ignored. This means the usual:
 - Changes to blueprints in AWS console (or other means) won't be detected by
   Terraform
 - Additions or removals of blueprints in the config won't apply with other
-  service-layer changes (after initial creation)
+  service-layer changes. Notably **deleting a custom blueprint source file will
+  result in an error during updates**, as the underlying blueprint resource will
+  try to be destroyed, but will still be referenced by the BDA project and so
+  the update will be prevented. See next section for more detail on removals.
 
 So after initial creation, if you wish to change the blueprints (or more
 generally, sync the deployed state to what is specified in the IaC), you will
 need to take a few extra steps:
 
-1. Update `blueprints` config item as appropriate
+1. Update `blueprints` config item (and custom blueprint files) as appropriate
    - For initial development, commit the changes now. For releases, checkout the
      commit corresponding to the release with the desired changes.
 1. Comment out `custom_output_configuration.blueprints` line in the
@@ -86,3 +89,27 @@ expecting frequent changes to the needed blueprints, you could remove the
 process.
 
 [dde-module]: /infra/modules/document-data-extraction/resources/main.tf
+
+### Removing custom blueprint files
+
+As mentioned above, you must follow the specified update steps when removing
+custom blueprint source files (default location:
+`/infra/<APP_NAME>/service/document-data-extraction-blueprints/`) to avoid
+errors during updates.
+
+This is because these files are turned into Bedrock blueprints, which are
+independent resources from any BDA project; the BDA project just references them
+by ARN. And because we ignore changes to the list of blueprint ARNs on the BDA
+project, a straight update will miss removing the Bedrock blueprint ARN from the
+list before the blueprint resource itself is (attempted to be) destroyed. You
+will encounter an error like:
+
+> Calling Cloud Control API service DeleteResource operation returned: waiter
+> state transitioned to FAILED.
+>
+> StatusMessage: Unable to delete the blueprint as it is being referenced by
+> some project. You must remove it from all referring projects before you can
+> delete the blueprint. (Service: BedrockDataAutomation, Status Code: 400,
+> Request ID: 5471570b-af48-40c4-bf88-293c92fe3021) (SDK Attempt Count: 1).
+>
+> ErrorCode: InvalidRequest

--- a/docs/infra/document-data-extraction.md
+++ b/docs/infra/document-data-extraction.md
@@ -44,22 +44,41 @@ their ARN in the `blueprints` config list in
 
 Due to [underlying provider
 limitations](https://github.com/navapbc/template-infra/issues/1027), when
-specifying blueprints to use, the BDA project resource will always show a diff
-between the IaC and current state.
+specifying blueprints to use, the BDA project resource will always show a (hard
+to understand) diff between the IaC and current state.
 
 To eliminate this noise (and facilitate a useful automated checks like
 `/.github/workflows/check-infra-deploy-status.yml`), changes to the list of
-blueprints are currently ignored. So after initial creation, if you wish to
-change the blueprints, you will need to take a few extra steps:
+blueprints are currently ignored. This means the usual:
+
+- Changes to blueprints in AWS console (or other means) won't be detected by
+  Terraform
+- Additions or removals of blueprints in the config won't apply with other
+  service-layer changes (after initial creation)
+
+So after initial creation, if you wish to change the blueprints (or more
+generally, sync the deployed state to what is specified in the IaC), you will
+need to take a few extra steps:
 
 1. Update `blueprints` config item as appropriate
+   - For initial development, commit the changes now. For releases, checkout the
+     commit corresponding to the release with the desired changes.
 1. Comment out `custom_output_configuration.blueprints` line in the
    `ignore_changes` block on `awscc_bedrock_data_automation_project` in the [DDE
    module][dde-module].
-1. Update the service (`make infra-update-app-service APP_NAME=<APP_NAME>
-   ENVIRONMENT=<ENVIRONMENT>`) to apply the blueprint changes
+   - Run `sed -i.bak 's/custom_output_configuration.blueprints/# custom_output_configuration.blueprints/' infra/modules/document-data-extraction/resources/main.tf`
+1. Update the service to apply the blueprint changes
+   - Run `make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>`
 1. Uncomment `custom_output_configuration.blueprints` line in the [DDE
    module][dde-module] to restore the silencing.
+   - Could achieve this simply by discarding changes in version tracking, e.g.
+     in git with `git reset --hard HEAD`, or restore the `*.bak` file created
+     via the `sed` example command above.
+
+This means deploying releases with blueprint updates will need manual handling
+for the service layer, similar to most other non-service layers. Depending on
+timeline of upstream Terraform provider fixes and feedback on if the manual
+process is burdensome or not, could develop greater automation around this.
 
 If you don't use the `check-infra-deploy-status.yml` workflow and/or are
 expecting frequent changes to the needed blueprints, you could remove the

--- a/infra/modules/document-data-extraction/resources/main.tf
+++ b/infra/modules/document-data-extraction/resources/main.tf
@@ -56,7 +56,10 @@ resource "awscc_bedrock_data_automation_project" "bda_project" {
   lifecycle {
     ignore_changes = [
       # Ignore these changes to avoid always showing a diff, see
-      # https://github.com/navapbc/template-infra/issues/1027
+      # /docs/infra/document-data-extraction.md for more info.
+      #
+      # NOTE: This does mean that if you comment this out to update blueprints,
+      # you must uncomment it after deployment to restore the silencing.
       custom_output_configuration.blueprints
     ]
   }

--- a/infra/modules/document-data-extraction/resources/main.tf
+++ b/infra/modules/document-data-extraction/resources/main.tf
@@ -52,6 +52,14 @@ resource "awscc_bedrock_data_automation_project" "bda_project" {
     blueprints = local.all_blueprints
   } : null
   override_configuration = var.override_configuration
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore these changes to avoid always showing a diff, see
+      # https://github.com/navapbc/template-infra/issues/1027
+      custom_output_configuration.blueprints
+    ]
+  }
 }
 
 resource "awscc_bedrock_blueprint" "bda_blueprint" {

--- a/infra/modules/document-data-extraction/resources/main.tf
+++ b/infra/modules/document-data-extraction/resources/main.tf
@@ -72,4 +72,21 @@ resource "awscc_bedrock_blueprint" "bda_blueprint" {
   schema         = each.value.schema
   type           = each.value.type
   tags           = local.bda_tags
+
+  lifecycle {
+    # Blueprints can't be deleted until all things (notably BDA Projects)
+    # referencing them are updated.
+    #
+    # NOTE: If you wish to change the type/modality of an existing blueprint,
+    # this setting will result in an error. As changing the type will force the
+    # resource to be re-created and this setting will make updates attempt to
+    # create a new blueprint with the same name before the existing one is
+    # removed, but blueprint names need to be unique. The simplest fix is to use
+    # a different name than the existing blueprint.
+    #
+    # Multiple modalities for custom blueprint files are not supported natively
+    # in the Strata templates, so this is just an FYI, see
+    # https://github.com/navapbc/template-infra/issues/1035
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION


## Ticket

Related to https://github.com/navapbc/template-infra/issues/1027

## Changes

Due to (presumed) [underlying provider limitations](https://github.com/navapbc/template-infra/issues/1027), when specifying blueprints to use, the BDA project resource will always show a diff between the IaC and current state.

Operating assumption is the list of blueprints won't change frequently after initially setting things up. So default to ignoring changes there to workaround (likely) provider issues which would break useful functionality like the `check-infra-deploy-status.yml` workflow.

Added docs for the manual steps involved why you do want to update blueprints and since no docs existed for the feature in general, added some basics there too.

In addition, the blueprint resources should have `create_before_destroy=true` Terraform lifecycle setting so the BDA project is updated to drop the blueprint _before_ the blueprint itself is destroyed, which would cause errors otherwise. 

## Testing

As a part of https://github.com/navapbc/platform-test/pull/278, making no config (or any other) changes and just running `make infra-update-app-service APP_NAME=app-documentai ENVIRONMENT=dev`

### Before (no `ignore_changes`):

<img width="3840" height="1966" alt="image" src="https://github.com/user-attachments/assets/640d14d7-4228-49e9-b3fb-02820a946094" />

<img width="3840" height="1726" alt="image" src="https://github.com/user-attachments/assets/ceef3d52-b9d0-47f1-b998-9385c4dccff9" />


### After (with `ignore_changes`):

<img width="3840" height="1173" alt="image" src="https://github.com/user-attachments/assets/68ae7e64-54ee-4aa6-88af-46e0fec600fb" />

#### Other attributes that change still show up

<img width="2344" height="188" alt="image" src="https://github.com/user-attachments/assets/270eec69-26fe-4f98-a323-0683e7fd0082" />

#### Adding/removing blueprints process

When adding a new custom template (`tester.json` here), the template resource itself is created:

<img width="2532" height="771" alt="image" src="https://github.com/user-attachments/assets/183942cc-a80d-43c6-9c8b-269406c1549d" />

But that's it, the project config is not updated:

<img width="2532" height="277" alt="image" src="https://github.com/user-attachments/assets/667b7ab1-7ac0-4e21-9b35-ffed6a3b82f2" />

Unless you follow the instructions, commenting out the ignore_changes line: 

<img width="2532" height="277" alt="image" src="https://github.com/user-attachments/assets/e370f58d-8370-4344-9fd3-8abb07353797" />
<img width="2532" height="342" alt="image" src="https://github.com/user-attachments/assets/718f2152-31df-4d01-a04a-276758df70a7" />

The diff is confusing due to the ordering bug, but the new templates does show up in the project:

<img width="2608" height="1371" alt="image" src="https://github.com/user-attachments/assets/24108af6-31a9-48f3-9b1e-0e6800319a5c" />

The same applies when adding an existing ARN and adding/removing blueprints (evidence left out here for brevity).

#### Checking infra state

All the `check-infra-deploy-status.yml` workdlow does is run [`terraform plan -detailed-exitcode`](https://github.com/navapbc/template-infra/blob/20eeedf941efe4b9794d57d66d7a0ab0b2ef3f78/.github/workflows/check-infra-deploy-status.yml#L72) against the root modules, which just exits non-zero if there are state changes. Existing evidence shows there are state changes in a service's root module without this fix, and no state changes with it. But 

Relevant section from ` ./bin/infra-deploy-status-check-configs`:
<img width="973" height="311" alt="image" src="https://github.com/user-attachments/assets/921fd7d1-2f41-4ce5-8f72-932df8aec597" />

Then run: `terraform -chdir="infra/app-documentai/service" plan -input=false -detailed-exitcode -var="environment_name=dev" ` simulating the CI check.

With `ignore_changes`:
<img width="1075" height="842" alt="image" src="https://github.com/user-attachments/assets/9a446fd9-5731-453e-be5e-6c2f90ebedbc" />

Without `ignore_changes`:
<img width="1080" height="1007" alt="image" src="https://github.com/user-attachments/assets/14d2fef2-5cb0-49c1-aa7e-b656f881c954" />

