### PR TITLE
Don't reference BDA project resource directly in DDE access policy

### DIFF
--- a/infra/modules/document-data-extraction/resources/access_control.tf
+++ b/infra/modules/document-data-extraction/resources/access_control.tf
@@ -15,8 +15,8 @@ data "aws_iam_policy_document" "bedrock_access" {
     ]
     effect = "Allow"
     resources = [
-      awscc_bedrock_data_automation_project.bda_project.project_arn,
-      "${awscc_bedrock_data_automation_project.bda_project.project_arn}/*",
+      local.bda_project_arn,
+      "${local.bda_project_arn}/*",
       "arn:aws:bedrock:*:*:blueprint/*",
       "arn:aws:bedrock:*:*:data-automation-profile/*"
     ]

--- a/infra/modules/document-data-extraction/resources/main.tf
+++ b/infra/modules/document-data-extraction/resources/main.tf
@@ -41,6 +41,8 @@ locals {
       }
     ] : []
   )
+
+  bda_project_arn = awscc_bedrock_data_automation_project.bda_project.project_arn
 }
 
 resource "awscc_bedrock_data_automation_project" "bda_project" {

--- a/infra/modules/document-data-extraction/resources/outputs.tf
+++ b/infra/modules/document-data-extraction/resources/outputs.tf
@@ -8,7 +8,7 @@ output "access_policy_arn" {
 
 output "bda_project_arn" {
   description = "The ARN of the Bedrock Data Automation project"
-  value       = awscc_bedrock_data_automation_project.bda_project.project_arn
+  value       = local.bda_project_arn
 }
 
 # aws bedrock data automation requires users to use cross Region inference support


### PR DESCRIPTION
This avoid unnecessary recreation/updates to the IAM policy.

## Testing

Update the BDA project description field, just appending ` - test` to trigger some change detection.

Before these code changes, the policy updates:

<img width="2330" height="1570" alt="image" src="https://github.com/user-attachments/assets/3d45bcb1-b2fa-4ff9-8d8d-45ced10aae96" />
<img width="2330" height="1725" alt="image" src="https://github.com/user-attachments/assets/8c5f7eb9-2949-46e6-92fb-49c479c45dae" />

After changes, only the project itself updates:

<img width="2330" height="1570" alt="image" src="https://github.com/user-attachments/assets/a3318f94-248c-43dc-b678-f04548da130c" />

Standing up a new project with these changes was a part of https://github.com/navapbc/platform-test/pull/283