### PR TITLE
update to checkov 3.2.527 and fix/skip arising issues

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download actionlint
         id: get_actionlint
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Shellcheck
         run: make infra-lint-scripts
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -76,19 +76,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - uses: actions/checkout@v6
 
       - name: Run Checkov check
         # Pin to specific checkov version rather than running from checkov@master
         # since checkov frequently adds new checks that can cause CI checks to fail unpredictably.
         # There is currently no way to specify the checkov version to pin to (See https://github.com/bridgecrewio/checkov-action/issues/41)
         # so we need to pin the version of the checkov-action, which indirectly pins the checkov version.
-        # In this case, checkov-action v12.2296.0 is mapped to checkov v2.3.194.
-        uses: bridgecrewio/checkov-action@v12.2296.0
+        # In this case, checkov-action v12.3102.0 is mapped to checkov v3.2.527
+        uses: bridgecrewio/checkov-action@v12.3102.0
         with:
           directory: infra
           framework: terraform
@@ -103,7 +99,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run tfsec check
         uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0

--- a/infra/modules/container-image-repository/main.tf
+++ b/infra/modules/container-image-repository/main.tf
@@ -81,7 +81,33 @@ data "aws_iam_policy_document" "image_access" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
 resource "aws_kms_key" "ecr_kms" {
   enable_key_rotation = true
   description         = "KMS key for ECR repository ${var.name}"
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }

