### PR TITLE
Update deprecated aws_partition.id -> aws_partition.partition

### DIFF
--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -226,7 +226,7 @@ data "aws_iam_policy_document" "tf_log" {
       variable = "aws:SourceArn"
 
       values = [
-        "arn:${data.aws_partition.current.id}:s3:::${aws_s3_bucket.tf_log.id}"
+        "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.tf_log.id}"
       ]
     }
 


### PR DESCRIPTION
The `id` attribute was deprecated in v6.47.0[1] of the AWS provider. We now require v6.50.x[2]. So update.

[1] https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.47.0
[2] cd6b7b4c97b08aa53a7cde7fee51b099b031d1e2

## Testing

See CI test runs where deprecation warnings are no longer present.
