### PR TITLE
Docs: Fix Terraform backend location in set-up-database.md

### DIFF
--- a/docs/infra/set-up-database.md
+++ b/docs/infra/set-up-database.md
@@ -28,7 +28,7 @@ make infra-configure-app-database APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>
 ```
 
 `APP_NAME` needs to be the name of the application folder within the `infra` folder.
-`ENVIRONMENT` needs to be the name of the environment you are creating. This will create a file called `<ENVIRONMENT>.s3.tfbackend` in the `infra/<APP_NAME>/service` module directory.
+`ENVIRONMENT` needs to be the name of the environment you are creating. This will create a file called `<ENVIRONMENT>.s3.tfbackend` in the `infra/<APP_NAME>/database` module directory.
 
 ### (Optional) Enable any database extensions that require `rds_superuser`
 


### PR DESCRIPTION
## Changes

Updated the set-up-database.md document to display the correct location of the generated Terraform backend (/database instead of /service)