### PR TITLE
OSCER-457: use explicit key policies

### DIFF
--- a/infra/modules/container-image-repository/main.tf
+++ b/infra/modules/container-image-repository/main.tf
@@ -81,7 +81,33 @@ data "aws_iam_policy_document" "image_access" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
 resource "aws_kms_key" "ecr_kms" {
   enable_key_rotation = true
   description         = "KMS key for ECR repository ${var.name}"
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }

--- a/infra/modules/database/resources/main.tf
+++ b/infra/modules/database/resources/main.tf
@@ -85,9 +85,33 @@ resource "aws_rds_cluster_instance" "primary" {
   # apply_immediately = true
 }
 
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
 resource "aws_kms_key" "db" {
   description         = "Key for RDS cluster ${var.name}"
   enable_key_rotation = true
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 # Query Logging

--- a/infra/modules/database/resources/role_manager.tf
+++ b/infra/modules/database/resources/role_manager.tf
@@ -61,6 +61,8 @@ data "aws_kms_key" "default_ssm_key" {
 resource "aws_kms_key" "role_manager" {
   description         = "Key for Lambda function ${local.role_manager_name}"
   enable_key_rotation = true
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 data "aws_secretsmanager_secret" "db_password" {

--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -6,6 +6,29 @@ locals {
   tf_state_bucket_name = var.name
   tf_logs_bucket_name  = "${var.name}-logs"
 }
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+
 # Options for encryption are an AWS owned key, which is not unique to your account; AWS managed; or customer managed. The latter two options are more secure, and customer managed gives
 # control over the key. This allows for ability to restrict access by key as well as policies attached to roles or users.
 # https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
@@ -15,6 +38,8 @@ resource "aws_kms_key" "tf_backend" {
   deletion_window_in_days = "10"
   # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
   enable_key_rotation = "true"
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 # Create the S3 bucket used to store terraform state remotely.


### PR DESCRIPTION
## Ticket

Part of OSCER-457

## Changes

Explicit iam policy documents added to kms keys in:
- Container image repository
- Database resources
- Database role manager
- Terraform backend S3

## Context for reviewers

Upgraded checkov tests require explicit iam policies for kms keys. Added the default kms iam policy (copied from infra/modules/storage/encryption) to all our kms keys.

Unsure if it is possible to DRY this up...

## Testing

Testing done in the [oscer pr](https://github.com/navapbc/oscer/pull/546).
- Checkov action passes
- terraform plan showed either no changes, changes identical to main, or the removal of the "Id" attribute for key policy for:
  - infra/networks
  - infra/accounts
  - infra/reporting-app/service (dev and sandbox)
  - infra/reporting-app/database (dev and sandbox)
  - infra/reporting-app/build-repository
- Preview works normally: https://p-546-reporting-app-dev-1571286055.us-east-1.elb.amazonaws.com/
