### PR TITLE
Add `document` block to DDE output config

### DIFF
--- a/infra/{{app_name}}/app-config/env-config/document_data_extraction.tf
+++ b/infra/{{app_name}}/app-config/env-config/document_data_extraction.tf
@@ -31,7 +31,25 @@ locals {
           types = ["IMAGE_SUMMARY"]
         }
       }
-    }
 
+      document = {
+        extraction = {
+          granularity = {
+            types = ["PAGE"]
+          }
+          bounding_box = {
+            state = "ENABLED"
+          }
+        }
+        output_format = {
+          additional_file_format = {
+            state = "DISABLED"
+          }
+          text_format = {
+            types = ["PLAIN_TEXT"]
+          }
+        }
+      }
+    }
   } : null
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/1036

## Changes

This is apparently necessary for field extraction.

## Testing

Same config used in https://github.com/navapbc/platform-test/pull/283

Applying against `app-docuai` in `platform-test`, it will show a diff from existing content being deleted:

<img width="1558" height="402" alt="image" src="https://github.com/user-attachments/assets/981bf247-ca41-4782-bbe7-da6bbe666d76" />

<img width="754" height="1785" alt="image" src="https://github.com/user-attachments/assets/4038cc55-2538-4297-9cfe-cf1372769a21" />

But the replacement content is the same (minus whitespace cleanup) after resolving conflict:

<img width="2686" height="462" alt="image" src="https://github.com/user-attachments/assets/24b40a4a-5ae9-45bf-ae8a-20cff8fa8f5a" />

The "Infra tests" CI failure is unrelated and happening elsewhere (subnets seem to be taking longer than expected to be destroyed).