### PR TITLE
Update deprecated aws_region.name -> aws_region.region

### DIFF
--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -3,7 +3,7 @@ data "aws_region" "current" {}
 
 locals {
   # This must match the name of the bucket created while bootstrapping the account in set-up-current-account
-  tf_state_bucket_name = "${module.project_config.project_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-tf"
+  tf_state_bucket_name = "${module.project_config.project_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-tf"
 
   # Choose the region where this infrastructure should be deployed.
   region = module.project_config.default_region

--- a/infra/accounts/outputs.tf
+++ b/infra/accounts/outputs.tf
@@ -7,7 +7,7 @@ output "project_name" {
 }
 
 output "region" {
-  value = data.aws_region.current.name
+  value = data.aws_region.current.region
 }
 
 output "tf_log_bucket_name" {

--- a/infra/modules/container-image-repository/main.tf
+++ b/infra/modules/container-image-repository/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 locals {
-  image_registry = "${aws_ecr_repository.app.registry_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com"
+  image_registry = "${aws_ecr_repository.app.registry_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com"
 }
 
 resource "aws_ecr_repository" "app" {

--- a/infra/modules/database/resources/main.tf
+++ b/infra/modules/database/resources/main.tf
@@ -7,7 +7,7 @@ locals {
   role_manager_name     = "${var.name}-role-manager"
   # The ARN that represents the users accessing the database are of the format: "arn:aws:rds-db:<region>:<account-id>:dbuser:<resource-id>/<database-user-name>""
   # See https://aws.amazon.com/blogs/database/using-iam-authentication-to-connect-with-pgadmin-amazon-aurora-postgresql-or-amazon-rds-for-postgresql/
-  db_user_arn_prefix = "arn:aws:rds-db:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_rds_cluster.db.cluster_resource_id}"
+  db_user_arn_prefix = "arn:aws:rds-db:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_rds_cluster.db.cluster_resource_id}"
 
   engine_version       = "16"
   engine_major_version = regex("^\\d+", local.engine_version)

--- a/infra/modules/database/resources/role_manager.tf
+++ b/infra/modules/database/resources/role_manager.tf
@@ -121,7 +121,7 @@ resource "aws_iam_role_policy" "role_manager_access_to_db_password" {
         Effect = "Allow"
         Action = ["ssm:GetParameter"]
         Resource = [
-          "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:parameter${local.db_password_param_name}"
+          "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:parameter${local.db_password_param_name}"
         ]
       }
     ]

--- a/infra/modules/document-data-extraction/resources/outputs.tf
+++ b/infra/modules/document-data-extraction/resources/outputs.tf
@@ -18,7 +18,7 @@ output "bda_project_arn" {
 # TODO(https://github.com/navapbc/template-infra/issues/993) Add GovCloud Support
 output "bda_profile_arn" {
   description = "The profile ARN associated with the BDA project"
-  value       = "arn:aws:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:data-automation-profile/us.data-automation-v1"
+  value       = "arn:aws:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:data-automation-profile/us.data-automation-v1"
 }
 
 output "bda_blueprint_arns" {

--- a/infra/modules/identity-provider-client/resources/access_control.tf
+++ b/infra/modules/identity-provider-client/resources/access_control.tf
@@ -10,6 +10,6 @@ data "aws_iam_policy_document" "identity_access" {
   statement {
     actions   = ["cognito-idp:*"]
     effect    = "Allow"
-    resources = ["arn:aws:cognito-idp:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:userpool/${var.user_pool_id}"]
+    resources = ["arn:aws:cognito-idp:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:userpool/${var.user_pool_id}"]
   }
 }

--- a/infra/modules/network/resources/vpc_endpoints.tf
+++ b/infra/modules/network/resources/vpc_endpoints.tf
@@ -81,7 +81,7 @@ resource "aws_vpc_endpoint" "interface" {
   for_each = local.interface_vpc_endpoints
 
   vpc_id              = module.aws_vpc.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.${each.key}"
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.aws_services.id]
   subnet_ids          = local.aws_service_subnets[each.key]
@@ -92,7 +92,7 @@ resource "aws_vpc_endpoint" "gateway" {
   for_each = local.gateway_vpc_endpoints
 
   vpc_id            = module.aws_vpc.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.${each.key}"
   vpc_endpoint_type = "Gateway"
   route_table_ids   = module.aws_vpc.private_route_table_ids
 }

--- a/infra/modules/network/resources/waf.tf
+++ b/infra/modules/network/resources/waf.tf
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "waf_logs" {
     resources = ["${aws_cloudwatch_log_group.waf_logs.arn}:*"]
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
       variable = "aws:SourceArn"
     }
     condition {

--- a/infra/modules/notifications-email-domain/resources/dns.tf
+++ b/infra/modules/notifications-email-domain/resources/dns.tf
@@ -24,7 +24,7 @@ resource "aws_route53_record" "mx_receive" {
   ttl             = "600"
   zone_id         = var.hosted_zone_id
   name            = local.mail_from_domain
-  records         = ["10 feedback-smtp.${data.aws_region.current.name}.amazonses.com"]
+  records         = ["10 feedback-smtp.${data.aws_region.current.region}.amazonses.com"]
 }
 
 resource "aws_route53_record" "dmarc" {

--- a/infra/modules/notifications-phone-pool/data/main.tf
+++ b/infra/modules/notifications-phone-pool/data/main.tf
@@ -4,7 +4,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   # Default to current region if no regions specified
-  search_regions = var.regions != null ? var.regions : [data.aws_region.current.name]
+  search_regions = var.regions != null ? var.regions : [data.aws_region.current.region]
 }
 
 # Check for existing phone pools in each specified region

--- a/infra/modules/notifications-phone-pool/resources/main.tf
+++ b/infra/modules/notifications-phone-pool/resources/main.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   phone_number_arn_base = (
-    "arn:aws:sms-voice:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:phone-number"
+    "arn:aws:sms-voice:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:phone-number"
   )
   registration_id_arn = var.sms_sender_phone_number_registration_id != null ? "${local.phone_number_arn_base}/${var.sms_sender_phone_number_registration_id}" : null
 

--- a/infra/modules/notifications-sms/resources/main.tf
+++ b/infra/modules/notifications-sms/resources/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy" "cloudformation_sms_permissions" {
           "sms-voice:*"
         ]
         Resource = [
-          "arn:aws:sms-voice:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+          "arn:aws:sms-voice:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
         ]
       },
       {

--- a/infra/modules/service/access_logs.tf
+++ b/infra/modules/service/access_logs.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "access_logs_put_access" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.elb_account_map[data.aws_region.current.name]}:root"]
+      identifiers = ["arn:aws:iam::${local.elb_account_map[data.aws_region.current.region]}:root"]
     }
   }
 }

--- a/infra/modules/service/events_role.tf
+++ b/infra/modules/service/events_role.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "run_task" {
       "events:PutRule",
       "events:DescribeRule",
     ]
-    resources = ["arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"]
+    resources = ["arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"]
   }
 
   dynamic "statement" {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -12,8 +12,8 @@ locals {
 
   base_environment_variables = [
     { name : "PORT", value : tostring(var.container_port) },
-    { name : "AWS_DEFAULT_REGION", value : data.aws_region.current.name },
-    { name : "AWS_REGION", value : data.aws_region.current.name },
+    { name : "AWS_DEFAULT_REGION", value : data.aws_region.current.region },
+    { name : "AWS_REGION", value : data.aws_region.current.region },
     { name : "IMAGE_TAG", value : var.image_tag },
   ]
   db_environment_variables = var.db_vars == null ? [] : [
@@ -130,7 +130,7 @@ resource "aws_ecs_task_definition" "app" {
         logDriver = "awslogs",
         options = {
           "awslogs-group"         = aws_cloudwatch_log_group.service_logs.name,
-          "awslogs-region"        = data.aws_region.current.name,
+          "awslogs-region"        = data.aws_region.current.region,
           "awslogs-stream-prefix" = local.log_stream_prefix
         }
       },

--- a/infra/modules/service/scheduler_role.tf
+++ b/infra/modules/service/scheduler_role.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "scheduler" {
       "events:PutRule",
       "events:DescribeRule",
     ]
-    resources = ["arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"]
+    resources = ["arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"]
   }
 
   dynamic "statement" {

--- a/infra/modules/service/workflow_orchestrator_role.tf
+++ b/infra/modules/service/workflow_orchestrator_role.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "workflow_orchestrator_assume_role" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:*"]
+      values   = ["arn:aws:states:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:stateMachine:*"]
     }
 
     condition {
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "workflow_orchestrator" {
       "events:DescribeRule",
     ]
     resources = [
-      "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule",
+      "arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule",
     ]
   }
 
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "workflow_orchestrator" {
       "ecs:StopTask",
       "ecs:DescribeTasks",
     ]
-    resources = ["arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task/${var.service_name}/*"]
+    resources = ["arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task/${var.service_name}/*"]
     condition {
       test     = "ArnLike"
       variable = "ecs:cluster"

--- a/infra/modules/storage/encryption.tf
+++ b/infra/modules/storage/encryption.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
       condition {
         test     = "StringEquals"
         variable = "kms:ViaService"
-        values   = ["s3.${data.aws_region.current.name}.amazonaws.com"]
+        values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
       }
     }
   }

--- a/infra/{{app_name}}/service/notifications.tf
+++ b/infra/{{app_name}}/service/notifications.tf
@@ -21,7 +21,7 @@ locals {
 
   # Get pool from current region (for temporary environments)
   current_region_pool = local.sms_config != null && local.is_temporary ? try(
-    module.existing_notifications_phone_pool[0].pools_by_region[data.aws_region.current.name],
+    module.existing_notifications_phone_pool[0].pools_by_region[data.aws_region.current.region],
     null
   ) : null
 


### PR DESCRIPTION
The `name` attribute was deprecated in v6.0.0[1] of the AWS provider. We now require v6.50.x[2]. So update.

[1] https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.0.0
[2] cd6b7b4c97b08aa53a7cde7fee51b099b031d1e2

## Testing

See CI test runs where deprecation warnings are no longer present.
