### PR TITLE
OSCER-457: Upgrade github checkout action to v6

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,7 +36,7 @@ jobs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/check-infra-deploy-status.yml
+++ b/.github/workflows/check-infra-deploy-status.yml
@@ -19,7 +19,7 @@ jobs:
       root_module_configs: ${{ steps.collect-infra-deploy-status-check-configs.outputs.root_module_configs }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Collect root module configurations
         id: collect-infra-deploy-status-check-configs
@@ -47,7 +47,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # This is the GitHub Actions-friendly port of the linter used in the Makefile.
       - uses: tcort/github-action-markdown-link-check@v1

--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download actionlint
         id: get_actionlint
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Shellcheck
         run: make infra-lint-scripts
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:
@@ -103,7 +103,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run tfsec check
         uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0

--- a/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
+++ b/.github/workflows/ci-{{app_name}}-infra-service.yml.jinja
@@ -64,7 +64,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{'{{'}} inputs.version || github.ref {{'}}'}}
 

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -40,7 +40,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       service_endpoint: ${{ steps.deploy-release.outputs.service_endpoint }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -41,7 +41,7 @@ jobs:
       service_endpoint: ${{ steps.update-environment.outputs.service_endpoint }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -27,7 +27,7 @@ jobs:
       repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/scan-orphaned-environments.yml
+++ b/.github/workflows/scan-orphaned-environments.yml
@@ -18,7 +18,7 @@ jobs:
       app_names: ${{ steps.get-app-names.outputs.app_names }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get app names
         id: get-app-names
@@ -48,7 +48,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/send-system-notification.yml
+++ b/.github/workflows/send-system-notification.yml
@@ -27,7 +27,7 @@ jobs:
     name: Notify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: project-repo
           repository: ${{ matrix.project_repo }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout template-infra repo (for example app)
         if: "${{ matrix.project_repo == 'navapbc/platform-test' }}"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: template-infra
 

--- a/.github/workflows/template-only-ci-app.yml
+++ b/.github/workflows/template-only-ci-app.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run build
       run: make release-build
 
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Test healthcheck examples
       run: ./bin/test-healthchecks

--- a/.github/workflows/template-only-ci-infra.yml
+++ b/.github/workflows/template-only-ci-infra.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Shellcheck
         run: make -f template-only.mak lint-template-scripts
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout template-infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: template-infra
 

--- a/.github/workflows/template-only-cleanup-orphaned-infra-test-resources.yml
+++ b/.github/workflows/template-only-cleanup-orphaned-infra-test-resources.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/template-only-scan-orphaned-infra-test-resources.yml
+++ b/.github/workflows/template-only-scan-orphaned-infra-test-resources.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: hadolint-config
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: trivy-ignore
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: grype-config
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: dockle-config

--- a/docs/infra/style-guide.md
+++ b/docs/infra/style-guide.md
@@ -73,7 +73,7 @@ Here are some exceptions (and additions) to Hashicorp's Terraform style guide.
     ```yaml
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Ticket

Resolves OSCER-457

## Changes

All github workflows upgraded the checkout action from v4 to v6.
e2e workflow node upgraded to v6.

## Context for reviewers

Wanting to keep using the latest versions as the default.
- checkout: https://github.com/marketplace/actions/checkout
  - v5 upgraded to node 24 (requires a minimum Actions Runner version of [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) to run.
  - v6 improved credential security: 
- setup-node (https://github.com/marketplace/actions/setup-node-js-environment)
  - v5 upgraded to node 24 (requires a minimum Actions Runner version of [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) to run; adds caching
  - v6 has more caching rules, removes always-auth (we don't use)
## Testing

Already using in oscer, and it works fine.
