### PR TITLE
Make `file_upload_jobs` work in temporary environments

### DIFF
--- a/infra/{{app_name}}/app-config/env-config/service.tf
+++ b/infra/{{app_name}}/app-config/env-config/service.tf
@@ -16,8 +16,9 @@ locals {
 
     file_upload_jobs = {
       for job_name, job_config in local.file_upload_jobs :
-      # For job configs that don't define a source_bucket, add the source_bucket config property
-      job_name => merge({ source_bucket = local.bucket_name, handle_temp_prefix = true }, job_config)
+      # For job configs that don't define a source_bucket, default to the
+      # service's bucket and PR/temporary environment prefixing.
+      job_name => merge({ source_bucket = local.bucket_name, source_bucket_apply_workspace_prefix = true }, job_config)
     }
 
     ephemeral_write_volumes = []

--- a/infra/{{app_name}}/app-config/env-config/service.tf
+++ b/infra/{{app_name}}/app-config/env-config/service.tf
@@ -17,7 +17,7 @@ locals {
     file_upload_jobs = {
       for job_name, job_config in local.file_upload_jobs :
       # For job configs that don't define a source_bucket, add the source_bucket config property
-      job_name => merge({ source_bucket = local.bucket_name }, job_config)
+      job_name => merge({ source_bucket = local.bucket_name, handle_temp_prefix = true }, job_config)
     }
 
     ephemeral_write_volumes = []

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -35,7 +35,7 @@ locals {
   # this will need to change as well.
   prefixed_file_upload_jobs = {
     for job_name, job_config in local.service_config.file_upload_jobs :
-    job_name => job_config.handle_temp_prefix
+    job_name => job_config.source_bucket_apply_workspace_prefix
     ? merge(job_config, { source_bucket = "${local.prefix}${job_config.source_bucket}" })
     : job_config
   }

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -22,6 +22,23 @@ locals {
   service_config          = local.environment_config.service_config
 
   service_name = "${local.prefix}${local.service_config.service_name}"
+
+  # The `source_bucket` config value (generally) contains a raw service-specific
+  # bucket name for the "real"/non-temporary environment. For temporary
+  # environments, these buckets will generally be automatically prefixed with
+  # the temporary environment identifier in this module, so add that to the base
+  # `source_bucket` value unless the config specifies not to (i.e., it is a
+  # shared/fixed bucket that _should_ trigger jobs across different
+  # environments).
+  #
+  # This is a little fragile and relies on naming conventions; if those change,
+  # this will need to change as well.
+  prefixed_file_upload_jobs = {
+    for job_name, job_config in local.service_config.file_upload_jobs :
+    job_name => job_config.handle_temp_prefix
+    ? merge(job_config, { source_bucket = "${local.prefix}${job_config.source_bucket}" })
+    : job_config
+  }
 }
 
 terraform {
@@ -77,7 +94,7 @@ module "service" {
   desired_instance_count   = local.service_config.desired_instance_count
   enable_command_execution = local.service_config.enable_command_execution
 
-  file_upload_jobs = local.service_config.file_upload_jobs
+  file_upload_jobs = local.prefixed_file_upload_jobs
   scheduled_jobs   = local.environment_config.scheduled_jobs
 
   db_vars = module.app_config.has_database ? {


### PR DESCRIPTION
Previously the temporary environments' `file_upload_jobs` would trigger based on file events in the "real" service buckets, not the temporary environment buckets.

This is because the `source_bucket` configuration parameter for `file_upload_jobs` generally contains the service's "real" bucket name(s), but we programmatically change these names for temporary environments, breaking the connection between "the created service" and "the service's created buckets".

In some cases users may intentionally want to have a bucket trigger jobs across different environments, so provide an opt-out mechanism in the config (though this is likely a rare situation).

Longer term may want to take a different approach for specifying which "bucket" to use, perhaps supporting some "logical" identifiers in the config module (though this seems hard to generalize) or possibly doing away with the "config" element altogether and configuring these things directly in the service root module.

## Testing

Tested in https://github.com/navapbc/platform-test/pull/278.

### Before

Real env:

<img width="2990" height="1952" alt="image" src="https://github.com/user-attachments/assets/ced99b2b-1c2a-46f8-ba79-7ec8ae5dede4" />


PR env:

<img width="2990" height="1952" alt="image" src="https://github.com/user-attachments/assets/810b4d15-2a5f-4393-8f6f-b0a70106c099" />


### After

Real env:

<img width="2990" height="1952" alt="image" src="https://github.com/user-attachments/assets/755a1f9a-5fd3-48b0-8401-ff377685a88a" />

PR env:

<img width="2990" height="1952" alt="image" src="https://github.com/user-attachments/assets/69260993-3928-4db6-8129-9d352fefdcde" />

Example plan in the PR env:

<img width="3815" height="1606" alt="image" src="https://github.com/user-attachments/assets/f4f4c87b-9b87-42df-9599-fd8528ad76d1" />

