### PR TITLE
OSCER-457:  upgrade python in role manager lambda

### DIFF
--- a/infra/modules/database/resources/role_manager.tf
+++ b/infra/modules/database/resources/role_manager.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "role_manager" {
 
   filename         = local.role_manager_archive_path
   source_code_hash = filebase64sha256(local.role_manager_archive_path)
-  runtime          = "python3.9"
+  runtime          = "python3.10"
   handler          = "role_manager.lambda_handler"
   role             = aws_iam_role.role_manager.arn
   kms_key_arn      = aws_kms_key.role_manager.arn


### PR DESCRIPTION
## Ticket

Address #949

## Changes

Python version for database role manager lambda upgraded to 3.14

## Context for reviewers

Python 3.9 is no longer supported by AWS, and upgrading checkov (OSCER-457) requires this upgrade.

## Testing

Passed latest checkov.
Verified migration issues from 3.9 to 3.14 do not apply to role manager code.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lambda runtime environment to Python 3.10 for improved performance and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/navapbc/template-infra/pull/1031)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->