--- a/infra/modules/database/resources/main.tf
+++ b/infra/modules/database/resources/main.tf
@@ -70,6 +70,7 @@ resource "aws_rds_cluster" "db" {
 }
 
 resource "aws_rds_cluster_instance" "primary" {
+  # checkov:skip=CKV_AWS_353:Ensure that RDS instances have performance insights enabled
   identifier                 = local.primary_instance_name
   cluster_identifier         = aws_rds_cluster.db.id
   instance_class             = "db.serverless"
@@ -85,9 +86,33 @@ resource "aws_rds_cluster_instance" "primary" {
   # apply_immediately = true
 }
 
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
 resource "aws_kms_key" "db" {
   description         = "Key for RDS cluster ${var.name}"
   enable_key_rotation = true
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 # Query Logging

--- a/infra/modules/database/resources/networking.tf
+++ b/infra/modules/database/resources/networking.tf
@@ -14,6 +14,7 @@ resource "aws_security_group" "db" {
 }
 
 resource "aws_security_group" "role_manager" {
+  # checkov:skip=CKV2_AWS_5:Ensure that Security Groups are attached to another resource
   name_prefix = "${var.name}-role-manager"
   description = "Database role manager security group"
   vpc_id      = module.network.vpc_id

--- a/infra/modules/database/resources/role_manager.tf
+++ b/infra/modules/database/resources/role_manager.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "role_manager" {
 
   filename         = local.role_manager_archive_path
   source_code_hash = filebase64sha256(local.role_manager_archive_path)
-  runtime          = "python3.9"
+  runtime          = "python3.10"
   handler          = "role_manager.lambda_handler"
   role             = aws_iam_role.role_manager.arn
   kms_key_arn      = aws_kms_key.role_manager.arn
@@ -61,6 +61,8 @@ data "aws_kms_key" "default_ssm_key" {
 resource "aws_kms_key" "role_manager" {
   description         = "Key for Lambda function ${local.role_manager_name}"
   enable_key_rotation = true
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 data "aws_secretsmanager_secret" "db_password" {

--- a/infra/modules/domain/resources/query_logs.tf
+++ b/infra/modules/domain/resources/query_logs.tf
@@ -1,6 +1,7 @@
 # DNS query logging
 
 resource "aws_cloudwatch_log_group" "dns_query_logging" {
+  # checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   provider = aws.us-east-1
 
   count = var.manage_dns ? 1 : 0

--- a/infra/modules/identity-provider-client/resources/main.tf
+++ b/infra/modules/identity-provider-client/resources/main.tf
@@ -31,6 +31,7 @@ resource "aws_cognito_user_pool_client" "client" {
 }
 
 resource "aws_ssm_parameter" "client_secret" {
+  # checkov:skip=CKV_AWS_337:Ensure SSM parameters are using KMS CMK
   name  = "/${var.name}/identity-provider/client-secret"
   type  = "SecureString"
   value = aws_cognito_user_pool_client.client.client_secret

--- a/infra/modules/network/resources/main.tf
+++ b/infra/modules/network/resources/main.tf
@@ -12,6 +12,7 @@ module "interface" {
 }
 
 module "aws_vpc" {
+  # checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.2.0"
 

--- a/infra/modules/network/resources/waf.tf
+++ b/infra/modules/network/resources/waf.tf
@@ -66,6 +66,7 @@ resource "aws_wafv2_web_acl" "main" {
 
 resource "aws_cloudwatch_log_group" "waf_logs" {
   # checkov:skip=CKV_AWS_158:The KMS key triggered an operation error
+  # checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   name              = "aws-waf-logs-${var.name}"
   retention_in_days = 30
 }

--- a/infra/modules/notifications-sms/resources/main.tf
+++ b/infra/modules/notifications-sms/resources/main.tf
@@ -4,6 +4,7 @@ data "aws_region" "current" {}
 
 # CloudWatch Log Group for SMS delivery receipts
 resource "aws_cloudwatch_log_group" "sms_logs" {
+  # checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   name              = "/aws/sms-voice/${var.name}/sms-notifications/delivery-receipts"
   retention_in_days = 30
 

--- a/infra/modules/secrets/main.tf
+++ b/infra/modules/secrets/main.tf
@@ -18,6 +18,7 @@ resource "random_password" "secrets" {
 }
 
 resource "aws_ssm_parameter" "secrets" {
+  # checkov:skip=CKV_AWS_337:Ensure SSM parameters are using KMS CMK
   for_each = local.generated_secrets
 
   name  = each.value.secret_store_name

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -4,6 +4,7 @@
 
 # ALB for an app running in ECS
 resource "aws_lb" "alb" {
+  # checkov:skip=CKV2_AWS_76:Ensure AWS ALB attached WAFv2 WebACL is configured with AMR for Log4j Vulnerability
   depends_on      = [aws_s3_bucket_policy.access_logs]
   name            = var.service_name
   idle_timeout    = "120"
@@ -137,6 +138,7 @@ resource "aws_lb_listener_rule" "app_https_forward" {
 }
 
 resource "aws_lb_target_group" "app_tg" {
+  # checkov:skip=CKV_AWS_378:Ensure AWS Load Balancer doesn't use HTTP protocol
   # you must use a prefix, to facilitate successful tg changes
   name_prefix          = "app-"
   port                 = var.container_port

--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -9,6 +9,7 @@ module "network" {
 }
 
 resource "aws_security_group" "alb" {
+  # checkov:skip=CKV_AWS_382:Ensure no security groups allow egress from 0.0.0.0:0 to port -1
   # Specify name_prefix instead of name because when a change requires creating a new
   # security group, sometimes the change requires the new security group to be created
   # before the old one is destroyed. In this situation, the new one needs a unique name

--- a/infra/modules/service/workflow_orchestrator_role.tf
+++ b/infra/modules/service/workflow_orchestrator_role.tf
@@ -44,6 +44,7 @@ resource "aws_iam_policy" "workflow_orchestrator" {
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "workflow_orchestrator" {
   # checkov:skip=CKV_AWS_111:These permissions are scoped just fine
+  # checkov:skip=CKV_AWS_356:Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
 
   statement {
     sid = "UnscopeLogsPermissions"

--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -6,6 +6,29 @@ locals {
   tf_state_bucket_name = var.name
   tf_logs_bucket_name  = "${var.name}-logs"
 }
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
 # Options for encryption are an AWS owned key, which is not unique to your account; AWS managed; or customer managed. The latter two options are more secure, and customer managed gives
 # control over the key. This allows for ability to restrict access by key as well as policies attached to roles or users.
 # https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
@@ -15,6 +38,8 @@ resource "aws_kms_key" "tf_backend" {
   deletion_window_in_days = "10"
   # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
   enable_key_rotation = "true"
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 # Create the S3 bucket used to store terraform state remotely.


### PR DESCRIPTION
## Ticket

Resolves [OSCER-457](https://github.com/navapbc/oscer/issues/457)

## Changes

- GHA ci-infra updated
  - Uses checkov action v12.3102.0 (checkov v3.2.527)
  - Other actions updated to easily match oscer
- Low hanging fixes addressed:
  - Update database rolemanager lambda to use Python 3.10
  - Explicitly set default policies on kms keys (copied from infra/modules/storage/encryption.tf)
- Used checkov:skip with error as comment for everything else

## Context for reviewers

These changes are identical to the [oscer reference pr](https://github.com/navapbc/oscer/pull/546) (used `git diff main > oscer.patch` in oscer then `git apply oscer.patch` in infra-template).

It has been three years since the version of checkov we are using to check our infrastructure code came out. The new version flagged sixteen issues in the infrastructure code.

I put `checkov:skip` everywhere I was unsure of the fix. Preexisting checkov:skips explain why the skip (and/or reference a follow-up ticket), whereas I left the error message as the explanation, in the hope the reviewers could either suggest the fix or justify the skip.

## Testing

Testing done in the [oscer pr](https://github.com/navapbc/oscer/pull/546).
- Checkov action passes
- terraform plan showed either no changes, changes identical to main, or the removal of the "Id" attribute for key policy for:
  - infra/networks
  - infra/accounts
  - infra/reporting-app/service (dev and sandbox)
  - infra/reporting-app/database (dev and sandbox)
  - infra/reporting-app/build-repository
- [Preview deploy](https://p-546-reporting-app-dev-1571286055.us-east-1.elb.amazonaws.com/) works fine
